### PR TITLE
Allow pathEnd version string to be specified in the config file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	defaultOrder   = "ORDERED"
+	defaultVersion = "ics20-1"
+)
+
 func configCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "config",
@@ -185,8 +190,16 @@ func cfgFilesAdd(dir string) (cfg *Config, err error) {
 
 			// In the case that order isn't added to the path, add it manually
 			if p.Src.Order == "" || p.Dst.Order == "" {
-				p.Src.Order = "ORDERED"
-				p.Dst.Order = "ORDERED"
+				p.Src.Order = defaultOrder
+				p.Dst.Order = defaultOrder
+			}
+
+			// If the version isn't added to the path, add it manually
+			if p.Src.Version == "" {
+				p.Src.Version = defaultVersion
+			}
+			if p.Dst.Version == "" {
+				p.Dst.Version = defaultVersion
 			}
 
 			pthName := strings.Split(f.Name(), ".")[0]

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -110,6 +110,9 @@ func (p *Path) Validate() (err error) {
 	if err = p.Src.Validate(); err != nil {
 		return err
 	}
+	if p.Src.Version == "" {
+		return fmt.Errorf("Source must specify a version")
+	}
 	if err = p.Dst.Validate(); err != nil {
 		return err
 	}
@@ -139,7 +142,7 @@ func (p *Path) String() string {
 
 // GenPath generates a path with random client, connection and channel identifiers
 // given chainIDs and portIDs
-func GenPath(srcChainID, dstChainID, srcPortID, dstPortID, order string) *Path {
+func GenPath(srcChainID, dstChainID, srcPortID, dstPortID, order string, version string) *Path {
 	return &Path{
 		Src: &PathEnd{
 			ChainID:      srcChainID,

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -111,7 +111,7 @@ func (p *Path) Validate() (err error) {
 		return err
 	}
 	if p.Src.Version == "" {
-		return fmt.Errorf("Source must specify a version")
+		return fmt.Errorf("source must specify a version")
 	}
 	if err = p.Dst.Validate(); err != nil {
 		return err
@@ -151,6 +151,7 @@ func GenPath(srcChainID, dstChainID, srcPortID, dstPortID, order string, version
 			ChannelID:    RandLowerCaseLetterString(10),
 			PortID:       srcPortID,
 			Order:        order,
+			Version:      version,
 		},
 		Dst: &PathEnd{
 			ChainID:      dstChainID,
@@ -159,6 +160,7 @@ func GenPath(srcChainID, dstChainID, srcPortID, dstPortID, order string, version
 			ChannelID:    RandLowerCaseLetterString(10),
 			PortID:       dstPortID,
 			Order:        order,
+			Version:      version,
 		},
 		Strategy: &StrategyCfg{
 			Type: "naive",

--- a/relayer/pathEnd.go
+++ b/relayer/pathEnd.go
@@ -26,6 +26,7 @@ type PathEnd struct {
 	ChannelID    string `yaml:"channel-id,omitempty" json:"channel-id,omitempty"`
 	PortID       string `yaml:"port-id,omitempty" json:"port-id,omitempty"`
 	Order        string `yaml:"order,omitempty" json:"order,omitempty"`
+	Version      string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 // OrderFromString parses a string into a channel order byte
@@ -129,7 +130,7 @@ func (src *PathEnd) ChanInit(dst *PathEnd, signer sdk.AccAddress) sdk.Msg {
 	return chanTypes.NewMsgChannelOpenInit(
 		src.PortID,
 		src.ChannelID,
-		defaultTransferVersion,
+		src.Version,
 		src.getOrder(),
 		[]string{src.ConnectionID},
 		dst.PortID,
@@ -143,7 +144,7 @@ func (src *PathEnd) ChanTry(dst *PathEnd, dstChanState chanTypes.ChannelResponse
 	return chanTypes.NewMsgChannelOpenTry(
 		src.PortID,
 		src.ChannelID,
-		defaultTransferVersion,
+		src.Version,
 		dstChanState.Channel.Ordering,
 		[]string{src.ConnectionID},
 		dst.PortID,

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -200,7 +200,7 @@ func getLoggingChain(chns []*Chain, rsr *dockertest.Resource) *Chain {
 }
 
 func genTestPathAndSet(src, dst *Chain, srcPort, dstPort string) (*Path, error) {
-	path := GenPath(src.ChainID, dst.ChainID, srcPort, dstPort, "ORDERED")
+	path := GenPath(src.ChainID, dst.ChainID, srcPort, dstPort, "ORDERED", "ics20-1")
 	if err := src.SetPath(path.Src); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Default, as before, to `"ics20-1"`, but this allows non-transfer ports to be relayed without much difficulty.
