### PR TITLE
More Agoric tweaks

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,17 +77,36 @@ $ %s cfg list`, appName, defaultHome, appName)),
 				return fmt.Errorf("config does not exist: %s", cfgPath)
 			}
 
-			out, err := yaml.Marshal(config)
+			jsn, err := cmd.Flags().GetBool(flagJSON)
 			if err != nil {
 				return err
 			}
-
-			fmt.Println(string(out))
-			return nil
+			yml, err := cmd.Flags().GetBool(flagYAML)
+			if err != nil {
+				return err
+			}
+			switch {
+			case yml && jsn:
+				return fmt.Errorf("can't pass both --json and --yaml, must pick one")
+			case jsn:
+				out, err := json.Marshal(config)
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(out))
+				return nil
+			default:
+				out, err := yaml.Marshal(config)
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(out))
+				return nil
+			}
 		},
 	}
 
-	return cmd
+	return yamlFlag(jsonFlag(cmd))
 }
 
 // Command for inititalizing an empty config at the --home location

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -206,7 +206,18 @@ $ %s tx con demo-path -o 3s`, appName, appName, appName)),
 				return err
 			}
 
-			modified, err := c[src].CreateOpenConnections(c[dst], retries, to)
+			// ensure that the clients exist
+			modified, err := c[src].CreateClients(c[dst])
+			if modified {
+				if err := overWriteConfig(cmd, config); err != nil {
+					return err
+				}
+			}
+			if err != nil {
+				return err
+			}
+
+			modified, err = c[src].CreateOpenConnections(c[dst], retries, to)
 			if modified {
 				if err := overWriteConfig(cmd, config); err != nil {
 					return err
@@ -398,7 +409,7 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 			return sCmd.RunE(cmd, args)
 		},
 	}
-	return strategyFlag(timeoutFlag(cmd))
+	return strategyFlag(retryFlag(timeoutFlag(cmd)))
 }
 
 func relayMsgsCmd() *cobra.Command {

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -34,7 +34,7 @@ $ %s tx xfer ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39
 $ %s tx xfer ibc-0 ibc-1 100000stake raw:non-bech32-address --path demo
 $ %s tx txf ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk --path demo
 $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk --path demo -c 5
-`, appName, appName, appName, appName)),
+`, appName, appName, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
 			c, err := config.Chains.Gets(src, dst)

--- a/configs/agoric.json
+++ b/configs/agoric.json
@@ -4,7 +4,7 @@
   "daemon": "ag-chain-cosmos",
   "cli": "ag-cosmos-helper",
   "daemon-testnet": "ag-nchainz testnet $chainid -o $chainid --v 1 --chain-id $chainid --node-dir-prefix n --keyring-backend test",
-  "daemon-start": "ag-nchainz start-daemon $chainid --home \"$DAEMON_HOME\" start --pruning=nothing",
+  "daemon-start": "ag-nchainz start-daemon $chainid --home \"$DAEMON_HOME\" start --pruning=nothing --log_level=warn",
   "post-light-client": "ag-nchainz start-solos $chainid",
   "link": {
     "account-prefix": "agoric",

--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -56,11 +56,6 @@ SRCPORTS=()
 DSTS=()
 DSTPORTS=()
 
-get_alphabetic() {
-  id="$1"
-  ida=$(echo "$1" | sed -e 's/0/zero/g; s/1/one/g; s/2/two/g; s/3/three/g; s/4/four/g; s/5/five/g; s/6/six/g; s/7/seven/g; s/8/eight/g; s/9/nine/g;')
-}
-
 validate() {
   status=0
   # Have at least one default.
@@ -513,22 +508,48 @@ clients)
   exit 0
   ;;
 
+connect)
+  . "$NCONFIG"
+
+  paths=
+  for i in ${!SRCS[@]}; do
+    src=${SRCS[$i]}
+    dst=${DSTS[$i]}
+
+    path="path-$i"
+    paths="$paths $path"
+    echo "Starting 'rly tx conn $path' ($src<>$dst) logs in $LOGS/$path.log"
+    (
+      try=0
+      while ! rly tx conn $path --timeout=3s -d >> "$LOGS/$path.log" 2>&1; do
+        try=$(( $try + 1 ))
+        echo "$path tx conn not yet ready (try=$try)"
+        sleep 1
+      done
+      try=$(( $try + 1 ))
+      echo "$path tx conn initialized (try=$try)"
+    ) &
+  done
+
+  wait
+  echo "==============================="
+  echo "=== All connections initialized"
+  for path in $paths; do
+    tail -1 "$LOGS/$path.log"
+  done
+  echo "==============================="
+  exit 0
+  ;;
+
 relay)
   . "$NCONFIG"
 
   paths=
   for i in ${!SRCS[@]}; do
     src=${SRCS[$i]}
-    get_alphabetic "$src"
-    srca=$ida
-
     dst=${DSTS[$i]}
-    get_alphabetic "$dst"
-    dsta=$ida
 
-    get_alphabetic "$i"
-    ia=$ida
-    path="$ia"
+    path="path-$i"
     paths="$paths $path"
     echo "Starting 'rly tx link $path' ($src<>$dst) logs in $LOGS/$path.log"
     (
@@ -627,34 +648,22 @@ done
 for i in ${!SRCS[@]}; do
   src=${SRCS[$i]}
   srcport=${SRCPORTS[$i]}
-  get_alphabetic "$src"
-  srca=$ida
 
   dst=${DSTS[$i]}
   dstport=${DSTPORTS[$i]}
-  get_alphabetic "$dst"
-  dsta=$ida
 
-  get_alphabetic "$i"
-  ia=$ida
-  path="$ida"
+  path="path-$i"
   out="$BASEDIR/config/$path.json"
   echo "creating $out"
   cat >"$out" <<EOF
 {
   "src": {
     "chain-id": "$src",
-    "client-id": "${dsta}client",
-    "connection-id": "${dsta}link",
-    "channel-id": "${dsta}xfer${ida}",
     "port-id": "$srcport",
     "order": "unordered"
   },
   "dst": {
     "chain-id": "$dst",
-    "client-id": "${srca}client",
-    "connection-id": "${srca}link",
-    "channel-id": "${srca}xfer${ida}",
     "port-id": "$dstport",
     "order": "unordered"
   },
@@ -671,7 +680,7 @@ cat <<EOF
 =====================
 Done generating $BASEDIR
 
-You can use: \`$progname [run|relay]' at any time.
+You can use: \`$progname [run|connect|relay]' at any time.
 
 EOF
 
@@ -680,7 +689,7 @@ if [[ $SKIP == norun ]]; then
 fi
 
 if [[ $SKIP != yes ]]; then
-  read -p "Do you wish to \`run', and \`relay' right now (y/N)? " -n 1 -r
+  read -p "Do you wish to \`run', and \`connect' right now (y/N)? " -n 1 -r
   echo
 
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -689,6 +698,6 @@ if [[ $SKIP != yes ]]; then
 fi
 
 "$0" run skip &
-"$0" relay skip &
+"$0" connect skip &
 echo "Hit Control-C to exit"
 wait


### PR DESCRIPTION
I found these changes were useful to help make the Agoric dynamic IBC layer work correctly:

- allow `rly config show --json` to dump the YAML config as JSON
- `rly tx conn` should create the client if it isn't already
- minor fix to add a missing help `%s` format argument to `rly tx raw send`
- have `nchainz` default to set up the connections but not relay any paths
- turn down the Agoric chain `--log_level` to `warn` to help prevent noise
