### PR TITLE
add Interchain Gmbh as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+*       @colin-axner @fedekunze @AdityaSripal


### PR DESCRIPTION
Until a different entity takes ownership of the relayer, Interchain Gmbh is responsible for back stopping the relayer. We might as well make this explicit for now. IG does not have interest in long term ownership 