### PR TITLE
Add check in 'rly tx gen' to not use clients with last state expired

### DIFF
--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/tendermint/tendermint/types/time"
 	"io/ioutil"
 	"os"
 
@@ -119,8 +120,9 @@ func pathsGenCmd() *cobra.Command {
 				// TODO: support other client types through a switch here as they become available
 				clnt, ok := c.(tmclient.ClientState)
 				if ok && clnt.LastHeader.Commit != nil && clnt.LastHeader.Header != nil {
-					if clnt.GetChainID() == dst && !clnt.IsFrozen() {
-						path.Src.ClientID = c.GetID()
+					if clnt.GetChainID() == dst && !clnt.IsFrozen() &&
+						time.Now().Sub(clnt.GetLatestTimestamp()) < clnt.TrustingPeriod{
+						path.Src.ClientID = clnt.GetID()
 					}
 				}
 			}
@@ -134,8 +136,9 @@ func pathsGenCmd() *cobra.Command {
 				// TODO: support other client types through a switch here as they become available
 				clnt, ok := c.(tmclient.ClientState)
 				if ok && clnt.LastHeader.Commit != nil && clnt.LastHeader.Header != nil {
-					if c.GetChainID() == src && !c.IsFrozen() {
-						path.Dst.ClientID = c.GetID()
+					if clnt.GetChainID() == src && !clnt.IsFrozen() &&
+						time.Now().Sub(clnt.GetLatestTimestamp()) < clnt.TrustingPeriod {
+						path.Dst.ClientID = clnt.GetID()
 					}
 				}
 			}

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -91,7 +91,7 @@ func createClientCmd() *cobra.Command {
 				return err
 			}
 
-			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.CreateClient(dstHeader, chains[src].GetTrustingPeriod(), chains[src].MustGetAddress())}, chains[src], cmd)
+			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.CreateClient(dstHeader, chains[dst].GetTrustingPeriod(), chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 	return cmd

--- a/relayer/client-tx.go
+++ b/relayer/client-tx.go
@@ -23,7 +23,7 @@ func (src *Chain) CreateClients(dst *Chain) (err error) {
 		if src.debug {
 			src.logCreateClient(dst, dstH.GetHeight())
 		}
-		clients.Src = append(clients.Src, src.PathEnd.CreateClient(dstH, src.GetTrustingPeriod(), src.MustGetAddress()))
+		clients.Src = append(clients.Src, src.PathEnd.CreateClient(dstH, dst.GetTrustingPeriod(), src.MustGetAddress()))
 	}
 
 	// Create client for src on dst if it doesn't exist
@@ -37,7 +37,7 @@ func (src *Chain) CreateClients(dst *Chain) (err error) {
 		if dst.debug {
 			dst.logCreateClient(src, srcH.GetHeight())
 		}
-		clients.Dst = append(clients.Dst, dst.PathEnd.CreateClient(srcH, dst.GetTrustingPeriod(), dst.MustGetAddress()))
+		clients.Dst = append(clients.Dst, dst.PathEnd.CreateClient(srcH, src.GetTrustingPeriod(), dst.MustGetAddress()))
 	}
 
 	// Send msgs to both chains


### PR DESCRIPTION
Fixes #254


The `rly tx gen` does not use clients that are frozen but doesn't check for expired clients. A new check is now added to not use clients with last state expired.
Also changed the code to create clients with the trusted period of the chain they follow and not the chain they are instantiated on.
      
