### PR TITLE
Fixed issues in scripts to start two or three chains

### DIFF
--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -1,5 +1,11 @@
 #!/bin/sh
-# USAGE: ./one-chain test-chain-id ./data 26657 26656
+
+display_usage() {
+	echo "\nMissing $1 parameter. Please check if all parameters were specified."
+	echo "\nUsage: ./one-chain [CHAIN_ID] [CHAIN_DIR] [RPC_PORT] [P2P_PORT] [PROFILING_PORT] [GRPC_PORT]"
+  echo "\nExample: ./one-chain test-chain-id ./data 26657 26656 6060 9090 \n"
+  exit 1
+}
 
 CHAINID=$1
 CHAINDIR=$2
@@ -9,55 +15,81 @@ PROFPORT=$5
 GRPCPORT=$6
 
 if [ -z "$1" ]; then
-  echo "Need to input chain id..."
-  exit 1
+  display_usage "[CHAIN_ID]"
 fi
 
 if [ -z "$2" ]; then
-  echo "Need to input directory to create files in..."
-  exit 1
+  display_usage "[CHAIN_DIR]"
 fi
 
 if [ -z "$3" ]; then
-  echo "Need to input rpc port (e.g. 26657)..."
-  exit 1
+  display_usage "[RPC_PORT]"
 fi
 
 if [ -z "$4" ]; then
-  echo "Need to input p2p port (e.g. 26656)..."
-  exit 1
+  display_usage "[P2P_PORT]"
 fi
 
 if [ -z "$5" ]; then
-  echo "Need to input profiling server port (e.g. 6060)..."
-  exit 1
+  display_usage "[PROFILING_PORT]"
 fi
 
 if [ -z "$6" ]; then
-  echo "Need to input grpc server port (e.g. 9090)..."
-  exit 1
+  display_usage "[GRPC_PORT]"
 fi
 
-echo "Creating gaiad instance with home=$CHAINDIR chain-id=$CHAINID p2p=:$P2PPORT rpc=:$RPCPORT..."
+echo "Creating gaiad instance: home=$CHAINDIR | chain-id=$CHAINID | p2p=:$P2PPORT | rpc=:$RPCPORT | profiling=:$PROFPORT | grpc=:$GRPCPORT"
+
+# Add dir for chain, exit if error
+if ! mkdir -p $CHAINDIR/$CHAINID 2>/dev/null; then
+    echo "Failed to create chain folder. Aborting..."
+    exit 1
+fi
+
 # Build genesis file incl account for passed address
 coins="100000000000stake,100000000000samoleans"
-gaiad --home $CHAINDIR/$CHAINID --chain-id $CHAINID init $CHAINID &> /dev/null
-gaiad --home $CHAINDIR/$CHAINID keys add validator --keyring-backend="test" > $CHAINDIR/$CHAINID/validator_seed.json 2> /dev/null
-gaiad --home $CHAINDIR/$CHAINID keys add user --keyring-backend="test" --output json > $CHAINDIR/$CHAINID/key_seed.json 2> /dev/null
-gaiad --home $CHAINDIR/$CHAINID add-genesis-account $(gaiad --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show user -a) $coins &> /dev/null
-gaiad --home $CHAINDIR/$CHAINID add-genesis-account $(gaiad --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show validator -a) $coins  &> /dev/null
-gaiad --home $CHAINDIR/$CHAINID gentx validator --keyring-backend="test" --chain-id $CHAINID &> /dev/null
-gaiad --home $CHAINDIR/$CHAINID collect-gentxs &> /dev/null
 
-# Set proper defaults and change ports
-# TODO: sed for linux
-sed -i '' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPCPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
-sed -i '' 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
-sed -i '' 's#"localhost:6060"#"localhost:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
-sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
-sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
-sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAINDIR/$CHAINID/config/config.toml
-# sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAINDIR/$CHAINID/config/app.toml
+gaiad --home $CHAINDIR/$CHAINID --chain-id $CHAINID init $CHAINID &> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID keys add validator --keyring-backend="test" --output json > $CHAINDIR/$CHAINID/validator_seed.json 2> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID keys add user --keyring-backend="test" --output json > $CHAINDIR/$CHAINID/key_seed.json 2> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID add-genesis-account $(gaiad --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show user -a) $coins &> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID add-genesis-account $(gaiad --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show validator -a) $coins  &> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID gentx validator --keyring-backend="test" --chain-id $CHAINID &> /dev/null
+sleep 1
+gaiad --home $CHAINDIR/$CHAINID collect-gentxs &> /dev/null
+sleep 1
+
+# Check platform
+platform='unknown'
+unamestr=`uname`
+if [ "$unamestr" = 'Linux' ]; then
+   platform='linux'
+fi
+
+# Set proper defaults and change ports (use a different sed for Mac or Linux)
+echo "Change settings in config.toml file..."
+if [ $platform = 'linux' ]; then
+  sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPCPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's#"localhost:6060"#"localhost:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/index_all_keys = false/index_all_keys = true/g' $CHAINDIR/$CHAINID/config/config.toml
+  # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAINDIR/$CHAINID/config/app.toml
+else
+  sed -i '' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPCPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's#"localhost:6060"#"localhost:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAINDIR/$CHAINID/config/config.toml
+  # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAINDIR/$CHAINID/config/app.toml
+fi
 
 # Start the gaia
 gaiad --home $CHAINDIR/$CHAINID start --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT" > $CHAINDIR/$CHAINID.log 2>&1 &

