### PR TITLE
Update on chain light clients in conn open init

### DIFF
--- a/relayer/connection-tx.go
+++ b/relayer/connection-tx.go
@@ -155,7 +155,10 @@ func (c *Chain) CreateConnectionStep(dst *Chain) (*RelayMsgs, error) {
 		if c.debug {
 			logConnectionStates(c, dst, srcConn, dstConn)
 		}
-		out.Src = append(out.Src, c.PathEnd.ConnInit(dst.PathEnd, c.MustGetAddress()))
+		out.Src = append(out.Src,
+			c.PathEnd.UpdateClient(dstUpdateHeader, c.MustGetAddress()),
+			c.PathEnd.ConnInit(dst.PathEnd, c.MustGetAddress()),
+		)
 
 	// Handshake has started on dst (1 stepdone), relay `connOpenTry` and `updateClient` on src
 	case srcConn.Connection.State == conntypes.UNINITIALIZED && dstConn.Connection.State == conntypes.INIT:


### PR DESCRIPTION
If conn open try fails, the light client on chain will never be updated. The failure of conn open try could be due to having an outdated light client. Adding update on conn open init prevents the light client on the source chain from being outdated