### PR TITLE
fix wrong chain in create client raw tx

### DIFF
--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -104,7 +104,7 @@ $ %s tx raw clnt ibc-1 ibc-0 ibconeclient`, appName, appName)),
 				return err
 			}
 
-			dstHeader, err := chains[src].GetIBCCreateClientHeader()
+			dstHeader, err := chains[dst].GetIBCCreateClientHeader()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
`rly tx raw client A B client-id` is expected to create a client of B on chain A, while currently it is creating a client of A of A.