### PR TITLE
Allow faucet to send multiple tokens at a time

### DIFF
--- a/cmd/testnets.go
+++ b/cmd/testnets.go
@@ -112,7 +112,7 @@ func faucetStartCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			amount, err := sdk.ParseCoin(args[2])
+			amount, err := sdk.ParseCoins(args[2])
 			if err != nil {
 				return err
 			}

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -103,7 +103,7 @@ func (src *Chain) faucetSend(fromAddr, toAddr sdk.AccAddress, amounts sdk.Coins)
 		return err
 	}
 
-	res, err := src.SendMsgWithKey(bank.NewMsgSend(fromAddr, toAddr, amounts), info.GetName())
+	res, err := src.SendMsgWithKey(bank.NewMsgSend(fromAddr, toAddr, sdk.NewCoins(amounts...)), info.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to send transaction: %w\n%s", err, res)
 	} else if res.Code != 0 {

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -23,15 +23,6 @@ func (src *Chain) SendMsgWithKey(datagram sdk.Msg, keyName string) (res sdk.TxRe
 
 }
 
-// SendMsgsWithKey sign and broadcast tx with multiple messages
-func (src *Chain) SendMsgsWithKey(datagram []sdk.Msg, keyName string) (res sdk.TxResponse, err error) {
-	var out []byte
-	if out, err = src.BuildAndSignTxWithKey(datagram, keyName); err != nil {
-		return res, err
-	}
-	return src.BroadcastTxCommit(out)
-}
-
 // BuildAndSignTxWithKey allows the user to specify which relayer key will sign the message
 func (src *Chain) BuildAndSignTxWithKey(datagram []sdk.Msg, keyName string) ([]byte, error) {
 
@@ -112,12 +103,7 @@ func (src *Chain) faucetSend(fromAddr, toAddr sdk.AccAddress, amounts sdk.Coins)
 		return err
 	}
 
-	msgs := []sdk.Msg{}
-	for _, amount := range amounts {
-		msgs = append(msgs, bank.NewMsgSend(fromAddr, toAddr, sdk.NewCoins(amount)))
-	}
-
-	res, err := src.SendMsgsWithKey(msgs, info.GetName())
+	res, err := src.SendMsgWithKey(bank.NewMsgSend(fromAddr, toAddr, amounts), info.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to send transaction: %w\n%s", err, res)
 	} else if res.Code != 0 {

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -23,6 +23,15 @@ func (src *Chain) SendMsgWithKey(datagram sdk.Msg, keyName string) (res sdk.TxRe
 
 }
 
+// SendMsgsWithKey sign and broadcast tx with multiple messages
+func (src *Chain) SendMsgsWithKey(datagram []sdk.Msg, keyName string) (res sdk.TxResponse, err error) {
+	var out []byte
+	if out, err = src.BuildAndSignTxWithKey(datagram, keyName); err != nil {
+		return res, err
+	}
+	return src.BroadcastTxCommit(out)
+}
+
 // BuildAndSignTxWithKey allows the user to specify which relayer key will sign the message
 func (src *Chain) BuildAndSignTxWithKey(datagram []sdk.Msg, keyName string) ([]byte, error) {
 
@@ -48,7 +57,7 @@ func (src *Chain) BuildAndSignTxWithKey(datagram []sdk.Msg, keyName string) ([]b
 }
 
 // FaucetHandler listens for addresses
-func (src *Chain) FaucetHandler(fromKey sdk.AccAddress, amount sdk.Coin) func(w http.ResponseWriter, r *http.Request) {
+func (src *Chain) FaucetHandler(fromKey sdk.AccAddress, amounts sdk.Coins) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		src.Log("handling faucet request...")
@@ -85,25 +94,30 @@ func (src *Chain) FaucetHandler(fromKey sdk.AccAddress, amount sdk.Coin) func(w 
 		done := src.UseSDKContext()
 		defer done()
 
-		if err := src.faucetSend(fromKey, fr.addr(), amount); err != nil {
+		if err := src.faucetSend(fromKey, fr.addr(), amounts); err != nil {
 			src.Error(err)
 			respondWithError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-
-		src.Log(fmt.Sprintf("%s was sent %s successfully", fr.Address, amount.String()))
-		respondWithJSON(w, http.StatusCreated, success{Address: fr.Address, Amount: amount.String()})
+		src.Log(fmt.Sprintf("%s was sent %s successfully", fr.Address, amounts.String()))
+		respondWithJSON(w, http.StatusCreated, success{Address: fr.Address, Amount: amounts.String()})
 	}
 }
 
-func (src *Chain) faucetSend(fromAddr, toAddr sdk.AccAddress, amount sdk.Coin) error {
+func (src *Chain) faucetSend(fromAddr, toAddr sdk.AccAddress, amounts sdk.Coins) error {
 	// Set sdk config to use custom Bech32 account prefix
 
 	info, err := src.Keybase.KeyByAddress(fromAddr)
 	if err != nil {
 		return err
 	}
-	res, err := src.SendMsgWithKey(bank.NewMsgSend(fromAddr, toAddr, sdk.NewCoins(amount)), info.GetName())
+
+	msgs := []sdk.Msg{}
+	for _, amount := range amounts {
+		msgs = append(msgs, bank.NewMsgSend(fromAddr, toAddr, sdk.NewCoins(amount)))
+	}
+
+	res, err := src.SendMsgsWithKey(msgs, info.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to send transaction: %w\n%s", err, res)
 	} else if res.Code != 0 {


### PR DESCRIPTION
This allows faucet to send multiple tokens at a time

We used it for tamagotchi zone

new command syntax to start faucet is 
`rly tesnets faucet [chain-id] [key-name] [amounts]`

where amounts is something like "1000fish,100stake,1doubloons"

