### PR TITLE
Solve a race between first packets and rly start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c // indirect
-	github.com/cosmos/cosmos-sdk v0.34.4-0.20200430150743-930802e7a13c
+	github.com/cosmos/cosmos-sdk v0.34.4-0.20200502230752-7557f0eda346
 	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d
 	github.com/gorilla/mux v1.7.4
 	github.com/ory/dockertest/v3 v3.5.5

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/cosmos/cosmos-sdk v0.34.4-0.20200423152229-f1fdde5d1b18 h1:9OjontPURN
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200423152229-f1fdde5d1b18/go.mod h1:Kcgs8c2WWtO2Q+KmDogvGRw+sdEqpvHYXFhj/QiAoOg=
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200430150743-930802e7a13c h1:6ssAsFEFfGnTE+rMBmI8qjacpqqmaXnvBx02i5Nnr3E=
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200430150743-930802e7a13c/go.mod h1:tvCen72hkJxkYT1/CsOaKHjZ4PouX4Isp4w9aRL2K4c=
+github.com/cosmos/cosmos-sdk v0.34.4-0.20200502230752-7557f0eda346 h1:8zSHAaoImyObcijcfmAxiRRfYR65IW/i3SkQKE+b2d8=
+github.com/cosmos/cosmos-sdk v0.34.4-0.20200502230752-7557f0eda346/go.mod h1:tvCen72hkJxkYT1/CsOaKHjZ4PouX4Isp4w9aRL2K4c=
 github.com/cosmos/cosmos-sdk v0.38.3 h1:qIBTiw+2T9POaSUJ5rvbBbXeq8C8btBlJxnSegPBd3Y=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -151,21 +151,21 @@ func sendTxFromEventPackets(src, dst *Chain, rlyPackets []relayPacket, sh *SyncH
 		}
 	}
 
-	// instantiate the RelayMsgs with the appropriate update client
-	txs := &RelayMsgs{
-		Src: []sdk.Msg{
-			src.PathEnd.UpdateClient(sh.GetHeader(dst.ChainID), src.MustGetAddress()),
-		},
-		Dst: []sdk.Msg{},
-	}
-
-	// add the packet msgs to RelayPackets
-	for _, rp := range rlyPackets {
-		txs.Src = append(txs.Src, rp.Msg(src, dst))
-	}
-
 	// send the transaction, retrying if not successful
 	if err := retry.Do(func() error {
+		// instantiate the RelayMsgs with the appropriate update client
+		txs := &RelayMsgs{
+			Src: []sdk.Msg{
+				src.PathEnd.UpdateClient(sh.GetHeader(dst.ChainID), src.MustGetAddress()),
+			},
+			Dst: []sdk.Msg{},
+		}
+
+		// add the packet msgs to RelayPackets
+		for _, rp := range rlyPackets {
+			txs.Src = append(txs.Src, rp.Msg(src, dst))
+		}
+
 		if txs.Send(src, dst); !txs.success {
 			return fmt.Errorf("failed to send packets")
 		}

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -194,7 +194,9 @@ func (nrs *NaiveStrategy) RelayPacketsOrderedChan(src, dst *Chain, sp *RelaySequ
 		if err != nil {
 			return err
 		}
-		msgs.Dst = append(msgs.Dst, msg)
+		if msg != nil {
+			msgs.Dst = append(msgs.Dst, msg)
+		}
 	}
 
 	// add messages for dst -> src
@@ -203,7 +205,9 @@ func (nrs *NaiveStrategy) RelayPacketsOrderedChan(src, dst *Chain, sp *RelaySequ
 		if err != nil {
 			return err
 		}
-		msgs.Src = append(msgs.Src, msg)
+		if msg != nil {
+			msgs.Src = append(msgs.Src, msg)
+		}
 	}
 
 	if !msgs.Ready() {
@@ -237,7 +241,8 @@ func packetMsgFromTxQuery(src, dst *Chain, sh *SyncHeaders, seq uint64) (sdk.Msg
 	case err != nil:
 		return nil, err
 	case tx.Count == 0:
-		return nil, fmt.Errorf("no transactions returned with query")
+		// Not an error, just try again later.
+		return nil, nil
 	case tx.Count > 1:
 		return nil, fmt.Errorf("more than one transaction returned with query")
 	}

--- a/relayer/pathEnd.go
+++ b/relayer/pathEnd.go
@@ -32,7 +32,7 @@ func (src *PathEnd) getOrder() chanState.Order {
 	return chanState.OrderFromString(strings.ToUpper(src.Order))
 }
 
-// UpdateClient creates an sdk.Msg to update the client on c with data pulled from cp
+// UpdateClient creates an sdk.Msg to update the client on src with data pulled from dst
 func (src *PathEnd) UpdateClient(dstHeader *tmclient.Header, signer sdk.AccAddress) sdk.Msg {
 	return tmclient.NewMsgUpdateClient(
 		src.ClientID,

--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -303,6 +303,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+mkdir -p "$BASEDIR"
 BASEDIR=$(cd "$BASEDIR" && pwd)
 NCONFIG="$BASEDIR/nchainz.cfg"
 DATA="$BASEDIR/data"

--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -528,6 +528,7 @@ relay)
     path="$ia"
     paths="$paths $path"
     echo "Starting 'rly tx link $path' ($src<>$dst) logs in $LOGS/$path.log"
+    rly start -d "$path" &
     (
       try=0
       while ! rly tx link $path --timeout=3s -d >> "$LOGS/$path.log" 2>&1; do
@@ -537,7 +538,6 @@ relay)
       done
       try=$(( $try + 1 ))
       echo "$path tx link initialized (try=$try)"
-      rly start "$path"
     ) &
   done
 


### PR DESCRIPTION
This PR moves nchainz around so that it runs `rly start` earlier, to catch the first packet sent out by a channel.

Additionally, allow `rly start` to run even if there are no packets yet.