### PR TITLE
Prevent unnecessary backgrounding of `rly start`

### DIFF
--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -537,7 +537,7 @@ relay)
       done
       try=$(( $try + 1 ))
       echo "$path tx link initialized (try=$try)"
-      rly start "$path" &
+      rly start "$path"
     ) &
   done
 


### PR DESCRIPTION
Simple, but critical fix for using the `nchainz relay` script.  Without this fix, the relayer is double-forked, which means Bash cannot track its pid, and when you terminate the `nchainz relay`, it keeps running.
