### PR TITLE
Fixes for accountPrefix other than "cosmos", and more tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-zip: go.sum
 
 install: go.sum
 	@echo "installing rly binary..."
-	@go build -mod=readonly $(BUILD_FLAGS) -o ${GOBIN}/rly main.go
+	@go build -mod=readonly $(BUILD_FLAGS) -o $${GOBIN-$${GOPATH-$$HOME/go}/bin}/rly main.go
 
 ###############################################################################
 # Tests / CI

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ rly chains add -f configs/demo/ibc1.json
 $ cat ~/.relayer/config/config.yaml
 
 # To finalize your config, add a path between the two chains
-$ rly paths add ibc0 ibc1 demo-path -f configs/demo/path.json
+$ rly paths add ibc0 ibc1 demo-path -f configs/demo/demo.json
 
 # Now, add the key seeds from each chain to the relayer to give it funds to work with
 $ rly keys restore ibc0 testkey "$(jq -r '.secret' data/ibc0/n0/gaiacli/key_seed.json)"

--- a/configs/agoric/demo.json
+++ b/configs/agoric/demo.json
@@ -1,0 +1,1 @@
+{"src":{"chain-id":"ibc0","client-id":"ibconeclient","connection-id":"ibconeconnection","channel-id":"ibconexfer","port-id":"transfer"},"dst":{"chain-id":"ibc1","client-id":"ibczeroclient","connection-id":"ibczeroconnection","channel-id":"ibczeroxfer","port-id":"transfer"},"strategy":{"type":"naive"}}

--- a/configs/agoric/ibc0.json
+++ b/configs/agoric/ibc0.json
@@ -1,0 +1,1 @@
+{"key":"testkey","chain-id":"ibc0","rpc-addr":"http://localhost:26657","account-prefix":"agoric","gas":200000,"gas-prices":"","default-denom":"uagstake","trusting-period":"336h"}

--- a/configs/agoric/ibc1.json
+++ b/configs/agoric/ibc1.json
@@ -1,0 +1,1 @@
+{"key":"testkey","chain-id":"ibc1","rpc-addr":"http://localhost:26557","account-prefix":"agoric","gas":200000,"gas-prices":"","default-denom":"uagstake","trusting-period":"336h"}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iqlusioninc/relayer
 
-go 1.13
+go 1.14
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible

--- a/relayer/contextual.go
+++ b/relayer/contextual.go
@@ -1,84 +1,80 @@
 package relayer
 
 import (
+	"sync"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	stdcodec "github.com/cosmos/cosmos-sdk/codec/std"
 )
 
+var globalMutex sync.Mutex
+
 type contextualStdCodec struct {
 	*stdcodec.Codec
-	setContext func() func()
+	useContext func() func()
 }
 
 type contextualAminoCodec struct {
 	*codec.Codec
-	setContext func() func()
+	useContext func() func()
 }
 
 // newContextualCodec creates a codec that sets and resets context
