### PR TITLE
Config refactor to handle provider abstraction

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cosmos/relayer/relayer"
 )

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,8 +19,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cosmos/relayer/relayer/provider"
-	"github.com/cosmos/relayer/relayer/provider/cosmos"
 	"io/ioutil"
 	"os"
 	"path"
@@ -31,9 +29,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/relayer/relayer"
+	"github.com/cosmos/relayer/relayer/provider"
+	"github.com/cosmos/relayer/relayer/provider/cosmos"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -97,14 +97,14 @@ $ %s cfg list`, appName, defaultHome, appName)),
 			case yml && jsn:
 				return fmt.Errorf("can't pass both --json and --yaml, must pick one")
 			case jsn:
-				out, err := json.Marshal(config)
+				out, err := json.Marshal(ConfigToWrapper(config))
 				if err != nil {
 					return err
 				}
 				fmt.Println(string(out))
 				return nil
 			default:
-				out, err := yaml.Marshal(config)
+				out, err := yaml.Marshal(ConfigToWrapper(config))
 				if err != nil {
 					return err
 				}
@@ -224,8 +224,10 @@ func cfgFilesAddChains(dir string) (cfg *Config, err error) {
 	}
 	cfg = config
 	for _, f := range files {
-		c := &relayer.Chain{}
-		var pcw ProviderConfigWrapper
+		var (
+			pcw ProviderConfigJSONWrapper
+			c   *relayer.Chain
+		)
 		pth := fmt.Sprintf("%s/%s", dir, f.Name())
 		if f.IsDir() {
 			fmt.Printf("directory at %s, skipping...\n", pth)
@@ -241,11 +243,19 @@ func cfgFilesAddChains(dir string) (cfg *Config, err error) {
 			return nil, fmt.Errorf("failed to unmarshal file %s: %w", pth, err)
 		}
 
-		fmt.Printf("container=%+v\n", pcw)
-		fmt.Printf("value=%#v\n", pcw.Value)
+		prov, err := pcw.Value.NewProvider(homePath, debug)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build ChainProvider for %s. Err: %w", pth, err)
+		}
+
+		c = &relayer.Chain{ChainProvider: prov, ChainID: prov.ChainId()}
 
 		if err = cfg.AddChain(c); err != nil {
-			return nil, fmt.Errorf("failed to add chain%s: %w", pth, err)
+			return nil, fmt.Errorf("failed to add chain %s: %w", pth, err)
+		}
+
+		if err = overWriteConfig(cfg); err != nil {
+			return nil, err
 		}
 		fmt.Printf("added chain %s...\n", c.ChainID)
 	}
@@ -305,6 +315,21 @@ func cfgFilesAddPaths(dir string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
+// ConfigToWrapper converts the Config struct into a ConfigOutputWrapper struct
+func ConfigToWrapper(config *Config) *ConfigOutputWrapper {
+	cfgw := &ConfigOutputWrapper{Global: config.Global, Paths: config.Paths}
+	var providers []*ProviderConfigJSONWrapper
+	for _, chain := range config.Chains {
+		pcfgw := &ProviderConfigJSONWrapper{
+			Type:  chain.ChainProvider.Type(),
+			Value: chain.ChainProvider.ProviderConfig(),
+		}
+		providers = append(providers, pcfgw)
+	}
+	cfgw.ProviderConfigs = providers
+	return cfgw
+}
+
 // Config represents the config file for the relayer
 type Config struct {
 	Global GlobalConfig   `yaml:"global" json:"global"`
@@ -312,40 +337,57 @@ type Config struct {
 	Paths  relayer.Paths  `yaml:"paths" json:"paths"`
 }
 
-// ConfigInput is used to unmarshal the config file for the relayer from disk
-type ConfigInput struct {
+// ConfigOutputWrapper is an intermediary type for writing the config to disk and stdout
+type ConfigOutputWrapper struct {
 	Global          GlobalConfig    `yaml:"global" json:"global"`
 	ProviderConfigs ProviderConfigs `yaml:"chains" json:"chains"`
 	Paths           relayer.Paths   `yaml:"paths" json:"paths"`
 }
 
-type ProviderConfigs []ProviderConfigWrapper
-
-type ProviderConfigWrapper struct {
-	Type  string                  `json:"type" yaml:"type"`
-	Value provider.ProviderConfig `json:"value" yaml:"value"`
+// ConfigInputWrapper is an intermediary type for parsing the config.yaml file
+type ConfigInputWrapper struct {
+	Global          GlobalConfig                 `yaml:"global"`
+	ProviderConfigs []*ProviderConfigYAMLWrapper `yaml:"chains"`
+	Paths           relayer.Paths                `yaml:"paths"`
 }
 
-func (pcw ProviderConfigWrapper) UnmarshalJSON(data []byte) error {
+type ProviderConfigs []*ProviderConfigJSONWrapper
+
+// ProviderConfigJSONWrapper is used to parse arbitrary ProviderConfigs from json files
+type ProviderConfigJSONWrapper struct {
+	Type  string                  `json:"type"`
+	Value provider.ProviderConfig `json:"value"`
+}
+
+// ProviderConfigYAMLWrapper is used to parse arbitrary ProviderConfigs from yaml files
+type ProviderConfigYAMLWrapper struct {
+	Type  string      `yaml:"type"`
+	Value interface{} `yaml:"-"`
+}
+
+// UnmarshalJSON adds support for unmarshalling data from an arbitrary ProviderConfig
+// NOTE: Add new ProviderConfig types in the map here with the key set equal to the type of ChainProvider (e.g. cosmos, substrate, etc.)
+func (pcw *ProviderConfigJSONWrapper) UnmarshalJSON(data []byte) error {
 	customTypes := map[string]reflect.Type{
 		"cosmos": reflect.TypeOf(cosmos.CosmosProviderConfig{}),
 	}
-	val, err := UnmarshalProviderConfig(data, customTypes)
+	val, err := UnmarshalJSONProviderConfig(data, customTypes)
 	if err != nil {
 		return err
 	}
-	pcw.Value = val
+	pc := val.(provider.ProviderConfig)
+	pcw.Value = pc
 	return nil
 }
 
-func UnmarshalProviderConfig(data []byte, customTypes map[string]reflect.Type) (interface{}, error) {
+// UnmarshalJSONProviderConfig contains the custom unmarshalling logic for ProviderConfig structs
+func UnmarshalJSONProviderConfig(data []byte, customTypes map[string]reflect.Type) (interface{}, error) {
 	m := map[string]interface{}{}
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
 
 	typeName := m["type"].(string)
-	fmt.Println(typeName)
 	var provCfg provider.ProviderConfig
 	if ty, found := customTypes[typeName]; found {
 		provCfg = reflect.New(ty).Interface().(provider.ProviderConfig)
@@ -361,6 +403,30 @@ func UnmarshalProviderConfig(data []byte, customTypes map[string]reflect.Type) (
 	}
 
 	return provCfg, nil
+}
+
+// UnmarshalYAML adds support for unmarshalling data from arbitrary ProviderConfig entries found in the config file
+// NOTE: Add new ProviderConfig types in a switch case here
+func (iw *ProviderConfigYAMLWrapper) UnmarshalYAML(n *yaml.Node) error {
+	type inputWrapper ProviderConfigYAMLWrapper
+	type T struct {
+		*inputWrapper `yaml:",inline"`
+		Wrapper       yaml.Node `yaml:"value"`
+	}
+
+	obj := &T{inputWrapper: (*inputWrapper)(iw)}
+	if err := n.Decode(obj); err != nil {
+		return err
+	}
+
+	switch iw.Type {
+	case "cosmos":
+		iw.Value = new(cosmos.CosmosProviderConfig)
+	default:
+		return fmt.Errorf("%s is an invalid chain type, check your config file", iw.Type)
+	}
+
+	return obj.Wrapper.Decode(iw.Value)
 }
 
 // ChainsFromPath takes the path name and returns the properly configured chains
@@ -421,12 +487,13 @@ func newDefaultGlobalConfig() GlobalConfig {
 
 // AddChain adds an additional chain to the config
 func (c *Config) AddChain(chain *relayer.Chain) (err error) {
-	if chain.ChainID == "" {
+	chainId := chain.ChainID
+	if chainId == "" {
 		return fmt.Errorf("chain ID cannot be empty")
 	}
-	chn, err := c.Chains.Get(chain.ChainID)
-	if chn == nil || err == nil {
-		return fmt.Errorf("chain with ID %s already exists in config", chain.ChainID)
+	chn, err := c.Chains.Get(chainId)
+	if chn != nil || err == nil {
+		return fmt.Errorf("chain with ID %s already exists in config", chainId)
 	}
 	c.Chains = append(c.Chains, chain)
 	return nil
@@ -507,7 +574,7 @@ func (c *Config) AddPath(name string, path *relayer.Path) (err error) {
 func (c *Config) DeleteChain(chain string) *Config {
 	var set relayer.Chains
 	for _, ch := range c.Chains {
-		if ch.ChainID != chain {
+		if ch.Provider.ChainID() != chain {
 			set = append(set, ch)
 		}
 	}
@@ -515,17 +582,11 @@ func (c *Config) DeleteChain(chain string) *Config {
 	return c
 }
 
-// Called to initialize the relayer.Chain types on Config
+// validateConfig is used to validate the GlobalConfig values
 func validateConfig(c *Config) error {
-	to, err := time.ParseDuration(config.Global.Timeout)
+	_, err := time.ParseDuration(c.Global.Timeout)
 	if err != nil {
 		return fmt.Errorf("did you remember to run 'rly config init' error:%w", err)
-	}
-
-	for _, i := range c.Chains {
-		if err := i.Init(homePath, to, nil, debug); err != nil {
-			return fmt.Errorf("did you remember to run 'rly config init' error:%w", err)
-		}
 	}
 
 	return nil
@@ -538,7 +599,6 @@ func initConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	config = &Config{}
 	cfgPath := path.Join(home, "config", "config.yaml")
 	if _, err := os.Stat(cfgPath); err == nil {
 		viper.SetConfigFile(cfgPath)
@@ -550,11 +610,28 @@ func initConfig(cmd *cobra.Command) error {
 				os.Exit(1)
 			}
 
-			// unmarshall them into the struct
-			err = yaml.Unmarshal(file, config)
+			// unmarshall them into the wrapper struct
+			cfgWrapper := &ConfigInputWrapper{}
+			err = yaml.Unmarshal(file, cfgWrapper)
 			if err != nil {
 				fmt.Println("Error unmarshalling config:", err)
 				os.Exit(1)
+			}
+
+			// build the config struct
+			var chains relayer.Chains
+			for _, pcfg := range cfgWrapper.ProviderConfigs {
+				prov, err := pcfg.Value.(provider.ProviderConfig).NewProvider(homePath, debug)
+				if err != nil {
+					return fmt.Errorf("Error while building ChainProviders. Err: %s\n", err.Error())
+				}
+				chains = append(chains, &relayer.Chain{ChainProvider: prov, ChainID: prov.ChainId()})
+			}
+
+			config = &Config{
+				Global: cfgWrapper.Global,
+				Chains: chains,
+				Paths:  cfgWrapper.Paths,
 			}
 
 			// ensure config has []*relayer.Chain used for all chain operations
@@ -580,7 +657,7 @@ func overWriteConfig(cfg *Config) (err error) {
 			}
 
 			// marshal the new config
-			out, err := yaml.Marshal(cfg)
+			out, err := yaml.Marshal(ConfigToWrapper(config))
 			if err != nil {
 				return err
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -225,7 +225,7 @@ func cfgFilesAddChains(dir string) (cfg *Config, err error) {
 	cfg = config
 	for _, f := range files {
 		var (
-			pcw ProviderConfigJSONWrapper
+			pcw ProviderConfigWrapper
 			c   *relayer.Chain
 		)
 		pth := fmt.Sprintf("%s/%s", dir, f.Name())
@@ -318,9 +318,9 @@ func cfgFilesAddPaths(dir string) (cfg *Config, err error) {
 // ConfigToWrapper converts the Config struct into a ConfigOutputWrapper struct
 func ConfigToWrapper(config *Config) *ConfigOutputWrapper {
 	cfgw := &ConfigOutputWrapper{Global: config.Global, Paths: config.Paths}
-	var providers []*ProviderConfigJSONWrapper
+	var providers []*ProviderConfigWrapper
 	for _, chain := range config.Chains {
-		pcfgw := &ProviderConfigJSONWrapper{
+		pcfgw := &ProviderConfigWrapper{
 			Type:  chain.ChainProvider.Type(),
 			Value: chain.ChainProvider.ProviderConfig(),
 		}
@@ -351,15 +351,15 @@ type ConfigInputWrapper struct {
 	Paths           relayer.Paths                `yaml:"paths"`
 }
 
-type ProviderConfigs []*ProviderConfigJSONWrapper
+type ProviderConfigs []*ProviderConfigWrapper
 
-// ProviderConfigJSONWrapper is used to parse arbitrary ProviderConfigs from json files
-type ProviderConfigJSONWrapper struct {
-	Type  string                  `json:"type"`
-	Value provider.ProviderConfig `json:"value"`
+// ProviderConfigWrapper is an intermediary type for parsing arbitrary ProviderConfigs from json files and writing to json/yaml files
+type ProviderConfigWrapper struct {
+	Type  string                  `yaml:"type"  json:"type"`
+	Value provider.ProviderConfig `yaml:"value" json:"value"`
 }
 
-// ProviderConfigYAMLWrapper is used to parse arbitrary ProviderConfigs from yaml files
+// ProviderConfigYAMLWrapper is an intermediary type for parsing arbitrary ProviderConfigs from yaml files
 type ProviderConfigYAMLWrapper struct {
 	Type  string      `yaml:"type"`
 	Value interface{} `yaml:"-"`
@@ -367,7 +367,7 @@ type ProviderConfigYAMLWrapper struct {
 
 // UnmarshalJSON adds support for unmarshalling data from an arbitrary ProviderConfig
 // NOTE: Add new ProviderConfig types in the map here with the key set equal to the type of ChainProvider (e.g. cosmos, substrate, etc.)
-func (pcw *ProviderConfigJSONWrapper) UnmarshalJSON(data []byte) error {
+func (pcw *ProviderConfigWrapper) UnmarshalJSON(data []byte) error {
 	customTypes := map[string]reflect.Type{
 		"cosmos": reflect.TypeOf(cosmos.CosmosProviderConfig{}),
 	}
@@ -406,7 +406,7 @@ func UnmarshalJSONProviderConfig(data []byte, customTypes map[string]reflect.Typ
 }
 
 // UnmarshalYAML adds support for unmarshalling data from arbitrary ProviderConfig entries found in the config file
-// NOTE: Add new ProviderConfig types in a switch case here
+// NOTE: Add logic for new ProviderConfig types in a switch case here
 func (iw *ProviderConfigYAMLWrapper) UnmarshalYAML(n *yaml.Node) error {
 	type inputWrapper ProviderConfigYAMLWrapper
 	type T struct {

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/relayer/relayer"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func pathsCmd() *cobra.Command {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -213,10 +213,10 @@ $ %s q acc ibc-1`,
 
 func queryBalanceCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "balance [chain-id] [[key-name]]",
