### PR TITLE
Optimize KeyExists to avoid performance issues with hundreds of keys

### DIFF
--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -163,17 +163,12 @@ func defaultChainLogger() log.Logger {
 
 // KeyExists returns true if there is a specified key in chain's keybase
 func (src *Chain) KeyExists(name string) bool {
-	keyInfos, err := src.Keybase.List()
+	k, err := src.Keybase.Key(name)
 	if err != nil {
 		return false
 	}
 
-	for _, k := range keyInfos {
-		if k.GetName() == name {
-			return true
-		}
-	}
-	return false
+	return k.GetName() == name
 }
 
 func (src *Chain) getGasPrices() sdk.DecCoins {


### PR DESCRIPTION
The current implementation loads all keys in the keyring for each `KeyExists`. This is especially bad when using the `file` backend, which stores each key in a separate file. 

Currently if there are N keys, calling `KeyExists` results in N sequential disk operations. This will take several minutes when there are hundreds of keys in the keyring.