### PR TITLE
Log errors thrown by SendMsgs()

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -125,7 +125,10 @@ func ExecuteChannelStep(src, dst *Chain) (success, last, modified bool, err erro
 			return false, false, false, err
 		}
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -154,7 +157,10 @@ func ExecuteChannelStep(src, dst *Chain) (success, last, modified bool, err erro
 			return false, false, false, err
 		}
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -182,7 +188,10 @@ func ExecuteChannelStep(src, dst *Chain) (success, last, modified bool, err erro
 			return false, false, false, err
 		}
 
-		_, success, err = dst.SendMsgs(msgs)
+		res, success, err := dst.SendMsgs(msgs)
+		if err != nil {
+			dst.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -210,7 +219,10 @@ func ExecuteChannelStep(src, dst *Chain) (success, last, modified bool, err erro
 
 		last = true
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -236,7 +248,10 @@ func ExecuteChannelStep(src, dst *Chain) (success, last, modified bool, err erro
 			return false, false, false, err
 		}
 
-		_, success, err = dst.SendMsgs(msgs)
+		res, success, err := dst.SendMsgs(msgs)
+		if err != nil {
+			dst.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -284,6 +299,9 @@ func InitializeChannel(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := src.SendMsgs(msgs)
+			if err != nil {
+				src.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}
@@ -328,6 +346,9 @@ func InitializeChannel(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := src.SendMsgs(msgs)
+			if err != nil {
+				src.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}
@@ -373,6 +394,9 @@ func InitializeChannel(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := dst.SendMsgs(msgs)
+			if err != nil {
+				dst.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -294,8 +294,9 @@ func (c *Chain) UpgradeClients(dst *Chain, height int64) error {
 		upgradeMsg,
 	}
 
-	_, _, err = c.SendMsgs(msgs)
+	res, _, err := c.SendMsgs(msgs)
 	if err != nil {
+		c.LogFailedTx(res, err, msgs)
 		return err
 	}
 
@@ -467,6 +468,7 @@ func AutoUpdateClient(src, dst *Chain, thresholdTime time.Duration) (time.Durati
 
 	res, success, err := src.SendMsgs(msgs)
 	if err != nil {
+		src.LogFailedTx(res, err, msgs)
 		return 0, err
 	}
 	if !success {

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -124,7 +124,10 @@ func ExecuteConnectionStep(src, dst *Chain) (success, last, modified bool, err e
 			return false, false, false, err
 		}
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -143,7 +146,10 @@ func ExecuteConnectionStep(src, dst *Chain) (success, last, modified bool, err e
 			return false, false, false, err
 		}
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -161,7 +167,10 @@ func ExecuteConnectionStep(src, dst *Chain) (success, last, modified bool, err e
 			return false, false, false, err
 		}
 
-		_, success, err = dst.SendMsgs(msgs)
+		res, success, err := dst.SendMsgs(msgs)
+		if err != nil {
+			dst.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -177,7 +186,10 @@ func ExecuteConnectionStep(src, dst *Chain) (success, last, modified bool, err e
 			return false, false, false, err
 		}
 
-		_, success, err = src.SendMsgs(msgs)
+		res, success, err := src.SendMsgs(msgs)
+		if err != nil {
+			src.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -195,7 +207,10 @@ func ExecuteConnectionStep(src, dst *Chain) (success, last, modified bool, err e
 			return false, false, false, err
 		}
 
-		_, success, err = dst.SendMsgs(msgs)
+		res, success, err := dst.SendMsgs(msgs)
+		if err != nil {
+			dst.LogFailedTx(res, err, msgs)
+		}
 		if !success {
 			return false, false, false, err
 		}
@@ -248,6 +263,9 @@ func InitializeConnection(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := src.SendMsgs(msgs)
+			if err != nil {
+				src.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}
@@ -281,6 +299,9 @@ func InitializeConnection(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := src.SendMsgs(msgs)
+			if err != nil {
+				src.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}
@@ -314,6 +335,9 @@ func InitializeConnection(src, dst *Chain) (success, modified bool, err error) {
 			}
 
 			res, success, err := dst.SendMsgs(msgs)
+			if err != nil {
+				dst.LogFailedTx(res, err, msgs)
+			}
 			if !success {
 				return false, false, err
 			}


### PR DESCRIPTION
Most of the calls to `SendMsgs()` were passing errors up but never really logging them to stdout or stderr. 
This logs all errors returned by `SendMsgs()` across the entire application in the locations were they are thrown.

Closes #355 