### PR TITLE
Fix light block not found error on missing header

### DIFF
--- a/relayer/tm-light-client.go
+++ b/relayer/tm-light-client.go
@@ -294,7 +294,9 @@ func (c *Chain) GetLightSignedHeaderAtHeight(height int64) (*tmclient.Header, er
 		return nil, err
 	}
 
-	sh, err := client.TrustedLightBlock(height)
+	// VerifyLightBlock will return the header at provided height if it already exists in store,
+	// otherwise it retrieves from primary and verifies against trusted store before returning.
+	sh, err := client.VerifyLightBlockAtHeight(context.Background(), height, time.Now())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should fix #452, though I don't know of a way to test