### PR TITLE
fix: updating timeout to use clienttypes.Height instead of uint64

### DIFF
--- a/relayer/ibc-client.go
+++ b/relayer/ibc-client.go
@@ -128,7 +128,7 @@ func (c *Chain) InjectTrustedFields(dst *Chain, header *tmclient.Header) (*tmcli
 func MustGetHeight(h ibcexported.Height) clienttypes.Height {
 	height, ok := h.(clienttypes.Height)
 	if !ok {
-		panic("height is not an instance of height! wtf")
+		panic("height is not an instance of height!")
 	}
 	return height
 }

--- a/relayer/ibc-client.go
+++ b/relayer/ibc-client.go
@@ -125,10 +125,10 @@ func (c *Chain) InjectTrustedFields(dst *Chain, header *tmclient.Header) (*tmcli
 }
 
 // MustGetHeight takes the height inteface and returns the actual height
-func MustGetHeight(h ibcexported.Height) uint64 {
+func MustGetHeight(h ibcexported.Height) clienttypes.Height {
 	height, ok := h.(clienttypes.Height)
 	if !ok {
 		panic("height is not an instance of height! wtf")
 	}
-	return height.GetRevisionHeight()
+	return height
 }

--- a/relayer/msgs.go
+++ b/relayer/msgs.go
@@ -311,7 +311,6 @@ func (c *Chain) ChanCloseConfirm(dstChanState *chantypes.QueryChannelResponse) s
 // MsgTransfer creates a new transfer message
 func (c *Chain) MsgTransfer(dst *PathEnd, amount sdk.Coin, dstAddr string,
 	timeoutHeight, timeoutTimestamp uint64) sdk.Msg {
-
 	version := clienttypes.ParseChainID(dst.ChainID)
 	return transfertypes.NewMsgTransfer(
 		c.PathEnd.PortID,
@@ -366,7 +365,6 @@ func (c *Chain) MsgRelayRecvPacket(counterparty *Chain, packet *relayMsgRecvPack
 		return nil, fmt.Errorf("receive packet [%s]seq{%d} has no associated proofs", c.ChainID, packet.seq)
 	}
 
-	version := clienttypes.ParseChainID(c.ChainID)
 	msg := chantypes.NewMsgRecvPacket(
 		chantypes.NewPacket(
 			packet.packetData,
@@ -375,7 +373,7 @@ func (c *Chain) MsgRelayRecvPacket(counterparty *Chain, packet *relayMsgRecvPack
 			counterparty.PathEnd.ChannelID,
 			c.PathEnd.PortID,
 			c.PathEnd.ChannelID,
-			clienttypes.NewHeight(version, packet.timeout),
+			packet.timeout,
 			packet.timeoutStamp,
 		),
 		comRes.Proof,
@@ -428,7 +426,6 @@ func (c *Chain) MsgRelayAcknowledgement(counterparty *Chain, packet *relayMsgPac
 		return nil, fmt.Errorf("ack packet [%s]seq{%d} has no associated proofs", counterparty.ChainID, packet.seq)
 	}
 
-	version := clienttypes.ParseChainID(counterparty.ChainID)
 	msg := chantypes.NewMsgAcknowledgement(
 		chantypes.NewPacket(
 			packet.packetData,
@@ -437,7 +434,7 @@ func (c *Chain) MsgRelayAcknowledgement(counterparty *Chain, packet *relayMsgPac
 			c.PathEnd.ChannelID,
 			counterparty.PathEnd.PortID,
 			counterparty.PathEnd.ChannelID,
-			clienttypes.NewHeight(version, packet.timeout),
+			packet.timeout,
 			packet.timeoutStamp,
 		),
 		packet.ack,
@@ -493,7 +490,6 @@ func (c *Chain) MsgRelayTimeout(counterparty *Chain, packet *relayMsgTimeout) (m
 		return nil, fmt.Errorf("timeout packet [%s]seq{%d} has no associated proofs", c.ChainID, packet.seq)
 	}
 
-	version := clienttypes.ParseChainID(counterparty.ChainID)
 	msg := chantypes.NewMsgTimeout(
 		chantypes.NewPacket(
 			packet.packetData,
@@ -502,7 +498,7 @@ func (c *Chain) MsgRelayTimeout(counterparty *Chain, packet *relayMsgTimeout) (m
 			c.PathEnd.ChannelID,
 			counterparty.PathEnd.PortID,
 			counterparty.PathEnd.ChannelID,
-			clienttypes.NewHeight(version, packet.timeout),
+			packet.timeout,
 			packet.timeoutStamp,
 		),
 		packet.seq,

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -717,7 +717,7 @@ func relayPacketsFromResultTx(src, dst *Chain, res *ctypes.ResultTx) ([]relayPac
 
 			switch {
 			// If the packet has a timeout height, and it has been reached, return a timeout packet
-			case !rp.timeout.IsZero() != 0 && block.GetHeight().GTE(rp.timeout):
+			case !rp.timeout.IsZero() && block.GetHeight().GTE(rp.timeout):
 				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())
 			// If the packet has a timeout timestamp and it has been reached, return a timeout packet
 			case rp.timeoutStamp != 0 && block.GetTime().UnixNano() >= int64(rp.timeoutStamp):

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -717,7 +717,7 @@ func relayPacketsFromResultTx(src, dst *Chain, res *ctypes.ResultTx) ([]relayPac
 
 			switch {
 			// If the packet has a timeout height, and it has been reached, return a timeout packet
-			case rp.timeout.RevisionHeight != 0 && block.GetHeight().GetRevisionHeight() >= rp.timeout.RevisionHeight:
+			case !rp.timeout.IsZero() != 0 && block.GetHeight().GTE(rp.timeout):
 				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())
 			// If the packet has a timeout timestamp and it has been reached, return a timeout packet
 			case rp.timeoutStamp != 0 && block.GetTime().UnixNano() >= int64(rp.timeoutStamp):

--- a/relayer/pathEnd.go
+++ b/relayer/pathEnd.go
@@ -67,8 +67,7 @@ func UnmarshalChain(pe PathEnd) *Chain {
 
 // NewPacket returns a new packet from src to dist w
 func (pe *PathEnd) NewPacket(dst *PathEnd, sequence uint64, packetData []byte,
-	timeoutHeight, timeoutStamp uint64) chantypes.Packet {
-	version := clienttypes.ParseChainID(dst.ChainID)
+	timeoutHeight clienttypes.Height, timeoutStamp uint64) chantypes.Packet {
 	return chantypes.NewPacket(
 		packetData,
 		sequence,
@@ -76,7 +75,7 @@ func (pe *PathEnd) NewPacket(dst *PathEnd, sequence uint64, packetData []byte,
 		pe.ChannelID,
 		dst.PortID,
 		dst.ChannelID,
-		clienttypes.NewHeight(version, timeoutHeight),
+		timeoutHeight,
 		timeoutStamp,
 	)
 }

--- a/relayer/relayPackets.go
+++ b/relayer/relayPackets.go
@@ -14,13 +14,13 @@ type relayPacket interface {
 	FetchCommitResponse(src, dst *Chain) error
 	Data() []byte
 	Seq() uint64
-	Timeout() uint64
+	Timeout() clienttypes.Height
 }
 
 type relayMsgTimeout struct {
 	packetData   []byte
 	seq          uint64
-	timeout      uint64
+	timeout      clienttypes.Height
 	timeoutStamp uint64
 	dstRecvRes   *chantypes.QueryPacketReceiptResponse
 
@@ -35,7 +35,7 @@ func (rp *relayMsgTimeout) Seq() uint64 {
 	return rp.seq
 }
 
-func (rp *relayMsgTimeout) Timeout() uint64 {
+func (rp *relayMsgTimeout) Timeout() clienttypes.Height {
 	return rp.timeout
 }
 
@@ -76,7 +76,6 @@ func (rp *relayMsgTimeout) Msg(src, dst *Chain) (sdk.Msg, error) {
 	if rp.dstRecvRes == nil {
 		return nil, fmt.Errorf("timeout packet [%s]seq{%d} has no associated proofs", src.ChainID, rp.seq)
 	}
-	version := clienttypes.ParseChainID(dst.ChainID)
 	msg := chantypes.NewMsgTimeout(
 		chantypes.NewPacket(
 			rp.packetData,
@@ -85,7 +84,7 @@ func (rp *relayMsgTimeout) Msg(src, dst *Chain) (sdk.Msg, error) {
 			src.PathEnd.ChannelID,
 			dst.PathEnd.PortID,
 			dst.PathEnd.ChannelID,
-			clienttypes.NewHeight(version, rp.timeout),
+			rp.timeout,
 			rp.timeoutStamp,
 		),
 		rp.seq,
@@ -99,7 +98,7 @@ func (rp *relayMsgTimeout) Msg(src, dst *Chain) (sdk.Msg, error) {
 type relayMsgRecvPacket struct {
 	packetData   []byte
 	seq          uint64
-	timeout      uint64
+	timeout      clienttypes.Height
 	timeoutStamp uint64
 	dstComRes    *chantypes.QueryPacketCommitmentResponse
 
@@ -125,7 +124,7 @@ func (rp *relayMsgRecvPacket) Seq() uint64 {
 	return rp.seq
 }
 
-func (rp *relayMsgRecvPacket) Timeout() uint64 {
+func (rp *relayMsgRecvPacket) Timeout() clienttypes.Height {
 	return rp.timeout
 }
 
@@ -166,7 +165,6 @@ func (rp *relayMsgRecvPacket) Msg(src, dst *Chain) (sdk.Msg, error) {
 	if rp.dstComRes == nil {
 		return nil, fmt.Errorf("receive packet [%s]seq{%d} has no associated proofs", src.ChainID, rp.seq)
 	}
-	version := clienttypes.ParseChainID(src.ChainID)
 	packet := chantypes.NewPacket(
 		rp.packetData,
 		rp.seq,
@@ -174,7 +172,7 @@ func (rp *relayMsgRecvPacket) Msg(src, dst *Chain) (sdk.Msg, error) {
 		dst.PathEnd.ChannelID,
 		src.PathEnd.PortID,
 		src.PathEnd.ChannelID,
-		clienttypes.NewHeight(version, rp.timeout),
+		rp.timeout,
 		rp.timeoutStamp,
 	)
 	msg := chantypes.NewMsgRecvPacket(
@@ -190,7 +188,7 @@ type relayMsgPacketAck struct {
 	packetData   []byte
 	ack          []byte
 	seq          uint64
-	timeout      uint64
+	timeout      clienttypes.Height
 	timeoutStamp uint64
 	dstComRes    *chantypes.QueryPacketAcknowledgementResponse
 
@@ -203,7 +201,7 @@ func (rp *relayMsgPacketAck) Data() []byte {
 func (rp *relayMsgPacketAck) Seq() uint64 {
 	return rp.seq
 }
-func (rp *relayMsgPacketAck) Timeout() uint64 {
+func (rp *relayMsgPacketAck) Timeout() clienttypes.Height {
 	return rp.timeout
 }
 
@@ -211,7 +209,6 @@ func (rp *relayMsgPacketAck) Msg(src, dst *Chain) (sdk.Msg, error) {
 	if rp.dstComRes == nil {
 		return nil, fmt.Errorf("ack packet [%s]seq{%d} has no associated proofs", src.ChainID, rp.seq)
 	}
-	version := clienttypes.ParseChainID(dst.ChainID)
 	msg := chantypes.NewMsgAcknowledgement(
 		chantypes.NewPacket(
 			rp.packetData,
@@ -220,7 +217,7 @@ func (rp *relayMsgPacketAck) Msg(src, dst *Chain) (sdk.Msg, error) {
 			src.PathEnd.ChannelID,
 			dst.PathEnd.PortID,
 			dst.PathEnd.ChannelID,
-			clienttypes.NewHeight(version, rp.timeout),
+			rp.timeout,
 			rp.timeoutStamp,
 		),
 		rp.ack,


### PR DESCRIPTION
This PR updates the building and unpacking of ibc packets to use the same `clienttypes.Height` type rather than referencing only the `RevisionHeight` which is a `uint64`. 

Presently, for IBC application developers it is not possible to specify that timeout height should not be used as we always add version when rebuilding the packet before relaying -> https://github.com/cosmos/relayer/blob/76eb658fb20a872b002ac4a523ac14f649132937/relayer/msgs.go#L378

This PR allows for an IBC application to pass `clienttypes.ZeroHeight` as timeoutHeight when building an IBC packet. The relayer will then ignore timeoutHeight as intended. 

@colin-axner short term solution for https://github.com/cosmos/relayer/issues/481 ?