### PR TITLE
Fixed query.go

### DIFF
--- a/relayer/query.go
+++ b/relayer/query.go
@@ -221,7 +221,7 @@ func (c *Chain) QueryClientState() (*clientTypes.StateResponse, error) {
 
 	var cs exported.ClientState
 	if err := c.Amino.UnmarshalBinaryLengthPrefixed(res.Value, &cs); err != nil {
-		if err = c.Amino.UnmarshalBinaryBare(res.Value, &cs); err != nil {
+		if err := c.Amino.UnmarshalBinaryBare(res.Value, &cs); err != nil {
 			return nil, qClntConsStateErr(err)
 		}
 		return nil, qClntStateErr(err)


### PR DESCRIPTION
Added missing `:` that lead to wrong error message being returned