### PR TITLE
fix(cmd): fix command aliases of balance

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -214,6 +214,7 @@ $ %s q acc ibc-1`,
 func queryBalanceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "balance [chain-id] [[key-name]]",
+		Aliases: []string{"bal"},
 		Short: "query the relayer's account balance on a given network by chain-ID",
 		Args:  cobra.RangeArgs(1, 2),
 		Example: strings.TrimSpace(fmt.Sprintf(`


### PR DESCRIPTION
Signed-off-by: storyicon <yuanchao@bilibili.com>

When I executed the demo according to the prompts in README.md, I found that many steps used the wording of `bal`:
```bash
$ rly q bal ibc-0
$ rly q bal ibc-1
```
I noticed that many commands at the same level as balance have aliases defined, so I think there is something missing here.