### PR TITLE
fix: separate nchainz config/chains and config/paths

### DIFF
--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -467,7 +467,6 @@ clients)
       done
       SEED=$(jq -r '.secret' "$f")
       echo "Key $(rly keys restore $chainid testkey "$SEED") imported from $chainid to relayer..."
-      rly config add-paths "$BASEDIR/config/paths"
 
       try=0
       f="$DATA/$chainid/n0/$DAEMON/config/genesis.json"
@@ -491,6 +490,7 @@ clients)
 
   # Let all our chains initialise.
   wait
+  rly config add-paths "$BASEDIR/config/paths"
 
   for i in ${!IDS[@]}; do
     ID=${IDS[$i]}
@@ -619,7 +619,7 @@ if [[ -e $BASEDIR ]] && [[ $SKIP != yes ]]; then
 fi
 
 rm -rf "$BASEDIR"
-mkdir -p "$BASEDIR/config" "$LOGS"
+mkdir -p "$BASEDIR/config/paths" "$BASEDIR/config/chains" "$LOGS"
 
 echo "creating $NCONFIG"
 cat <<EOF >"$NCONFIG"
@@ -640,7 +640,7 @@ for i in ${!IDS[@]}; do
   id=${IDS[$i]}
   json=${JSONS[$i]}
   p26657=$(( 26657 - $i * 100 ))
-  out="$BASEDIR/config/$id.json"
+  out="$BASEDIR/config/chains/$id.json"
   echo "creating $out"
   jq ".link + { \"chain-id\": \"$id\", \"rpc-addr\": \"http://localhost:$p26657\", \"key\": \"testkey\" }" "$json" \
     > "$out"
@@ -654,7 +654,7 @@ for i in ${!SRCS[@]}; do
   dstport=${DSTPORTS[$i]}
 
   path="path-$i"
-  out="$BASEDIR/config/$path.json"
+  out="$BASEDIR/config/paths/$path.json"
   echo "creating $out"
   cat >"$out" <<EOF
 {


### PR DESCRIPTION
This is needed to work with changes from #406.

FWIW, you can test nchainz just by running:

```sh
$ scripts/nchainz init skip
[... a bunch of output]
Creating light client for ibc0 (gaiad)...
Key cosmos1796deuy9gkhx4xn7lcnvvz7a5w4qn4dwhdes2g imported from ibc1 to relayer...
Creating light client for ibc1 (gaiad)...
ibc0 light client initialized (try=1)
ibc1 light client initialized (try=1)
added path path-0...
Waiting for clients (Control-C to exit)...
path-0 tx conn initialized (try=14)
===============================
=== All connections initialized
I[2021-02-04|12:05:02.693] ★ Connection created: [ibc0]client{07-tendermint-0}conn{connection-0} -> [ibc1]client{07-tendermint-0}conn{connection-0} 
===============================
```

and then will stop until interrupted with Control-C.
