### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @jackzampolin @jtieri @colin-axner @AdityaSripal
+* @jackzampolin @jtieri


### PR DESCRIPTION
Since @AdityaSripal and I no longer maintain the go relayer, I think it makes sense to remove us from the CODEOWNER file. This will reduce our notifications and allow us to pay closer attention to when we are tagged in issues/pr's