### PR TITLE
docs(readme): fix the demo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ $ rly q bal ibc-1
 
 # Then send some tokens between the chains
 $ rly tx transfer ibc-0 ibc-1 1000000samoleans $(rly chains address ibc-1)
-$ rly tx relay demo -d
-$ rly tx acks demo -d
+$ rly tx relay-pkts demo -d
+$ rly tx relay-acks demo -d
 
 # See that the transfer has completed
 $ rly q bal ibc-0
@@ -311,8 +311,8 @@ $ rly q bal ibc-1
 
 # Send the tokens back to the account on ibc-0
 $ rly tx transfer ibc-1 ibc-0 1000000ibc/27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B006199894CF1824DF9AC7C $(rly chains addr ibc-0)
-$ rly tx relay demo -d
-$ rly tx acks demo -d
+$ rly tx relay-pkts demo -d
+$ rly tx relay-acks demo -d
 
 # See that the return trip has completed
 $ rly q bal ibc-0


### PR DESCRIPTION
Signed-off-by: storyicon <yuanchao@bilibili.com>

When I execute the demo in README.md, I found the adjustment of two commands. I understand that there is such a change here:
```
rly tx relay -> `rly tx relay-pkts` or `rly tx relay-packets`
rly tx acks -> `rly tx relay-acks` or `rly tx relay-acknowledgements`
```
After modifying here, the demo can be executed completely and smoothly.