### PR TITLE
R4R: Fix relay packets from unordered channel

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -689,7 +689,7 @@ func queryUnrelayed() *cobra.Command {
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(c[src], c[dst], sh)
+			sp, err := relayer.UnrelayedSequences(c[src], c[dst], sh, path.Ordered())
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -195,13 +195,13 @@ func relayMsgsCmd() *cobra.Command {
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(c[src], c[dst], sh)
+			path := config.Paths.MustGet(args[0])
+			strategy, err := GetStrategyWithOptions(cmd, path.MustGetStrategy())
 			if err != nil {
 				return err
 			}
 
-			path := config.Paths.MustGet(args[0])
-			strategy, err := GetStrategyWithOptions(cmd, path.MustGetStrategy())
+			sp, err := relayer.UnrelayedSequences(c[src], c[dst], sh, path.Ordered())
 			if err != nil {
 				return err
 			}

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -32,12 +32,12 @@ func (nrs *NaiveStrategy) GetType() string {
 
 // UnrelayedSequencesOrdered returns the unrelayed sequence numbers between two chains
 func (nrs *NaiveStrategy) UnrelayedSequencesOrdered(src, dst *Chain, sh *SyncHeaders) (*RelaySequences, error) {
-	return UnrelayedSequences(src, dst, sh)
+	return UnrelayedSequences(src, dst, sh, true)
 }
 
 // UnrelayedSequencesUnordered returns the unrelayed sequence numbers between two chains
 func (nrs *NaiveStrategy) UnrelayedSequencesUnordered(src, dst *Chain, sh *SyncHeaders) (*RelaySequences, error) {
-	return UnrelayedSequences(src, dst, sh)
+	return UnrelayedSequences(src, dst, sh, false)
 }
 
 // HandleEvents defines how the relayer will handle block and transaction events as they are emmited


### PR DESCRIPTION
# Relay Packet From Unordered Channel

## Bug Description

For unordered channel, cmd `rly tx rly [path]` and `rly start [path]` will relay all packets every time they are executed, whether they have been relayed or not.

And the packets have been relayed can be relayed again, causes the number of cross-chain tokens minted on counterparty chain is greater than the number of escrowed native tokens on source chain. This bug has been fixed here: https://github.com/cosmos/cosmos-sdk/pull/6337

## Reason

In ordered channel, receive-sequence and send-sequence must be sequential, so we can get the unrelayed sequences by `[src-next-send-seq] - [dst-next-recv-seq]`.

But for unordered channel, we can only get `src-next-send-seq`. So we can't get all unrelayed sequences though the method in ordered channel.

## Fix

We filter the sequences by whether the acknowledgement of packet exists, so that relayer can work normally.

```go
func newRlySeq(chain *Chain, start, end uint64, ordered bool, height uint64) []uint64 {
    if end < start {
        return []uint64{}
    }
    s := make([]uint64, 0, 1+(end-start))
    for start < end {
        if ordered {
            s = append(s, start)
            start++
        } else {
            ack, err := chain.QueryPacketAck(int64(height), int64(start))
            if err != nil {
                chain.Log(err.Error())
            } else if ack.Data == nil {
                s = append(s, start)
            }
            start++
        }
    }
    return s
}
```