+		Use:     "balance [chain-id] [[key-name]]",
 		Aliases: []string{"bal"},
-		Short: "query the relayer's account balance on a given network by chain-ID",
-		Args:  cobra.RangeArgs(1, 2),
+		Short:   "query the relayer's account balance on a given network by chain-ID",
+		Args:    cobra.RangeArgs(1, 2),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query balance ibc-0
 $ %s query balance ibc-0 testkey`,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.14
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -142,7 +142,7 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	nhooyr.io/websocket v1.8.6 // indirect
 )
 

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -31,6 +31,7 @@ import (
 	connectiontypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
 	ibcexported "github.com/cosmos/ibc-go/v2/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
+	"github.com/cosmos/relayer/relayer/provider"
 	"github.com/gogo/protobuf/proto"
 	"github.com/tendermint/tendermint/libs/log"
 	provtypes "github.com/tendermint/tendermint/light/provider"
@@ -51,6 +52,7 @@ var (
 
 // Chain represents the necessary data for connecting to and indentifying a chain and its counterparites
 type Chain struct {
+	ChainProvider  provider.ChainProvider
 	Key            string  `yaml:"key" json:"key"`
 	ChainID        string  `yaml:"chain-id" json:"chain-id"`
 	RPCAddr        string  `yaml:"rpc-addr" json:"rpc-addr"`
@@ -669,7 +671,7 @@ func (c Chains) Get(chainID string) (*Chain, error) {
 			return chain, nil
 		}
 	}
-	return &Chain{}, fmt.Errorf("chain with ID %s is not configured", chainID)
+	return nil, fmt.Errorf("chain with ID %s is not configured", chainID)
 }
 
 // MustGet returns the chain and panics on any error

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -666,8 +666,6 @@ type Chains []*Chain
 func (c Chains) Get(chainID string) (*Chain, error) {
 	for _, chain := range c {
 		if chainID == chain.ChainID {
-			addr, _ := chain.GetAddress()
-			chain.address = addr
 			return chain, nil
 		}
 	}

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
 	conntypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	_                  provider.QueryProvider  = &CosmosProvider{}
-	_                  provider.TxProvider     = &CosmosProvider{}
+	_                  provider.ChainProvider  = &CosmosProvider{}
 	_                  provider.KeyProvider    = &CosmosProvider{}
 	_                  provider.RelayerMessage = CosmosMessage{}
 	defaultChainPrefix                         = commitmenttypes.NewMerklePrefix([]byte("ibc"))

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -10,21 +10,19 @@ import (
 	"strings"
 	"time"
 
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	chanutils "github.com/cosmos/ibc-go/v2/modules/core/04-channel/client/utils"
-	"golang.org/x/sync/errgroup"
-
 	sdkTx "github.com/cosmos/cosmos-sdk/client/tx"
 	keys "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	transfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	clientutils "github.com/cosmos/ibc-go/v2/modules/core/02-client/client/utils"
 	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
 	connutils "github.com/cosmos/ibc-go/v2/modules/core/03-connection/client/utils"
 	conntypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
+	chanutils "github.com/cosmos/ibc-go/v2/modules/core/04-channel/client/utils"
 	chantypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
 	committypes "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
@@ -35,6 +33,7 @@ import (
 	prov "github.com/tendermint/tendermint/light/provider/http"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -55,6 +54,18 @@ type CosmosProviderConfig struct {
 	GasPrices      string  `yaml:"gas-prices" json:"gas-prices"`
 	TrustingPeriod string  `yaml:"trusting-period" json:"trusting-period"`
 	Timeout        string  `yaml:"timeout" json:"timeout"`
+}
+
+func (cp *CosmosProviderConfig) NewProvider(homepath string, debug bool) (provider.ChainProvider, error) {
+	err := cp.Validate()
+	if err != nil {
+		return nil, err
+	}
+	p, err := NewCosmosProvider(cp, homepath, debug)
+	if err != nil {
+		return nil, err
+	}
+	return p, err
 }
 
 func (cp *CosmosProviderConfig) Validate() error {
@@ -135,11 +146,19 @@ type CosmosProvider struct {
 	debug   bool
 }
 
-func (cp *CosmosProvider) Init() error {
-	if err := cp.Config.Validate(); err != nil {
-		return err
-	}
+func (cp *CosmosProvider) ProviderConfig() provider.ProviderConfig {
+	return cp.Config
+}
 
+func (cp *CosmosProvider) ChainId() string {
+	return cp.Config.ChainID
+}
+
+func (cp *CosmosProvider) Type() string {
+	return "cosmos"
+}
+
+func (cp *CosmosProvider) Init() error {
 	if err := cp.CreateKeystore(cp.HomePath); err != nil {
 		return err
 	}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -13,7 +13,8 @@ import (
 )
 
 type ProviderConfig interface {
-	// Provider() ChainProvider
+	NewProvider(homepath string, debug bool) (ChainProvider, error)
+	Validate() error
 }
 
 type RelayerMessage interface{}
@@ -55,6 +56,10 @@ type ChainProvider interface {
 	ChannelCloseConfirm(dstQueryProvider QueryProvider, dsth int64, dstChanId, dstPortId, srcPortId, srcChanId string) (RelayerMessage, error)
 	SendMessage(msg RelayerMessage) (*RelayerTxResponse, bool, error)
 	SendMessages(msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
+
+	ChainId() string
+	Type() string
+	ProviderConfig() ProviderConfig
 }
 
 // Do we need intermediate types? i.e. can we use the SDK types for both substrate and cosmos?

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -12,6 +12,10 @@ import (
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
+type ProviderConfig interface {
+	// Provider() ChainProvider
+}
+
 type RelayerMessage interface{}
 
 type RelayerTxResponse struct {
@@ -31,7 +35,7 @@ type KeyProvider interface {
 	DeleteKey(name string) error
 }
 
-type TxProvider interface {
+type ChainProvider interface {
 	QueryProvider
 	KeyProvider
 


### PR DESCRIPTION
Users implementing support for a new `ChainProvider` would need to make adjustments in two places to get their custom config working
https://github.com/cosmos/relayer/blob/9300258b9401f93f28bd9455cd7408413e1834d4/cmd/config.go#L372
https://github.com/cosmos/relayer/blob/9300258b9401f93f28bd9455cd7408413e1834d4/cmd/config.go#L423

Writing config back to disk requires being able to access `ProviderConfig` from a `Chain` struct which is why I added this
https://github.com/cosmos/relayer/blob/9300258b9401f93f28bd9455cd7408413e1834d4/relayer/provider/provider.go#L62