-func newContextualStdCodec(cdc *stdcodec.Codec, setContext func() func()) *contextualStdCodec {
+func newContextualStdCodec(cdc *stdcodec.Codec, useContext func() func()) *contextualStdCodec {
 	return &contextualStdCodec{
-		cdc,
-		setContext,
+		Codec:      cdc,
+		useContext: useContext,
 	}
 }
 
 // MarshalJSON marshals with the original codec and new context
 func (cdc *contextualStdCodec) MarshalJSON(ptr interface{}) ([]byte, error) {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.MarshalJSON(ptr)
 }
 
 // UnmarshalJSON unmarshals with the original codec and new context
 func (cdc *contextualStdCodec) UnmarshalJSON(bz []byte, ptr interface{}) error {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.UnmarshalJSON(bz, ptr)
 }
 
 func (cdc *contextualStdCodec) MarshalBinaryBare(ptr codec.ProtoMarshaler) ([]byte, error) {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.MarshalBinaryBare(ptr)
 }
 
 func (cdc *contextualStdCodec) UnmarshalBinaryBare(bz []byte, ptr codec.ProtoMarshaler) error {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.UnmarshalBinaryBare(bz, ptr)
 }
 
 // newContextualCodec creates a codec that sets and resets context
-func newContextualAminoCodec(cdc *codec.Codec, setContext func() func()) *contextualAminoCodec {
+func newContextualAminoCodec(cdc *codec.Codec, useContext func() func()) *contextualAminoCodec {
 	return &contextualAminoCodec{
-		cdc,
-		setContext,
+		Codec:      cdc,
+		useContext: useContext,
 	}
 }
 
 // MarshalJSON marshals with the original codec and new context
 func (cdc *contextualAminoCodec) MarshalJSON(ptr interface{}) ([]byte, error) {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.MarshalJSON(ptr)
 }
 
 // UnmarshalJSON unmarshals with the original codec and new context
 func (cdc *contextualAminoCodec) UnmarshalJSON(bz []byte, ptr interface{}) error {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.UnmarshalJSON(bz, ptr)
 }
 
 func (cdc *contextualAminoCodec) MarshalBinaryBare(ptr interface{}) ([]byte, error) {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.MarshalBinaryBare(ptr)
 }
 
 func (cdc *contextualAminoCodec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
-	reset := cdc.setContext()
-	defer reset()
+	defer cdc.useContext()()
 	return cdc.Codec.UnmarshalBinaryBare(bz, ptr)
 }

--- a/relayer/contextual.go
+++ b/relayer/contextual.go
@@ -1,0 +1,84 @@
+package relayer
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	stdcodec "github.com/cosmos/cosmos-sdk/codec/std"
+)
+
+type contextualStdCodec struct {
+	*stdcodec.Codec
+	setContext func() func()
+}
+
+type contextualAminoCodec struct {
+	*codec.Codec
+	setContext func() func()
+}
+
+// newContextualCodec creates a codec that sets and resets context
+func newContextualStdCodec(cdc *stdcodec.Codec, setContext func() func()) *contextualStdCodec {
+	return &contextualStdCodec{
+		cdc,
+		setContext,
+	}
+}
+
+// MarshalJSON marshals with the original codec and new context
+func (cdc *contextualStdCodec) MarshalJSON(ptr interface{}) ([]byte, error) {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.MarshalJSON(ptr)
+}
+
+// UnmarshalJSON unmarshals with the original codec and new context
+func (cdc *contextualStdCodec) UnmarshalJSON(bz []byte, ptr interface{}) error {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.UnmarshalJSON(bz, ptr)
+}
+
+func (cdc *contextualStdCodec) MarshalBinaryBare(ptr codec.ProtoMarshaler) ([]byte, error) {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.MarshalBinaryBare(ptr)
+}
+
+func (cdc *contextualStdCodec) UnmarshalBinaryBare(bz []byte, ptr codec.ProtoMarshaler) error {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.UnmarshalBinaryBare(bz, ptr)
+}
+
+// newContextualCodec creates a codec that sets and resets context
+func newContextualAminoCodec(cdc *codec.Codec, setContext func() func()) *contextualAminoCodec {
+	return &contextualAminoCodec{
+		cdc,
+		setContext,
+	}
+}
+
+// MarshalJSON marshals with the original codec and new context
+func (cdc *contextualAminoCodec) MarshalJSON(ptr interface{}) ([]byte, error) {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.MarshalJSON(ptr)
+}
+
+// UnmarshalJSON unmarshals with the original codec and new context
+func (cdc *contextualAminoCodec) UnmarshalJSON(bz []byte, ptr interface{}) error {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.UnmarshalJSON(bz, ptr)
+}
+
+func (cdc *contextualAminoCodec) MarshalBinaryBare(ptr interface{}) ([]byte, error) {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.MarshalBinaryBare(ptr)
+}
+
+func (cdc *contextualAminoCodec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
+	reset := cdc.setContext()
+	defer reset()
+	return cdc.Codec.UnmarshalBinaryBare(bz, ptr)
+}

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -39,8 +39,7 @@ func (src *Chain) BuildAndSignTxWithKey(datagram []sdk.Msg, keyName string) ([]b
 		return nil, err
 	}
 
-	reset := src.Amino.setContext()
-	defer reset()
+	defer src.UseSDKContext()()
 	return auth.NewTxBuilder(
 		auth.DefaultTxEncoder(src.Amino.Codec), acc.GetAccountNumber(),
 		acc.GetSequence(), src.Gas, src.GasAdjustment, false, src.ChainID,

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -39,8 +39,10 @@ func (src *Chain) BuildAndSignTxWithKey(datagram []sdk.Msg, keyName string) ([]b
 		return nil, err
 	}
 
+	reset := src.Amino.setContext()
+	defer reset()
 	return auth.NewTxBuilder(
-		auth.DefaultTxEncoder(src.Amino), acc.GetAccountNumber(),
+		auth.DefaultTxEncoder(src.Amino.Codec), acc.GetAccountNumber(),
 		acc.GetSequence(), src.Gas, src.GasAdjustment, false, src.ChainID,
 		src.Memo, sdk.NewCoins(), src.getGasPrices()).WithKeybase(src.Keybase).
 		BuildAndSign(info.GetName(), ckeys.DefaultKeyPass, datagram)

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -1200,8 +1200,7 @@ func (c *Chain) formatTxResults(resTxs []*ctypes.ResultTx, resBlocks map[int64]*
 
 // formatTxResult parses a tx into a TxResponse object
 func (c *Chain) formatTxResult(resTx *ctypes.ResultTx, resBlock *ctypes.ResultBlock) (sdk.TxResponse, error) {
-	reset := c.Amino.setContext()
-	defer reset()
+	defer c.UseSDKContext()()
 	tx, err := parseTx(c.Amino.Codec, resTx.Tx)
 	if err != nil {
 		return sdk.TxResponse{}, err

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -1200,7 +1200,9 @@ func (c *Chain) formatTxResults(resTxs []*ctypes.ResultTx, resBlocks map[int64]*
 
 // formatTxResult parses a tx into a TxResponse object
 func (c *Chain) formatTxResult(resTx *ctypes.ResultTx, resBlock *ctypes.ResultBlock) (sdk.TxResponse, error) {
-	tx, err := parseTx(c.Amino, resTx.Tx)
+	reset := c.Amino.setContext()
+	defer reset()
+	tx, err := parseTx(c.Amino.Codec, resTx.Tx)
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}

--- a/scripts/agoric-config-relayer
+++ b/scripts/agoric-config-relayer
@@ -1,0 +1,43 @@
+#/bin/bash
+
+# Ensure jq is installed
+if [[ ! -x "$(which jq)" ]]; then
+  echo "jq (a tool for parsing json in the command line) is required..."
+  echo "https://stedolan.github.io/jq/download/"
+  exit 1
+fi
+
+RELAYER_DIR="$GOPATH/src/github.com/iqlusioninc/relayer"
+RELAYER_CONF="$HOME/.relayer"
+GAIA_CONF="$(pwd)/data"
+
+# Ensure user understands what will be deleted
+if [[ -d $RELAYER_CONF ]] && [[ ! "$1" == "skip" ]]; then
+  read -p "$0 will delete $RELAYER_CONF folder. Do you wish to continue? (y/n): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 1
+  fi
+fi
+
+cd $RELAYER_DIR
+rm -rf $RELAYER_CONF &> /dev/null
+
+echo "Building Relayer..."
+make install
+
+echo "Generating rly configurations..."
+rly config init
+rly config add-dir configs/agoric/
+
+SEED0=$(jq -r '.secret' $GAIA_CONF/ibc0/n0/ag-cosmos-helper/key_seed.json)
+SEED1=$(jq -r '.secret' $GAIA_CONF/ibc1/n0/ag-cosmos-helper/key_seed.json)
+echo 
+echo "Key $(rly keys restore ibc0 testkey "$SEED0") imported from ibc0 to relayer..."
+echo "Key $(rly keys restore ibc1 testkey "$SEED1") imported from ibc1 to relayer..."
+echo
+echo "Creating lite clients..."
+echo
+sleep 3
+rly lite init ibc0 -f
+rly lite init ibc1 -f

--- a/scripts/agoric-two-chainz
+++ b/scripts/agoric-two-chainz
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+APP=agoric
+DAEMON=ag-chain-cosmos
+CLI=ag-cosmos-helper
+GAIA_REPO="$GOPATH/src/github.com/cosmos/gaia"
+GAIA_BRANCH=ibc-alpha
+CHAIN_DATA="$(pwd)/data"
+
+# ARGS: 
+# $1 -> local || remote, defaults to remote
+
+# Ensure user understands what will be deleted
+if [[ -d $CHAIN_DATA ]] && [[ ! "$2" == "skip" ]]; then
+  read -p "$0 will delete \$(pwd)/data folder. Do you wish to continue? (y/n): " -n 1 -r
+  echo 
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 1
+  fi
+fi
+
+rm -rf $CHAIN_DATA &> /dev/null
+killall $DAEMON &> /dev/null
+
+set -e
+
+chainid0=ibc0
+chainid1=ibc1
+
+echo "Generating $APP configurations..."
+mkdir -p $CHAIN_DATA && cd $CHAIN_DATA
+echo -e "\n" | $DAEMON testnet -o $chainid0 --v 1 --chain-id $chainid0 --node-dir-prefix n --keyring-backend test &> /dev/null
+echo -e "\n" | $DAEMON testnet -o $chainid1 --v 1 --chain-id $chainid1 --node-dir-prefix n --keyring-backend test &> /dev/null
+
+cfgpth="n0/$DAEMON/config/config.toml"
+if [ "$(uname)" = "Linux" ]; then
+  # TODO: Just index *some* specified tags, not all
+  sed -i 's/index_all_keys = false/index_all_keys = true/g' $chainid0/$cfgpth
+  sed -i 's/index_all_keys = false/index_all_keys = true/g' $chainid1/$cfgpth
+  
+  # Set proper defaults and change ports
+  sed -i 's/"leveldb"/"goleveldb"/g' $chainid0/$cfgpth
+  sed -i 's/"leveldb"/"goleveldb"/g' $chainid1/$cfgpth
+  sed -i 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:26556"#g' $chainid1/$cfgpth
+  sed -i 's#"tcp://0.0.0.0:26657"#"tcp://0.0.0.0:26557"#g' $chainid1/$cfgpth
+  sed -i 's#"localhost:6060"#"localhost:6061"#g' $chainid1/$cfgpth
+  sed -i 's#"tcp://127.0.0.1:26658"#"tcp://127.0.0.1:26558"#g' $chainid1/$cfgpth
+  
+  # Make blocks run faster than normal
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid0/$cfgpth
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid1/$cfgpth
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid0/$cfgpth
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid1/$cfgpth
+else
+  # TODO: Just index *some* specified tags, not all
+  sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $chainid0/$cfgpth
+  sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $chainid1/$cfgpth
+
+  # Set proper defaults and change ports
+  sed -i '' 's/"leveldb"/"goleveldb"/g' $chainid0/$cfgpth
+  sed -i '' 's/"leveldb"/"goleveldb"/g' $chainid1/$cfgpth
+  sed -i '' 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:26556"#g' $chainid1/$cfgpth
+  sed -i '' 's#"tcp://0.0.0.0:26657"#"tcp://0.0.0.0:26557"#g' $chainid1/$cfgpth
+  sed -i '' 's#"localhost:6060"#"localhost:6061"#g' $chainid1/$cfgpth
+  sed -i '' 's#"tcp://127.0.0.1:26658"#"tcp://127.0.0.1:26558"#g' $chainid1/$cfgpth
+
+  # Make blocks run faster than normal
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid0/$cfgpth
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid1/$cfgpth
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid0/$cfgpth
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid1/$cfgpth
+fi
+
+gclpth="n0/$CLI/"
+$CLI config --home $chainid0/$gclpth chain-id $chainid0 &> /dev/null
+$CLI config --home $chainid1/$gclpth chain-id $chainid1 &> /dev/null
+$CLI config --home $chainid0/$gclpth output json &> /dev/null
+$CLI config --home $chainid1/$gclpth output json &> /dev/null
+$CLI config --home $chainid0/$gclpth node http://localhost:26657 &> /dev/null
+$CLI config --home $chainid1/$gclpth node http://localhost:26557 &> /dev/null
+
+echo "Starting $DAEMON instances (Ctrl-C exits)..."
+trap 'kill %1 %2' EXIT 
+$DAEMON --home $CHAIN_DATA/$chainid0/n0/$DAEMON start --pruning=nothing > $chainid0.log 2>&1 &
+$DAEMON --home $CHAIN_DATA/$chainid1/n0/$DAEMON start --pruning=nothing > $chainid1.log 2>&1 & 
+wait

--- a/test/relayer_agoric_test.go
+++ b/test/relayer_agoric_test.go
@@ -14,7 +14,7 @@ var (
 	}
 )
 
-func TestAgoricToGaiaSteaming(t *testing.T) {
+func TestAgoricToGaiaStreaming(t *testing.T) {
 	chains := spinUpTestChains(t, agoricChains...)
 
 	var (
@@ -28,7 +28,7 @@ func TestAgoricToGaiaSteaming(t *testing.T) {
 		twoDstTestCoin = sdk.NewCoin(dstDenom, sdk.NewInt(2000))
 	)
 
-	path, err := genTestPathAndSet(src, dst, "transfer", "swingset")
+	path, err := genTestPathAndSet(src, dst, "transfer", "transfer")
 	require.NoError(t, err)
 
 	// query initial balances to compare against at the end

--- a/test/relayer_agoric_test.go
+++ b/test/relayer_agoric_test.go
@@ -28,7 +28,7 @@ func TestAgoricToGaiaStreaming(t *testing.T) {
 		twoDstTestCoin = sdk.NewCoin(dstDenom, sdk.NewInt(2000))
 	)
 
-	path, err := genTestPathAndSet(src, dst, "transfer", "transfer")
+	path, err := genTestPathAndSet(src, dst, "transfer", "transfer") // FIGME: "relayertesttransfer")
 	require.NoError(t, err)
 
 	// query initial balances to compare against at the end

--- a/test/relayer_mtd_test.go
+++ b/test/relayer_mtd_test.go
@@ -14,7 +14,7 @@ var (
 	}
 )
 
-func TestMtdToGaiaSteaming(t *testing.T) {
+func TestMtdToGaiaStreaming(t *testing.T) {
 	chains := spinUpTestChains(t, mtdChains...)
 
 	var (

--- a/test/test_chains.go
+++ b/test/test_chains.go
@@ -79,10 +79,10 @@ var (
 		dockerTag:      "ibc-alpha",
 		timeout:        3 * time.Second,
 		rpcPort:        "26657",
-		accountPrefix:  "cosmos",
+		accountPrefix:  "agoric",
 		gas:            200000,
-		gasPrices:      "0.025uagstake",
-		defaultDenom:   "uagstake",
+		gasPrices:      "",
+		defaultDenom:   "uag",
 		trustingPeriod: "330h",
 	}
 )

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -24,6 +24,7 @@ func testClient(t *testing.T, src, dst *Chain) {
 
 	client, err := src.QueryClientState()
 	require.NoError(t, err)
+	require.NotNil(t, client)
 	require.Equal(t, client.ClientState.GetID(), src.PathEnd.ClientID)
 	require.Equal(t, client.ClientState.ClientType().String(), "tendermint")
 }

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -97,11 +97,16 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 	require.NoError(t, c.CreateTestKey())
 
 	// setup docker options
+	reset := c.SetSDKContext()
+	addr := c.MustGetAddress()
+	addrString := addr.String()
+	reset()
+
 	dockerOpts := &dockertest.RunOptions{
 		Name:         fmt.Sprintf("%s-%s", c.ChainID, t.Name()),
 		Repository:   tc.t.dockerImage,
 		Tag:          tc.t.dockerTag,
-		Cmd:          []string{c.ChainID, c.MustGetAddress().String()},
+		Cmd:          []string{c.ChainID, addrString},
 		ExposedPorts: []string{tc.t.rpcPort},
 		PortBindings: map[dc.Port][]dc.PortBinding{
 			dc.Port(tc.t.rpcPort): {{HostPort: c.GetRPCPort()}},

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -97,21 +97,21 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 	require.NoError(t, c.CreateTestKey())
 
 	// setup docker options
-	reset := c.SetSDKContext()
-	addr := c.MustGetAddress()
-	addrString := addr.String()
-	reset()
-
 	dockerOpts := &dockertest.RunOptions{
 		Name:         fmt.Sprintf("%s-%s", c.ChainID, t.Name()),
 		Repository:   tc.t.dockerImage,
 		Tag:          tc.t.dockerTag,
-		Cmd:          []string{c.ChainID, addrString},
 		ExposedPorts: []string{tc.t.rpcPort},
 		PortBindings: map[dc.Port][]dc.PortBinding{
 			dc.Port(tc.t.rpcPort): {{HostPort: c.GetRPCPort()}},
 		},
 	}
+
+	func() {
+		// Ensure our address is encoded properly.
+		defer c.UseSDKContext()()
+		dockerOpts.Cmd = []string{c.ChainID, c.MustGetAddress().String()}
+	}()
 
 	// create the proper docker image with port forwarding setup
 	var resource *dockertest.Resource

--- a/two-chainz
+++ b/two-chainz
@@ -125,8 +125,6 @@ gaiacli config --home $chainid1/$gclpth output json &> /dev/null
 gaiacli config --home $chainid0/$gclpth node http://localhost:26657 &> /dev/null
 gaiacli config --home $chainid1/$gclpth node http://localhost:26557 &> /dev/null
 
-echo "Starting Gaiad instances (background this script or terminate with Control-C)..."
-trap 'kill %1 %2' EXIT
+echo "Starting Gaiad instances..."
 gaiad --home $GAIA_DATA/$chainid0/n0/gaiad start --pruning=nothing > $chainid0.log 2>&1 &
 gaiad --home $GAIA_DATA/$chainid1/n0/gaiad start --pruning=nothing > $chainid1.log 2>&1 & 
-wait

--- a/two-chainz
+++ b/two-chainz
@@ -125,6 +125,8 @@ gaiacli config --home $chainid1/$gclpth output json &> /dev/null
 gaiacli config --home $chainid0/$gclpth node http://localhost:26657 &> /dev/null
 gaiacli config --home $chainid1/$gclpth node http://localhost:26557 &> /dev/null
 
-echo "Starting Gaiad instances..."
+echo "Starting Gaiad instances (background this script or terminate with Control-C)..."
+trap 'kill %1 %2' EXIT
 gaiad --home $GAIA_DATA/$chainid0/n0/gaiad start --pruning=nothing > $chainid0.log 2>&1 &
 gaiad --home $GAIA_DATA/$chainid1/n0/gaiad start --pruning=nothing > $chainid1.log 2>&1 & 
+wait


### PR DESCRIPTION
Main change is to propagate the SDK account prefix settings whenever encoding and decoding addresses.  Other miscellaneous improvements:

* More tolerant determination of $GOBIN
* Use the correct path demo.json config
* Use go 1.14 to get the version of testing that has t.Cleanup
* Wrap uses of the `chain.Cdc` and `chain.Amino` with setting the SDK params
* Fix some Agoric test params (no gas fee, transfer port is "transfer", accountPrefix is "agoric")
* two-chainz now waits for its children (and kills them on exit or signal)
