### PR TITLE
Fix lock and timeout determination

### DIFF
--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -60,8 +60,6 @@ func xfersend() *cobra.Command {
 			// Should be relative to current time and block height
 			// --timeout-height-offset=1000
 			// --timeout-time-offset=2h
-			unlock := relayer.SDKConfig.SetLock(c[dst])
-			defer unlock()
 			dstAddr, err := sdk.AccAddressFromBech32(args[3])
 			if err != nil {
 				return err

--- a/relayer/faucet.go
+++ b/relayer/faucet.go
@@ -54,8 +54,6 @@ func (c *Chain) FaucetHandler(fromKey sdk.AccAddress, amounts sdk.Coins) func(w 
 			return
 		}
 
-		unlock := SDKConfig.SetLock(c)
-		defer unlock()
 		if err := c.faucetSend(fromKey, fr.addr(), amounts); err != nil {
 			c.Error(err)
 			respondWithError(w, http.StatusInternalServerError, err.Error())

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -471,7 +471,7 @@ func relayPacketFromQueryResponse(src, dst *PathEnd, res *ctypes.ResultTx,
 
 			// if we have decided not to relay this packet, don't add it
 			switch {
-			case sh.GetHeight(src.ChainID) >= rp.timeout:
+			case rp.timeout != 0 && sh.GetHeight(dst.ChainID) >= rp.timeout:
 				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())
 			case rp.timeoutStamp != 0 && time.Now().UnixNano() >= int64(rp.timeoutStamp):
 				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -237,7 +237,6 @@ func (nrs *NaiveStrategy) sendTxFromEventPackets(src, dst *Chain, rlyPackets []r
 		}
 		// instantiate the RelayMsgs with the appropriate update client
 		unlock := SDKConfig.SetLock(src)
-		defer unlock()
 
 		txs := &RelayMsgs{
 			Src: []sdk.Msg{
@@ -247,6 +246,7 @@ func (nrs *NaiveStrategy) sendTxFromEventPackets(src, dst *Chain, rlyPackets []r
 			MaxTxSize:    nrs.MaxTxSize,
 			MaxMsgLength: nrs.MaxMsgLength,
 		}
+		unlock()
 
 		// add the packet msgs to RelayPackets
 		for _, rp := range rlyPackets {


### PR DESCRIPTION
Fixes some of the lock hangups and fixes timeout determination. Checking if a packet was timed out was using the wrong chain height. This caused the packet to be attempted to be timed out. Timeouts currently don't work #317 , the relayer gets stuck querying the wrong chain for the packet commitment over and over and over causing it to look like the relaying is hanging. Even when it queries the correct packet commitment, it uses the wrong chain to construct the timeout packet causing the wrong capability to be used