### PR TITLE
R4R fix gaia test bugs

### DIFF
--- a/relayer/client-tx.go
+++ b/relayer/client-tx.go
@@ -18,7 +18,6 @@ func (src *Chain) CreateClients(dst *Chain) (err error) {
 	} else if srcCs == nil {
 		dstH, err := dst.UpdateLiteWithHeader()
 		if err != nil {
-			// fmt.Println("Herere")
 			return err
 		}
 		if src.debug {
@@ -26,7 +25,6 @@ func (src *Chain) CreateClients(dst *Chain) (err error) {
 		}
 		clients.Src = append(clients.Src, src.PathEnd.CreateClient(dstH, src.GetTrustingPeriod(), src.MustGetAddress()))
 	}
-	// TODO: maybe log something here that the client has been created?
 
 	// Create client for src on dst if it doesn't exist
 	if dstCs, err = dst.QueryClientState(); err != nil {
@@ -41,7 +39,6 @@ func (src *Chain) CreateClients(dst *Chain) (err error) {
 		}
 		clients.Dst = append(clients.Dst, dst.PathEnd.CreateClient(srcH, dst.GetTrustingPeriod(), dst.MustGetAddress()))
 	}
-	// TODO: maybe log something here that the client has been created?
 
 	// Send msgs to both chains
 	if clients.Ready() {

--- a/relayer/log-tx.go
+++ b/relayer/log-tx.go
@@ -68,7 +68,7 @@ func logConnectionStates(src, dst *Chain, conn map[string]connTypes.ConnectionRe
 }
 
 func (c *Chain) logCreateClient(dst *Chain, dstH uint64) {
-	c.Log(fmt.Sprintf("- [%s] -> creating client for [%s]header-height{%d} trust-period(%s)", c.ChainID, dst.ChainID, dstH, dst.GetTrustingPeriod()))
+	c.Log(fmt.Sprintf("- [%s] -> creating client (%s) for [%s]header-height{%d} trust-period(%s)", c.ChainID, c.PathEnd.ClientID, dst.ChainID, dstH, dst.GetTrustingPeriod()))
 }
 
 func (c *Chain) logTx(events map[string][]string) {

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -213,7 +213,7 @@ func (c *Chain) QueryClientState() (*clientTypes.StateResponse, error) {
 	if err != nil {
 		return conStateRes, qClntStateErr(err)
 	} else if res.Value == nil {
-		// TODO: Better way to handle this?
+		// client does not exist
 		return nil, nil
 	}
 

--- a/test/relayer_gaia_test.go
+++ b/test/relayer_gaia_test.go
@@ -58,6 +58,9 @@ func TestGaiaToGaiaStreamingRelayer(t *testing.T) {
 	rlyDone, err := relayer.RunStrategy(src, dst, path.MustGetStrategy(), path.Ordered())
 	require.NoError(t, err)
 
+	// Wait for relay message inclusion in both chains
+	require.NoError(t, src.WaitForNBlocks(1))
+
 	// send those tokens from dst back to dst and src back to src
 	require.NoError(t, src.SendTransferMsg(dst, twoTestCoin, dst.MustGetAddress(), false))
 	require.NoError(t, dst.SendTransferMsg(src, twoTestCoin, src.MustGetAddress(), false))

--- a/test/relayer_gaia_test.go
+++ b/test/relayer_gaia_test.go
@@ -60,6 +60,7 @@ func TestGaiaToGaiaStreamingRelayer(t *testing.T) {
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.WaitForNBlocks(1))
+	require.NoError(t, dst.WaitForNBlocks(1))
 
 	// send those tokens from dst back to dst and src back to src
 	require.NoError(t, src.SendTransferMsg(dst, twoTestCoin, dst.MustGetAddress(), false))

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -16,12 +16,13 @@ func testClientPair(t *testing.T, src, dst *Chain) {
 
 // testClient queries clients and client for dst on src and returns a variety of errors
 // testClient expects just one client on src, that for dst
-// TODO: we should be able to find the chain id of dst on src, add a case for this in each switch
+// a localhost client is always created upon init genesis
 func testClient(t *testing.T, src, dst *Chain) {
+	// require 2 clients on src, localhost and dst
 	clients, err := src.QueryClients(1, 1000)
 	require.NoError(t, err)
 	require.Equal(t, len(clients), 2)
-	require.Equal(t, clients[0].GetID(), src.PathEnd.ClientID)
+
 	client, err := src.QueryClientState()
 	require.NoError(t, err)
 	require.NotNil(t, client)

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -14,15 +14,8 @@ func testClientPair(t *testing.T, src, dst *Chain) {
 	testClient(t, dst, src)
 }
 
-// testClient queries clients and client for dst on src and returns a variety of errors
-// testClient expects just one client on src, that for dst
-// a localhost client is always created upon init genesis
+// testClient queries client for existance of dst on src
 func testClient(t *testing.T, src, dst *Chain) {
-	// require 2 clients on src, localhost and dst
-	clients, err := src.QueryClients(1, 1000)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(clients))
-
 	client, err := src.QueryClientState()
 	require.NoError(t, err)
 	require.NotNil(t, client)

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -21,7 +21,7 @@ func testClient(t *testing.T, src, dst *Chain) {
 	// require 2 clients on src, localhost and dst
 	clients, err := src.QueryClients(1, 1000)
 	require.NoError(t, err)
-	require.Equal(t, len(clients), 2)
+	require.Equal(t, 2, len(clients))
 
 	client, err := src.QueryClientState()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes bugs in integration tests with gaia.

Tests were failing for 2 reasons
- init chain now creates a localhost client so queryclients was returning localhost + dst_client, but in the order of their names which is random
- relaying the packets was not occurring before the transfer back to the original chains could be relayed and client updated

