### PR TITLE
Cleanup `rly start`

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,9 +27,10 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
+	"github.com/spf13/viper"
+
 	"github.com/cosmos/relayer/relayer"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/dev-env
+++ b/dev-env
@@ -21,9 +21,15 @@ echo "waiting for blocks..."
 sleep 3
 
 rly tx link demo -d -o 3s
+sleep 2
+echo "Initial balances"
+echo "balance 0 $(rly q bal ibc-0)"
+echo "balance 1 $(rly q bal ibc-1)"
 rly tx transfer ibc-0 ibc-1 100000samoleans "$(rly keys show ibc-1)" -d
 rly tx transfer ibc-1 ibc-0 100000samoleans "$(rly keys show ibc-0)" -d
 sleep 2
-rly tx relay-packets demo -d
+rly start demo -d
 sleep 2
-rly tx relay-acknowledgements demo -d
+echo "Balances after packets are sent"
+echo "balance 0 $(rly q bal ibc-0)"
+echo "balance 1 $(rly q bal ibc-1)"

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -415,15 +415,6 @@ func RelayPackets(src, dst *Chain, sp *RelaySequences, maxTxSize, maxMsgLength u
 	}
 
 	if len(msgs.Src) != 0 {
-		//dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.PathEnd.ClientID)
-		//if err != nil {
-		//	return err
-		//}
-		//updateMsg, err := src.ChainProvider.UpdateClient(src.PathEnd.ClientID, dstHeader)
-		//if err != nil {
-		//	return err
-		//}
-
 		var (
 			dstHeader ibcexported.Header
 			updateMsg provider.RelayerMessage

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -2,6 +2,7 @@ package relayer
 
 import (
 	"fmt"
+	"time"
 )
 
 // StartRelayer starts the main relaying loop
@@ -49,7 +50,7 @@ func StartRelayer(src, dst *Chain, maxTxSize, maxMsgLength uint64) (func(), erro
 					}
 				}
 
-				//time.Sleep(100 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 	}()


### PR DESCRIPTION
`rly start` needed a little polishing up after the recent refactor. 

Additionally we needed to make some small changes to the `dev-env` bash script testing environment to get it working with `gaia v6.0.0` and `rly start`