### PR TITLE
WIP debugging denom issues

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -52,14 +52,14 @@ func chainsAddrCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
-
+			unlock := relayer.SDKConfig.SetLock(chain)
 			addr, err := chain.GetAddress()
 			if err != nil {
 				return err
 			}
 
 			fmt.Println(addr.String())
+			unlock()
 			return nil
 		},
 	}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -56,7 +56,7 @@ func keysAddCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			var keyName string
 			if len(args) == 2 {
@@ -107,7 +107,7 @@ func keysRestoreCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			if chain.KeyExists(keyName) {
 				return errKeyExists(keyName)
@@ -178,7 +178,7 @@ func keysListCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			info, err := chain.Keybase.List()
 			if err != nil {
@@ -209,7 +209,7 @@ func keysShowCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			var keyName string
 			if len(args) == 2 {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -159,7 +159,7 @@ func queryAccountCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			res, err := types.NewQueryClient(chain.CLIContext(0)).Account(
 				context.Background(),
@@ -193,7 +193,7 @@ func queryBalanceCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 			var coins sdk.Coins
 			if len(args) == 2 {
 				coins, err = chain.QueryBalance(args[1])

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
 	tmclient "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/07-tendermint/types"
 	"github.com/ovrclk/relayer/relayer"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ func queryCmd() *cobra.Command {
 		queryBalanceCmd(),
 		queryHeaderCmd(),
 		queryNodeStateCmd(),
+		queryValSetAtHeightCmd(),
 		queryTxs(),
 		queryTx(),
 		flags.LineBreak,
@@ -387,6 +389,35 @@ func queryClientsCmd() *cobra.Command {
 	}
 
 	return paginationFlags(cmd)
+}
+
+func queryValSetAtHeightCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "valset [chain-id]",
+		Aliases: []string{"vs"},
+		Short:   "Query validator set at particular height",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chain, err := config.Chains.Get(args[0])
+			if err != nil {
+				return err
+			}
+
+			h, err := chain.QueryLatestHeight()
+			if err != nil {
+				return err
+			}
+
+			res, err := chain.QueryValsetAtHeight(clienttypes.NewHeight(0, uint64(h)))
+			if err != nil {
+				return err
+			}
+
+			return chain.CLIContext(0).PrintOutput(res)
+		},
+	}
+
+	return cmd
 }
 
 func queryConnections() *cobra.Command {

--- a/cmd/testnets.go
+++ b/cmd/testnets.go
@@ -41,7 +41,7 @@ func faucetRequestCmd() *cobra.Command {
 				return err
 			}
 
-			chain.UseSDKContext()
+			relayer.SDKConfig.Set(chain)
 
 			urlString, err := cmd.Flags().GetString(flagURL)
 			if err != nil {

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -60,11 +60,12 @@ func xfersend() *cobra.Command {
 			// Should be relative to current time and block height
 			// --timeout-height-offset=1000
 			// --timeout-time-offset=2h
-			c[dst].UseSDKContext()
+			unlock := relayer.SDKConfig.SetLock(c[dst])
 			dstAddr, err := sdk.AccAddressFromBech32(args[3])
 			if err != nil {
 				return err
 			}
+			unlock()
 
 			return c[src].SendTransferMsg(c[dst], amount, dstAddr)
 		},

--- a/configs/akash/demo.json
+++ b/configs/akash/demo.json
@@ -1,0 +1,1 @@
+{"src":{"chain-id":"ibc0","client-id":"ibconeclient","connection-id":"ibconeconnection","channel-id":"ibconexfer","port-id":"transfer","order":"unordered"},"dst":{"chain-id":"ibc1","client-id":"ibczeroclient","connection-id":"ibczeroconnection","channel-id":"ibczeroxfer","port-id":"transfer","order":"unordered"},"strategy":{"type":"naive"}}

--- a/configs/akash/ibc0.json
+++ b/configs/akash/ibc0.json
@@ -1,0 +1,1 @@
+{"key":"testkey","chain-id":"ibc0","rpc-addr":"http://localhost:26657","account-prefix":"cosmos","gas-adjustment":1.5,"gas-prices":"0.025stake","trusting-period":"336h"}

--- a/configs/akash/ibc1.json
+++ b/configs/akash/ibc1.json
@@ -1,0 +1,1 @@
+{"key":"testkey","chain-id":"ibc1","rpc-addr":"http://localhost:26557","account-prefix":"akash","gas-adjustment":1.5,"gas-prices":"0.025stake", "trusting-period":"336h"}

--- a/dev-env
+++ b/dev-env
@@ -15,8 +15,8 @@ fi
 
 cd $RELAYER_DIR
 rm -rf $RELAYER_CONF &> /dev/null
-bash scripts/two-chainz "local" "skip"
-bash scripts/config-relayer "skip"
+bash scripts/two-chainz-akash "local" "skip"
+bash scripts/config-relayer-akash "skip"
 
 echo "waiting for blocks..."
 sleep 3

--- a/relayer/channel-tx.go
+++ b/relayer/channel-tx.go
@@ -111,59 +111,71 @@ func (c *Chain) CreateChannelStep(dst *Chain, ordering chantypes.Order) (*RelayM
 		if c.debug {
 			logChannelStates(c, dst, srcChan, dstChan)
 		}
+		unlock := SDKConfig.SetLock(c)
 		out.Src = append(out.Src,
 			c.PathEnd.ChanInit(dst.PathEnd, c.MustGetAddress()),
 		)
+		unlock()
 
 	// Handshake has started on dst (1 step done), relay `chanOpenTry` and `updateClient` to src
 	case srcChan.Channel.State == chantypes.UNINITIALIZED && dstChan.Channel.State == chantypes.INIT:
 		if c.debug {
 			logChannelStates(c, dst, srcChan, dstChan)
 		}
+		unlock := SDKConfig.SetLock(c)
 		out.Src = append(out.Src,
 			c.PathEnd.UpdateClient(dstUpdateHeader, c.MustGetAddress()),
 			c.PathEnd.ChanTry(dst.PathEnd, dstChan, c.MustGetAddress()),
 		)
+		unlock()
 
 	// Handshake has started on src (1 step done), relay `chanOpenTry` and `updateClient` to dst
 	case srcChan.Channel.State == chantypes.INIT && dstChan.Channel.State == chantypes.UNINITIALIZED:
 		if dst.debug {
 			logChannelStates(dst, c, dstChan, srcChan)
 		}
+		unlock := SDKConfig.SetLock(dst)
 		out.Dst = append(out.Dst,
 			dst.PathEnd.UpdateClient(srcUpdateHeader, dst.MustGetAddress()),
 			dst.PathEnd.ChanTry(c.PathEnd, srcChan, dst.MustGetAddress()),
 		)
+		unlock()
 
 	// Handshake has started on src (2 steps done), relay `chanOpenAck` and `updateClient` to dst
 	case srcChan.Channel.State == chantypes.TRYOPEN && dstChan.Channel.State == chantypes.INIT:
 		if dst.debug {
 			logChannelStates(dst, c, dstChan, srcChan)
 		}
+		unlock := SDKConfig.SetLock(dst)
 		out.Dst = append(out.Dst,
 			dst.PathEnd.UpdateClient(srcUpdateHeader, dst.MustGetAddress()),
 			dst.PathEnd.ChanAck(c.PathEnd, srcChan, dst.MustGetAddress()),
 		)
+		unlock()
 
 	// Handshake has started on dst (2 steps done), relay `chanOpenAck` and `updateClient` to src
 	case srcChan.Channel.State == chantypes.INIT && dstChan.Channel.State == chantypes.TRYOPEN:
 		if c.debug {
 			logChannelStates(c, dst, srcChan, dstChan)
 		}
+		unlock := SDKConfig.SetLock(c)
 		out.Src = append(out.Src,
 			c.PathEnd.UpdateClient(dstUpdateHeader, c.MustGetAddress()),
 			c.PathEnd.ChanAck(dst.PathEnd, dstChan, c.MustGetAddress()),
 		)
+		unlock()
 
 	// Handshake has confirmed on dst (3 steps done), relay `chanOpenConfirm` and `updateClient` to src
 	case srcChan.Channel.State == chantypes.TRYOPEN && dstChan.Channel.State == chantypes.OPEN:
 		if c.debug {
 			logChannelStates(c, dst, srcChan, dstChan)
 		}
+		unlock := SDKConfig.SetLock(c)
 		out.Src = append(out.Src,
 			c.PathEnd.UpdateClient(dstUpdateHeader, c.MustGetAddress()),
 			c.PathEnd.ChanConfirm(dstChan, c.MustGetAddress()),
 		)
+		unlock()
 		out.last = true
 
 	// Handshake has confirmed on src (3 steps done), relay `chanOpenConfirm` and `updateClient` to dst
@@ -171,10 +183,12 @@ func (c *Chain) CreateChannelStep(dst *Chain, ordering chantypes.Order) (*RelayM
 		if dst.debug {
 			logChannelStates(dst, c, dstChan, srcChan)
 		}
+		unlock := SDKConfig.SetLock(dst)
 		out.Dst = append(out.Dst,
 			dst.PathEnd.UpdateClient(srcUpdateHeader, dst.MustGetAddress()),
 			dst.PathEnd.ChanConfirm(srcChan, dst.MustGetAddress()),
 		)
+		unlock()
 		out.last = true
 	}
 

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -54,14 +54,13 @@ func (c *Chain) FaucetHandler(fromKey sdk.AccAddress, amounts sdk.Coins) func(w 
 			return
 		}
 
-		c.UseSDKContext()
-		// defer done()
-
+		unlock := SDKConfig.SetLock(c)
 		if err := c.faucetSend(fromKey, fr.addr(), amounts); err != nil {
 			c.Error(err)
 			respondWithError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		unlock()
 
 		c.Log(fmt.Sprintf("%s was sent %s successfully", fr.Address, amounts.String()))
 		respondWithJSON(w, http.StatusCreated, success{Address: fr.Address, Amount: amounts.String()})

--- a/relayer/headers.go
+++ b/relayer/headers.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"fmt"
 	"sync"
 
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
@@ -127,6 +128,9 @@ func InjectTrustedFields(srcChain, dstChain *Chain, srcHeader *tmclient.Header) 
 
 	// query TrustedValidators at Trusted Height from srcChain
 	// srcChain.UseSDKContext()
+	fmt.Println("IN INJECTTRUSTEDFIELDS")
+	fmt.Println("SRC", srcChain.ChainID, srcChain.AccountPrefix)
+	fmt.Println("DST", dstChain.ChainID, dstChain.AccountPrefix)
 	valSet, err := srcChain.QueryValsetAtHeight(h.TrustedHeight)
 	if err != nil {
 		return nil, err

--- a/relayer/headers.go
+++ b/relayer/headers.go
@@ -1,7 +1,6 @@
 package relayer
 
 import (
-	"fmt"
 	"sync"
 
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
@@ -127,10 +126,6 @@ func InjectTrustedFields(srcChain, dstChain *Chain, srcHeader *tmclient.Header) 
 	h.TrustedHeight = cs.GetLatestHeight().(clienttypes.Height)
 
 	// query TrustedValidators at Trusted Height from srcChain
-	// srcChain.UseSDKContext()
-	fmt.Println("IN INJECTTRUSTEDFIELDS")
-	fmt.Println("SRC", srcChain.ChainID, srcChain.AccountPrefix)
-	fmt.Println("DST", dstChain.ChainID, dstChain.AccountPrefix)
 	valSet, err := srcChain.QueryValsetAtHeight(h.TrustedHeight)
 	if err != nil {
 		return nil, err

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -21,17 +21,20 @@ func (c *Chain) SendTransferMsg(dst *Chain, amount sdk.Coin, dstAddr fmt.Stringe
 	}
 
 	// Properly render the address string
-	dst.UseSDKContext()
+	unlock := SDKConfig.SetLock(dst)
 	dstAddrString := dstAddr.String()
+	unlock()
 
 	// MsgTransfer will call SendPacket on src chain
 	// TODO: Add ability to specify timeout time or height via command line flags
+	unlock = SDKConfig.SetLock(c)
 	txs := RelayMsgs{
 		Src: []sdk.Msg{c.PathEnd.MsgTransfer(
 			dst.PathEnd, amount, dstAddrString, c.MustGetAddress(), uint64(h.Header.Height+1000), 0,
 		)},
 		Dst: []sdk.Msg{},
 	}
+	unlock()
 
 	if txs.Send(c, dst); !txs.success {
 		return fmt.Errorf("failed to send transfer message")

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -338,20 +338,19 @@ func (c *Chain) QueryHistoricalInfo(height clienttypes.Height) (*stakingtypes.Qu
 
 // QueryValsetAtHeight returns the validator set at a given height
 func (c *Chain) QueryValsetAtHeight(height clienttypes.Height) (*tmproto.ValidatorSet, error) {
+	unlock := SDKConfig.SetLock(c)
 	res, err := c.QueryHistoricalInfo(height)
 	if err != nil {
 		return nil, err
 	}
 
 	// create tendermint ValidatorSet from SDK Validators
-	fmt.Println("USING SDK CONTEXT IN QUERYVALSETATHEIGHT")
-	fmt.Println(c.ChainID, c.AccountPrefix)
-	c.UseSDKContext()
 	tmVals := stakingtypes.Validators(res.Hist.Valset).ToTmValidators()
 	tmValSet := &tmtypes.ValidatorSet{
 		Validators: tmVals,
 		Proposer:   tmVals[0],
 	}
+	unlock()
 
 	return tmValSet.ToProto()
 }

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -344,7 +344,9 @@ func (c *Chain) QueryValsetAtHeight(height clienttypes.Height) (*tmproto.Validat
 	}
 
 	// create tendermint ValidatorSet from SDK Validators
-	// c.UseSDKContext()
+	fmt.Println("USING SDK CONTEXT IN QUERYVALSETATHEIGHT")
+	fmt.Println(c.ChainID, c.AccountPrefix)
+	c.UseSDKContext()
 	tmVals := stakingtypes.Validators(res.Hist.Valset).ToTmValidators()
 	tmValSet := &tmtypes.ValidatorSet{
 		Validators: tmVals,

--- a/relayer/relayPackets.go
+++ b/relayer/relayPackets.go
@@ -70,7 +70,8 @@ func (rp *relayMsgTimeout) Msg(src, dst *Chain) sdk.Msg {
 	if rp.dstRecvRes == nil {
 		return nil
 	}
-	return chantypes.NewMsgTimeout(
+	unlock := SDKConfig.SetLock(src)
+	msg := chantypes.NewMsgTimeout(
 		chantypes.NewPacket(
 			rp.packetData,
 			rp.seq,
@@ -86,6 +87,8 @@ func (rp *relayMsgTimeout) Msg(src, dst *Chain) sdk.Msg {
 		rp.dstRecvRes.ProofHeight,
 		src.MustGetAddress(),
 	)
+	unlock()
+	return msg
 }
 
 type relayMsgRecvPacket struct {
@@ -159,12 +162,15 @@ func (rp *relayMsgRecvPacket) Msg(src, dst *Chain) sdk.Msg {
 		clienttypes.NewHeight(0, rp.timeout),
 		rp.timeoutStamp,
 	)
-	return chantypes.NewMsgRecvPacket(
+	unlock := SDKConfig.SetLock(src)
+	msg := chantypes.NewMsgRecvPacket(
 		packet,
 		rp.dstComRes.Proof,
 		rp.dstComRes.ProofHeight,
 		src.MustGetAddress(),
 	)
+	unlock()
+	return msg
 }
 
 type relayMsgPacketAck struct {
@@ -187,7 +193,8 @@ func (rp *relayMsgPacketAck) Timeout() uint64 {
 }
 
 func (rp *relayMsgPacketAck) Msg(src, dst *Chain) sdk.Msg {
-	return chantypes.NewMsgAcknowledgement(
+	unlock := SDKConfig.SetLock(src)
+	msg := chantypes.NewMsgAcknowledgement(
 		chantypes.NewPacket(
 			rp.packetData,
 			rp.seq,
@@ -203,6 +210,8 @@ func (rp *relayMsgPacketAck) Msg(src, dst *Chain) sdk.Msg {
 		rp.dstComRes.ProofHeight,
 		src.MustGetAddress(),
 	)
+	unlock()
+	return msg
 }
 
 func (rp *relayMsgPacketAck) FetchCommitResponse(src, dst *Chain, sh *SyncHeaders) (err error) {

--- a/relayer/sdkcfg.go
+++ b/relayer/sdkcfg.go
@@ -1,0 +1,29 @@
+package relayer
+
+import "sync"
+
+func init() {
+	SDKConfig = &sdkCfg{}
+}
+
+// SDKConfig is a global to gate access to the SDK config object
+var SDKConfig *sdkCfg
+
+// sdkCfg helps manage access to the SDK config object
+type sdkCfg struct {
+	sync.Mutex
+}
+
+// SetContext sets the chains sdk context and prevents concurrent operations
+func (c *sdkCfg) Set(chain *Chain) {
+	c.Lock()
+	defer c.Unlock()
+	chain.UseSDKContext()
+}
+
+// SetLock returns the unlock function from the mutex so that the context can be held
+func (c *sdkCfg) SetLock(chain *Chain) func() {
+	c.Lock()
+	chain.UseSDKContext()
+	return c.Unlock
+}

--- a/scripts/config-relayer-akash
+++ b/scripts/config-relayer-akash
@@ -1,0 +1,40 @@
+#/bin/bash
+
+# Ensure jq is installed
+if [[ ! -x "$(which jq)" ]]; then
+  echo "jq (a tool for parsing json in the command line) is required..."
+  echo "https://stedolan.github.io/jq/download/"
+  exit 1
+fi
+
+RELAYER_DIR="$GOPATH/src/github.com/ovrclk/relayer"
+RELAYER_CONF="$HOME/.relayer"
+GAIA_CONF="$RELAYER_DIR/data"
+
+# Ensure user understands what will be deleted
+if [[ -d $RELAYER_CONF ]] && [[ ! "$1" == "skip" ]]; then
+  read -p "$0 will delete $RELAYER_CONF folder. Do you wish to continue? (y/n): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 1
+  fi
+fi
+
+cd $RELAYER_DIR
+rm -rf $RELAYER_CONF &> /dev/null
+
+echo "Building Relayer..."
+make install
+
+echo "Generating rly configurations..."
+rly config init
+rly config add-dir configs/akash/
+
+SEED0=$(jq -r '.mnemonic' $GAIA_CONF/ibc0/key_seed.json)
+SEED1=$(jq -r '.mnemonic' $GAIA_CONF/ibc1/key_seed.json)
+echo "Key $(rly keys restore ibc0 testkey "$SEED0") imported from ibc0 to relayer..."
+echo "Key $(rly keys restore ibc1 testkey "$SEED1") imported from ibc1 to relayer..."
+echo "Creating light clients..."
+sleep 3
+rly light init ibc0 -f
+rly light init ibc1 -f

--- a/scripts/one-chain-akash
+++ b/scripts/one-chain-akash
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+display_usage() {
+	echo "\nMissing $1 parameter. Please check if all parameters were specified."
+	echo "\nUsage: ./one-chain [CHAIN_ID] [CHAIN_DIR] [RPC_PORT] [P2P_PORT] [PROFILING_PORT] [GRPC_PORT]"
+  echo "\nExample: ./one-chain test-chain-id ./data 26657 26656 6060 9090 \n"
+  exit 1
+}
+
+CHAINID=$1
+CHAINDIR=$2
+RPCPORT=$3
+P2PPORT=$4
+PROFPORT=$5
+GRPCPORT=$6
+
+if [ -z "$1" ]; then
+  display_usage "[CHAIN_ID]"
+fi
+
+if [ -z "$2" ]; then
+  display_usage "[CHAIN_DIR]"
+fi
+
+if [ -z "$3" ]; then
+  display_usage "[RPC_PORT]"
+fi
+
+if [ -z "$4" ]; then
+  display_usage "[P2P_PORT]"
+fi
+
+if [ -z "$5" ]; then
+  display_usage "[PROFILING_PORT]"
+fi
+
+if [ -z "$6" ]; then
+  display_usage "[GRPC_PORT]"
+fi
+
+echo "Creating akash instance: home=$CHAINDIR | chain-id=$CHAINID | p2p=:$P2PPORT | rpc=:$RPCPORT | profiling=:$PROFPORT | grpc=:$GRPCPORT"
+
+# Add dir for chain, exit if error
+if ! mkdir -p $CHAINDIR/$CHAINID 2>/dev/null; then
+    echo "Failed to create chain folder. Aborting..."
+    exit 1
+fi
+
+# Build genesis file incl account for passed address
+coins="100000000000stake,100000000000samoleans"
+
+akash --home $CHAINDIR/$CHAINID --chain-id $CHAINID init $CHAINID &> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID keys add validator --keyring-backend="test" --output json > $CHAINDIR/$CHAINID/validator_seed.json 2> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID keys add user --keyring-backend="test" --output json > $CHAINDIR/$CHAINID/key_seed.json 2> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID add-genesis-account $(akash --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show user -a) $coins &> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID add-genesis-account $(akash --home $CHAINDIR/$CHAINID keys --keyring-backend="test" show validator -a) $coins  &> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID gentx validator --keyring-backend="test" --chain-id $CHAINID &> /dev/null
+sleep 1
+akash --home $CHAINDIR/$CHAINID collect-gentxs &> /dev/null
+sleep 1
+
+# Check platform
+platform='unknown'
+unamestr=`uname`
+if [ "$unamestr" = 'Linux' ]; then
+   platform='linux'
+fi
+
+# Set proper defaults and change ports (use a different sed for Mac or Linux)
+echo "Change settings in config.toml file..."
+if [ $platform = 'linux' ]; then
+  sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPCPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's#"localhost:6060"#"localhost:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i 's/index_all_keys = false/index_all_keys = true/g' $CHAINDIR/$CHAINID/config/config.toml
+  # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAINDIR/$CHAINID/config/app.toml
+else
+  sed -i '' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPCPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's#"localhost:6060"#"localhost:'"$P2PPORT"'"#g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAINDIR/$CHAINID/config/config.toml
+  sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAINDIR/$CHAINID/config/config.toml
+  # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAINDIR/$CHAINID/config/app.toml
+fi
+
+# Start the gaia
+akash --home $CHAINDIR/$CHAINID start --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT" > $CHAINDIR/$CHAINID.log 2>&1 &

--- a/scripts/two-chainz-akash
+++ b/scripts/two-chainz-akash
@@ -11,7 +11,9 @@ if [[ ! -d $GOPATH ]] || [[ ! -d $GOBIN ]] || [[ ! -x "$(which go)" ]]; then
 fi
 
 GAIA_REPO="$GOPATH/src/github.com/cosmos/gaia"
+AKASH_REPO="$GOPATH/src/github.com/ovrclk/akash"
 GAIA_BRANCH=stargate-4
+AKASH_BRANCH=jack/ibc
 GAIA_DATA="$(pwd)/data"
 
 # ARGS:
@@ -28,6 +30,7 @@ fi
 
 rm -rf $GAIA_DATA &> /dev/null
 killall gaiad &> /dev/null
+killall akash &> /dev/null
 
 set -e
 
@@ -43,7 +46,7 @@ if [[ -d $GAIA_REPO ]]; then
     echo "Building github.com/cosmos/gaia@$GAIA_BRANCH..."
     if [[ ! -n $(git status -s) ]]; then
       # sync with remote $GAIA_BRANCH
-      git fetch --all &> /dev/null
+      git fetch --all #&> /dev/null
 
       # ensure the gaia repository successfully pulls the latest $GAIA_BRANCH
       if [[ -n $(git checkout $GAIA_BRANCH -q) ]] || [[ -n $(git pull origin $GAIA_BRANCH -q) ]]; then
@@ -72,13 +75,53 @@ else
   echo "mkdir -p $(dirname $GAIA_REPO) && git clone git@github.com:cosmos/gaia $GAIA_REPO"
 fi
 
+if [[ -d $AKASH_REPO ]]; then
+  cd $AKASH_REPO
+
+  # remote build syncs with remote then builds
+  if [[ "$1" == "local" ]]; then
+    echo "Using local version of github.com/ovrclk/akash"
+    make install &> /dev/null
+  else
+    echo "Building github.com/ovrclk/akash@$AKASH_BRANCH..."
+    if [[ ! -n $(git status -s) ]]; then
+      # sync with remote $AKASH_BRANCH
+      git fetch --all &> /dev/null
+
+      # ensure the akash repository successfully pulls the latest $AKASH_BRANCH
+      if [[ -n $(git checkout $AKASH_BRANCH -q) ]] || [[ -n $(git pull origin $AKASH_BRANCH -q) ]]; then
+        echo "failed to sync remote branch $AKASH_BRANCH"
+        echo "in $AKASH_REPO, please rename the remote repository github.com/ovrclk/akash to 'origin'"
+        exit 1
+      fi
+
+      # install
+      make install &> /dev/null
+
+      # ensure that built binary has the same version as the repo
+      if [[ ! "$(akash version --long 2>&1 | grep "commit:" | sed 's/commit: //g')" == "$(git rev-parse HEAD)" ]]; then
+        echo "built version of akash commit doesn't match"
+        exit 1
+      fi
+    else
+      echo "uncommited changes in $AKASH_REPO, please commit or stash before building"
+      exit 1
+    fi
+
+  fi
+else
+  echo "$AKASH_REPO doesn't exist, and you may not have have the akash repo locally,"
+  echo "if you want to download akash to your \$GOPATH try running the following command:"
+  echo "mkdir -p $(dirname $AKASH_REPO) && git clone git@github.com:ovrclk/akash $AKASH_REPO"
+fi
+
 chainid0=ibc0
 chainid1=ibc1
 
 echo "Generating gaia configurations..."
 mkdir -p $GAIA_DATA && cd $GAIA_DATA && cd ../
 ./scripts/one-chain $chainid0 ./data 26657 26656 6060 9090
-./scripts/one-chain $chainid1 ./data 26557 26556 6061 9091
+./scripts/one-chain-akash $chainid1 ./data 26557 26556 6061 9091
 
-[ -f $GAIA_DATA/$chainid0.log ] && echo "$chainid0 initialized. Watch file $GAIA_DATA/$chainid0.log to see its execution."
-[ -f $GAIA_DATA/$chainid1.log ] && echo "$chainid1 initialized. Watch file $GAIA_DATA/$chainid1.log to see its execution."
+[ -f $GAIA_DATA/$chainid0.log ] && echo "$chainid0 (gaiad) initialized. Watch file $GAIA_DATA/$chainid0.log to see its execution."
+[ -f $GAIA_DATA/$chainid1.log ] && echo "$chainid1 (akash) initialized. Watch file $GAIA_DATA/$chainid1.log to see its execution."

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -13,6 +13,7 @@ import (
 	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ovrclk/relayer/relayer"
 	ry "github.com/ovrclk/relayer/relayer"
 )
 
@@ -137,8 +138,7 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource,
 
 	func() {
 		// Ensure our address is encoded properly.
-		c.UseSDKContext()
-
+		relayer.SDKConfig.Set(c)
 		dockerOpts.Cmd = []string{c.ChainID, c.MustGetAddress().String()}
 		dockerOpts.Labels = make(map[string]string)
 		dockerOpts.Labels["io.iqlusion.relayer.test"] = "true"


### PR DESCRIPTION
I'm getting a hard to track down SDK error that can be reproduced by `./dev-env`. I'll paste the error below:

cc @AdityaSripal @colin-axner @cwgoes 

```
$ go run main.go q vs ibc0
USING SDK CONTEXT IN QUERYVALSETATHEIGHT
ibc0 cosmos
{"validators":[{"address":"C0vEyjr4oteiPyqiPhuO45zMUcY=","pub_key":{"ed25519":"euM9LDo0XRXzZUYZGN9Z0fSFgW6eLBWfC9T8EusFxik="},"voting_power":"100","proposer_priority":"0"}],"proposer":{"address":"C0vEyjr4oteiPyqiPhuO45zMUcY=","pub_key":{"ed25519":"euM9LDo0XRXzZUYZGN9Z0fSFgW6eLBWfC9T8EusFxik="},"voting_power":"100","proposer_priority":"0"},"total_voting_power":"0"}
$ go run main.go q vs ibc1
USING SDK CONTEXT IN QUERYVALSETATHEIGHT
ibc1 akash
panic: invalid Bech32 prefix; expected cosmosvalconspub, got akashvalconspub

goroutine 1 [running]:
github.com/cosmos/cosmos-sdk/types.MustGetPubKeyFromBech32(...)
	/Users/johnzampolin/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.40.0-rc0/types/address.go:689
github.com/cosmos/cosmos-sdk/x/staking/types.Validator.GetConsPubKey(0xc0005ae5c0, 0x33, 0xc0005b2480, 0x52, 0x300000000, 0xc000599c80, 0xc000599ca0, 0xc0000434e8, 0x4, 0x0, ...)
	/Users/johnzampolin/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.40.0-rc0/x/staking/types/validator.go:441 +0x108
github.com/cosmos/cosmos-sdk/x/staking/types.Validator.ToTmValidator(0xc0005ae5c0, 0x33, 0xc0005b2480, 0x52, 0x300000000, 0xc000599c80, 0xc000599ca0, 0xc0000434e8, 0x4, 0x0, ...)
	/Users/johnzampolin/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.40.0-rc0/x/staking/types/validator.go:257 +0x58
github.com/cosmos/cosmos-sdk/x/staking/types.Validators.ToTmValidators(0xc0005ea000, 0x1, 0x1, 0x2, 0x2, 0xb)
	/Users/johnzampolin/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.40.0-rc0/x/staking/types/validator.go:87 +0xf8
github.com/ovrclk/relayer/relayer.(*Chain).QueryValsetAtHeight(0xc000fe5300, 0x0, 0x1be, 0x0, 0x4, 0xc000fe5300)
	/Users/johnzampolin/go/src/github.com/ovrclk/relayer/relayer/query.go:350 +0x1c5
github.com/ovrclk/relayer/cmd.queryValSetAtHeightCmd.func1(0xc000fe22c0, 0xc000fdc430, 0x1, 0x1, 0x0, 0x0)
	/Users/johnzampolin/go/src/github.com/ovrclk/relayer/cmd/query.go:411 +0xe8
github.com/spf13/cobra.(*Command).execute(0xc000fe22c0, 0xc000fdc410, 0x1, 0x1, 0xc000fe22c0, 0xc000fdc410)
	/Users/johnzampolin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0x5d13da0, 0x0, 0x0, 0x0)
	/Users/johnzampolin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/johnzampolin/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/ovrclk/relayer/cmd.Execute()
	/Users/johnzampolin/go/src/github.com/ovrclk/relayer/cmd/root.go:112 +0x4d
main.main()
	/Users/johnzampolin/go/src/github.com/ovrclk/relayer/main.go:21 +0x25
exit status 2
```