### PR TITLE
feat(cmd): make root command publicly accessible

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,14 +46,31 @@ var (
 	dord = "ordered"
 )
 
-func init() {
-	cobra.EnableCommandSorting = false
+// NewRootCmd returns the root command for relayer.
+func NewRootCmd() *cobra.Command {
+	// RootCmd represents the base command when called without any subcommands
+	var rootCmd = &cobra.Command{
+		Use:   appName,
+		Short: "This application relays data between configured IBC enabled chains",
+		Long: strings.TrimSpace(`The relayer has commands for:
+  1. Configuration of the Chains and Paths that the relayer with transfer packets over
+  2. Management of keys and light clients on the local machine that will be used to sign and verify txs
+  3. Query and transaction functionality for IBC
+  4. A responsive relaying application that listens on a path
+  5. Commands to assist with development, testnets, and versioning.
 
-	rootCmd.SilenceUsage = true
+NOTE: Most of the commands have aliases that make typing them much quicker (i.e. 'rly tx', 'rly q', etc...)`),
+	}
+
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		// reads `homeDir/config/config.yaml` into `var config *Config` before each command
+		return initConfig(rootCmd)
+	}
 
 	// Register top level flags --home and --debug
 	rootCmd.PersistentFlags().StringVar(&homePath, flags.FlagHome, defaultHome, "set home directory")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug output")
+
 	if err := viper.BindPFlag(flags.FlagHome, rootCmd.Flags().Lookup(flags.FlagHome)); err != nil {
 		panic(err)
 	}
@@ -82,29 +99,17 @@ func init() {
 	// This is a bit of a cheat :shushing_face:
 	// cdc = codecstd.MakeCodec(simapp.ModuleBasics)
 	// appCodec = codecstd.NewAppCodec(cdc)
-}
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   appName,
-	Short: "This application relays data between configured IBC enabled chains",
-	Long: strings.TrimSpace(`The relayer has commands for:
-  1. Configuration of the Chains and Paths that the relayer with transfer packets over
-  2. Management of keys and light clients on the local machine that will be used to sign and verify txs
-  3. Query and transaction functionality for IBC
-  4. A responsive relaying application that listens on a path
-  5. Commands to assist with development, testnets, and versioning.
-
-NOTE: Most of the commands have aliases that make typing them much quicker (i.e. 'rly tx', 'rly q', etc...)`),
+	return rootCmd
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
-		// reads `homeDir/config/config.yaml` into `var config *Config` before each command
-		return initConfig(rootCmd)
-	}
+	cobra.EnableCommandSorting = false
+
+	rootCmd := NewRootCmd()
+	rootCmd.SilenceUsage = true
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
so, it can be reused as a sub command by other cobra compatible CLIs. e.g. (`starport relayer rly -h`)