### PR TITLE
fix race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ test:
 	@TEST_DEBUG=true go test -mod=readonly -v ./test/...
 
 test-gaia:
-	@TEST_DEBUG=true go test -race -mod=readonly -v ./test/... -run TestGaia*
+	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestGaia*
 
 test-akash:
-	@TEST_DEBUG=true go test -race -mod=readonly -v ./test/... -run TestAkash* -race
+	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestAkash* -race
 
 coverage:
 	@echo "viewing test coverage..."

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ test:
 	@TEST_DEBUG=true go test -mod=readonly -v ./test/...
 
 test-gaia:
-	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestGaia*
+	@TEST_DEBUG=true go test -race -mod=readonly -v ./test/... -run TestGaia*
 
 test-akash:
-	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestAkash*
+	@TEST_DEBUG=true go test -race -mod=readonly -v ./test/... -run TestAkash* -race
 
 coverage:
 	@echo "viewing test coverage..."

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-gaia:
 	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestGaia*
 
 test-akash:
-	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestAkash* -race
+	@TEST_DEBUG=true go test -mod=readonly -v ./test/... -run TestAkash*
 
 coverage:
 	@echo "viewing test coverage..."

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -771,10 +771,12 @@ func (c *Chain) GenerateConnHandshakeProof(height uint64) (clientState ibcexport
 	}
 
 	eg.Go(func() error {
+		var err error
 		consensusStateRes, err = c.QueryClientConsensusState(int64(height), clientState.GetLatestHeight())
 		return err
 	})
 	eg.Go(func() error {
+		var err error
 		connectionStateRes, err = c.QueryConnection(int64(height))
 		return err
 	})

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -21,6 +21,7 @@ func (c *Chain) CreateOpenChannels(dst *Chain, maxRetries uint64, to time.Durati
 	ticker := time.NewTicker(to)
 	failures := uint64(0)
 	for ; true; <-ticker.C {
+		var err error
 		success, lastStep, recentlyModified, err := ExecuteChannelStep(c, dst)
 		if err != nil {
 			c.Log(err.Error())

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -29,10 +29,12 @@ func (c *Chain) CreateClients(dst *Chain, allowUpdateAfterExpiry, allowUpdateAft
 	}
 
 	eg.Go(func() error {
+		var err error
 		srcUpdateHeader, err = c.GetLightSignedHeaderAtHeight(srch)
 		return err
 	})
 	eg.Go(func() error {
+		var err error
 		dstUpdateHeader, err = dst.GetLightSignedHeaderAtHeight(dsth)
 		return err
 	})

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -66,7 +66,10 @@ func (nrs *NaiveStrategy) UnrelayedSequences(src, dst *Chain) (*RelaySequences, 
 	}
 
 	eg.Go(func() error {
-		var res *chantypes.QueryPacketCommitmentsResponse
+		var (
+			res *chantypes.QueryPacketCommitmentsResponse
+			err error
+		)
 		if err = retry.Do(func() error {
 			// Query the packet commitment
 			res, err = src.QueryPacketCommitments(DefaultPageRequest(), uint64(srch))
@@ -90,7 +93,10 @@ func (nrs *NaiveStrategy) UnrelayedSequences(src, dst *Chain) (*RelaySequences, 
 	})
 
 	eg.Go(func() error {
-		var res *chantypes.QueryPacketCommitmentsResponse
+		var (
+			res *chantypes.QueryPacketCommitmentsResponse
+			err error
+		)
 		if err = retry.Do(func() error {
 			res, err = dst.QueryPacketCommitments(DefaultPageRequest(), uint64(dsth))
 			switch {
@@ -119,6 +125,7 @@ func (nrs *NaiveStrategy) UnrelayedSequences(src, dst *Chain) (*RelaySequences, 
 	eg.Go(func() error {
 		// Query all packets sent by src that have been received by dst
 		return retry.Do(func() error {
+			var err error
 			rs.Src, err = dst.QueryUnreceivedPackets(uint64(dsth), srcPacketSeq)
 			return err
 		}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
@@ -129,6 +136,7 @@ func (nrs *NaiveStrategy) UnrelayedSequences(src, dst *Chain) (*RelaySequences, 
 	eg.Go(func() error {
 		// Query all packets sent by dst that have been received by src
 		return retry.Do(func() error {
+			var err error
 			rs.Dst, err = src.QueryUnreceivedPackets(uint64(srch), dstPacketSeq)
 			return err
 		}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -226,6 +226,7 @@ func QueryConnectionPair(
 	srcH, dstH int64) (srcConn, dstConn *conntypes.QueryConnectionResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
+		var err error
 		srcConn, err = src.QueryConnection(srcH)
 		return err
 	})
@@ -674,10 +675,12 @@ func (c *Chain) QueryLatestHeight() (int64, error) {
 func QueryLatestHeights(src, dst *Chain) (srch, dsth int64, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
+		var err error
 		srch, err = src.QueryLatestHeight()
 		return err
 	})
 	eg.Go(func() error {
+		var err error
 		dsth, err = dst.QueryLatestHeight()
 		return err
 	})

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -283,10 +283,12 @@ var emptyChannelRes = chantypes.NewQueryChannelResponse(
 func QueryChannelPair(src, dst *Chain, srcH, dstH int64) (srcChan, dstChan *chantypes.QueryChannelResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
+		var err error
 		srcChan, err = src.QueryChannel(srcH)
 		return err
 	})
 	eg.Go(func() error {
+		var err error
 		dstChan, err = dst.QueryChannel(dstH)
 		return err
 	})


### PR DESCRIPTION
Race conditions were occurring when using concurrent goroutines that try to write to a functions named return value or a variable from outside the local scope of the goroutine.

The only race condition that still intermittently appears is related to the global config singelton/bech32 account prefix issue in the SDK.

```
WARNING: DATA RACE
Write at 0x00c000d64c60 by goroutine 77:
  runtime.mapassign_faststr()
      /usr/lib/go/src/runtime/map_faststr.go:202 +0x0
  github.com/cosmos/cosmos-sdk/types.(*Config).SetBech32PrefixForAccount()
      /home/anon/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.44.3/types/config.go:89 +0x108
  github.com/cosmos/relayer/relayer.(*Chain).UseSDKContext()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/chain.go:560 +0x51
  github.com/cosmos/relayer/relayer.(*Chain).GetAddress()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/chain.go:522 +0x65
  github.com/cosmos/relayer/relayer.(*Chain).CLIContext()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/chain.go:449 +0x84
  github.com/cosmos/relayer/relayer.(*Chain).QueryClientStateResponse()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/query.go:112 +0x5a
  github.com/cosmos/relayer/relayer.(*Chain).QueryClientState()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/query.go:118 +0x3a
  github.com/cosmos/relayer/relayer.(*Chain).InjectTrustedFields()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/ibc-client.go:56 +0xe4
  github.com/cosmos/relayer/relayer.(*Chain).GetIBCUpdateHeader()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/ibc-client.go:41 +0x84
  github.com/cosmos/relayer/relayer.(*NaiveStrategy).sendTxFromEventPackets()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:379 +0x7e
  github.com/cosmos/relayer/relayer.(*NaiveStrategy).HandleEvents.func1()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:267 +0xe4
  github.com/avast/retry-go.Do()
      /home/anon/go/pkg/mod/github.com/avast/retry-go@v2.6.0+incompatible/retry.go:114 +0x455
  github.com/cosmos/relayer/relayer.(*NaiveStrategy).HandleEvents()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:267 +0x390
  github.com/cosmos/relayer/relayer.relayerListenLoop·dwrap·4()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/strategies.go:140 +0x9d

Previous read at 0x00c000d64c60 by goroutine 27:
  [failed to restore the stack]

Goroutine 77 (running) created at:
  github.com/cosmos/relayer/relayer.relayerListenLoop()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/strategies.go:140 +0x118c
  github.com/cosmos/relayer/relayer.RunStrategy·dwrap·3()
      /home/anon/go/src/github.com/cosmos/relayer/relayer/strategies.go:63 +0x71

Goroutine 27 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:49 +0x22b
```

Closes #276 