--- a/scripts/three-chainz
+++ b/scripts/three-chainz
@@ -78,5 +78,8 @@ echo "Generating gaia configurations..."
 mkdir -p $GAIA_DATA && cd $GAIA_DATA && cd ../
 ./scripts/one-chain $chainid0 ./data 26657 26656 6060 9090
 ./scripts/one-chain $chainid1 ./data 26557 26556 6061 9091
-./scripts/one-chain $chainid1 ./data 25557 25556 6062 9092
+./scripts/one-chain $chainid2 ./data 25557 25556 6062 9092
 
+[ -f $GAIA_DATA/$chainid0.log ] && echo "$chainid0 initialized. Watch file $GAIA_DATA/$chainid0.log to see its execution."
+[ -f $GAIA_DATA/$chainid1.log ] && echo "$chainid1 initialized. Watch file $GAIA_DATA/$chainid1.log to see its execution."
+[ -f $GAIA_DATA/$chainid1.log ] && echo "$chainid2 initialized. Watch file $GAIA_DATA/$chainid2.log to see its execution."

--- a/scripts/two-chainz
+++ b/scripts/two-chainz
@@ -11,16 +11,16 @@ if [[ ! -d $GOPATH ]] || [[ ! -d $GOBIN ]] || [[ ! -x "$(which go)" ]]; then
 fi
 
 GAIA_REPO="$GOPATH/src/github.com/cosmos/gaia"
-GAIA_BRANCH=gaiav3.0
+GAIA_BRANCH=stargate-3
 GAIA_DATA="$(pwd)/data"
 
-# ARGS: 
+# ARGS:
 # $1 -> local || remote, defaults to remote
 
 # Ensure user understands what will be deleted
 if [[ -d $GAIA_DATA ]] && [[ ! "$2" == "skip" ]]; then
   read -p "$0 will delete \$(pwd)/data folder. Do you wish to continue? (y/n): " -n 1 -r
-  echo 
+  echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
       exit 1
   fi
@@ -59,14 +59,14 @@ if [[ -d $GAIA_REPO ]]; then
       if [[ ! "$(gaiad version --long 2>&1 | grep "commit:" | sed 's/commit: //g')" == "$(git rev-parse HEAD)" ]]; then
         echo "built version of gaiad commit doesn't match"
         exit 1
-      fi 
+      fi
     else
       echo "uncommited changes in $GAIA_REPO, please commit or stash before building"
       exit 1
     fi
-    
-  fi 
-else 
+
+  fi
+else
   echo "$GAIA_REPO doesn't exist, and you may not have have the gaia repo locally,"
   echo "if you want to download gaia to your \$GOPATH try running the following command:"
   echo "mkdir -p $(dirname $GAIA_REPO) && git clone git@github.com:cosmos/gaia $GAIA_REPO"
@@ -79,3 +79,6 @@ echo "Generating gaia configurations..."
 mkdir -p $GAIA_DATA && cd $GAIA_DATA && cd ../
 ./scripts/one-chain $chainid0 ./data 26657 26656 6060 9090
 ./scripts/one-chain $chainid1 ./data 26557 26556 6061 9091
+
+[ -f $GAIA_DATA/$chainid0.log ] && echo "$chainid0 initialized. Watch file $GAIA_DATA/$chainid0.log to see its execution."
+[ -f $GAIA_DATA/$chainid1.log ] && echo "$chainid1 initialized. Watch file $GAIA_DATA/$chainid1.log to see its execution."


### PR DESCRIPTION
Closes: #283 

Implemented changes:

- Fixed logic to allow script to run on Linux (tested on Ubuntu). Tested on a Mac and it's works.
- Changed gaia branch to `stargate-3`.
- Fixed logic to start three chains.
- Better display usage output.
- Added sleep logic between `gaiad` race conditions that were making the script to fail.
- Output message at the end with log filename so users can watch it (`tail -f [log file]`).