### PR TITLE
Fix wrong headers being used by the create client cmd

### DIFF
--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -113,12 +113,12 @@ $ %s tx raw clnt ibc-1 ibc-0 ibconeclient`, appName, appName)),
 				return err
 			}
 
-			h, err := chains[src].QueryLatestHeight()
+			h, err := chains[dst].QueryLatestHeight()
 			if err != nil {
 				return err
 			}
 
-			dstHeader, err := chains[src].GetLightSignedHeaderAtHeight(h)
+			dstHeader, err := chains[dst].GetLightSignedHeaderAtHeight(h)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
While working on [ibc-testbed](https://github.com/lum-network/ibc-testbed) I discovered that the raw create client command seems to be using the wrong chain headers (from src instead of dst).

I did not check much more, but it appears that other client creation implementations do not share this issue.