### PR TITLE
Provide a "single-node" subcommand to docker entrypoints

### DIFF
--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -100,7 +100,7 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 		Name:         fmt.Sprintf("%s-%s", c.ChainID, t.Name()),
 		Repository:   tc.t.dockerImage,
 		Tag:          tc.t.dockerTag,
-		Cmd:          []string{c.ChainID, c.MustGetAddress().String()},
+		Cmd:          []string{"single-node", c.ChainID, c.MustGetAddress().String()},
 		ExposedPorts: []string{tc.t.rpcPort},
 		PortBindings: map[dc.Port][]dc.PortBinding{
 			dc.Port(tc.t.rpcPort): []dc.PortBinding{{HostPort: c.GetRPCPort()}},


### PR DESCRIPTION
Hi @jackzampolin, the problem I see with the existing Docker-based tests is that unadorned arguments `<chainID> <genesisAccount>` are supplied during the test, without any context for the entrypoint.

I'd like to use my main Docker image and add functionality to its entrypoint so that `single-node <chainID> <genesisAccount>` can be accepted as arguments.  Since that's an extension to my existing entrypoint (rather than an incompatible change), it makes me happy.  One less Docker image to publish.

I've got a PR for gaia contrib single-node.sh, too: cosmos/gaia#343