### PR TITLE
Improve run for loop logic and fix lint issues

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -143,7 +143,9 @@ func getTimeout(cmd *cobra.Command) (time.Duration, error) {
 
 func urlFlag(cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagURL, "u", "", "url to fetch data from")
-	viper.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL))
+	if err := viper.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL)); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 

--- a/cmd/testnets.go
+++ b/cmd/testnets.go
@@ -51,7 +51,6 @@ LimitNOFILE=4096
 [Install]
 WantedBy=multi-user.target
 `, args[0], args[1], args[1])
-			return
 		},
 	}
 	return cmd

--- a/relayer/codespace.go
+++ b/relayer/codespace.go
@@ -15,7 +15,7 @@ func GetCodespace(codespace string, code int) (msg string, err error) {
 }
 
 var codespaces = map[string]map[int]string{
-	"client": map[int]string{
+	"client": {
 		1:  "light client already exists",
 		2:  "light client not found",
 		3:  "light client is frozen due to misbehaviour",
@@ -35,7 +35,7 @@ var codespaces = map[string]map[int]string{
 		19: "next sequence receive verification failed",
 		20: "self consensus state not found",
 	},
-	"connection": map[int]string{
+	"connection": {
 		1: "connection already exists",
 		2: "connection not found",
 		3: "light client connection paths not found",
@@ -44,7 +44,7 @@ var codespaces = map[string]map[int]string{
 		6: "invalid counterparty connection",
 		7: "invalid connection",
 	},
-	"channels": map[int]string{
+	"channels": {
 		1:  "channel already exists",
 		2:  "channel not found",
 		3:  "invalid channel",
@@ -59,23 +59,23 @@ var codespaces = map[string]map[int]string{
 		12: "too many connection hops",
 		13: "acknowledgement too long",
 	},
-	"tendermint": map[int]string{
+	"tendermint": {
 		1: "invalid trusting period",
 		2: "invalid unbonding period",
 		3: "invalid header",
 	},
-	"transfer": map[int]string{
+	"transfer": {
 		1: "invalid packet timeout",
 	},
-	"commitment": map[int]string{
+	"commitment": {
 		1: "invalid proof",
 		2: "invalid prefix",
 	},
-	"ibc": map[int]string{
+	"ibc": {
 		1: "invalid height",
 		2: "invalid version",
 	},
-	"sdk": map[int]string{
+	"sdk": {
 		2:  "tx parse error",
 		3:  "invalid sequence",
 		4:  "unauthorized",

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -104,7 +104,10 @@ func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	w.Write(response)
+	_, err := w.Write(response)
+	if err != nil {
+		fmt.Printf("error writing to the underlying response")
+	}
 }
 
 // FaucetRequest represents a request to the facuet

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -169,8 +169,8 @@ func QueryClientConsensusStatePair(src, dst *Chain, srcH, dstH, srcClientConsH, 
 	var wg sync.WaitGroup
 
 	chps := []chh{
-		chh{src, srcH, srcClientConsH},
-		chh{dst, dstH, dstClientConsH},
+		{src, srcH, srcClientConsH},
+		{dst, dstH, dstClientConsH},
 	}
 
 	for _, chain := range chps {
@@ -390,8 +390,8 @@ func QueryConnectionPair(src, dst *Chain, srcH, dstH int64) (map[string]connType
 	var wg sync.WaitGroup
 
 	chps := []chpair{
-		chpair{src, srcH},
-		chpair{dst, dstH},
+		{src, srcH},
+		{dst, dstH},
 	}
 
 	for _, chain := range chps {
@@ -471,8 +471,8 @@ func QueryChannelPair(src, dst *Chain, srcH, dstH int64) (map[string]chanTypes.C
 	var wg sync.WaitGroup
 
 	chps := []chpair{
-		chpair{src, srcH},
-		chpair{dst, dstH},
+		{src, srcH},
+		{dst, dstH},
 	}
 
 	for _, chain := range chps {


### PR DESCRIPTION
Improve run logic to include the signal in the select loop making it non-blocking but still processing events, and quit signal as well.

It also fixes some lint issues with `make ci-lint` 