### PR TITLE
Fix Timeout Handling on Relayer start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [\#468](https://github.com/cosmos/relayer/pull/468) cli: UX cleanup for query commands
 * [\#467](https://github.com/cosmos/relayer/pull/467) cli: UX cleanup for tx commands
 * [\#466](https://github.com/cosmos/relayer/pull/466) Docs cleanup. 
+* [\#506](https://github.com/cosmos/relayer/pull/506) Fix Timeout Handling on Relayer restart
 
 ## v0.9.3
 

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -736,7 +736,7 @@ func relayPacketsFromResultTx(src, dst *Chain, res *ctypes.ResultTx) ([]relayPac
 			}
 
 			// fetch the header which represents a block produced on destination
-			block, err := src.GetIBCUpdateHeader(dst)
+			block, err := dst.GetIBCUpdateHeader(src)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Need to swap src and dst

Timeout handling on streaming relayer still unimplemented

TESTED on two-chainz and it works