### PR TITLE
Moving `Provider` implementation back into the relayer from `lens`

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -11,11 +11,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
-
 	"github.com/cosmos/relayer/relayer"
+	"github.com/cosmos/relayer/relayer/provider/cosmos"
+	"github.com/spf13/cobra"
 	registry "github.com/strangelove-ventures/lens/client/chain_registry"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -419,7 +419,21 @@ func chainRegistryAdd(chains []string) (*Config, error) {
 			}
 
 			// build the ChainProvider
-			prov, err := chainConfig.NewProvider(homePath, debug)
+			pcfg := &cosmos.CosmosProviderConfig{
+				Key:            chainConfig.Key,
+				ChainID:        chainConfig.ChainID,
+				RPCAddr:        chainConfig.RPCAddr,
+				AccountPrefix:  chainConfig.AccountPrefix,
+				KeyringBackend: chainConfig.KeyringBackend,
+				GasAdjustment:  chainConfig.GasAdjustment,
+				GasPrices:      chainConfig.GasPrices,
+				Debug:          chainConfig.Debug,
+				Timeout:        chainConfig.Timeout,
+				OutputFormat:   chainConfig.OutputFormat,
+				SignModeStr:    chainConfig.SignModeStr,
+			}
+
+			prov, err := pcfg.NewProvider(homePath, debug)
 			if err != nil {
 				log.Printf("failed to build ChainProvider for %s. Err: %v", chainConfig.ChainID, err)
 				continue

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,9 +30,9 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/relayer/relayer"
 	"github.com/cosmos/relayer/relayer/provider"
+	"github.com/cosmos/relayer/relayer/provider/cosmos"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	lens "github.com/strangelove-ventures/lens/client"
 	"gopkg.in/yaml.v3"
 )
 
@@ -367,7 +367,7 @@ type ProviderConfigYAMLWrapper struct {
 // NOTE: Add new ProviderConfig types in the map here with the key set equal to the type of ChainProvider (e.g. cosmos, substrate, etc.)
 func (pcw *ProviderConfigWrapper) UnmarshalJSON(data []byte) error {
 	customTypes := map[string]reflect.Type{
-		"cosmos": reflect.TypeOf(lens.ChainClientConfig{}),
+		"cosmos": reflect.TypeOf(cosmos.CosmosProviderConfig{}),
 	}
 	val, err := UnmarshalJSONProviderConfig(data, customTypes)
 	if err != nil {
@@ -419,7 +419,7 @@ func (iw *ProviderConfigYAMLWrapper) UnmarshalYAML(n *yaml.Node) error {
 
 	switch iw.Type {
 	case "cosmos":
-		iw.Value = new(lens.ChainClientConfig)
+		iw.Value = new(cosmos.CosmosProviderConfig)
 	default:
 		return fmt.Errorf("%s is an invalid chain type, check your config file", iw.Type)
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa
+	github.com/strangelove-ventures/lens v0.3.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible
-	github.com/cosmos/cosmos-sdk v0.45.0
-	github.com/cosmos/ibc-go/v2 v2.0.2
+	github.com/cosmos/cosmos-sdk v0.45.1
+	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/gin-gonic/gin v1.7.0 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gogo/protobuf v1.3.3
@@ -22,7 +22,7 @@ require (
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/strangelove-ventures/lens v0.2.2-0.20220131192754-f2a69f2e3fd7
+	github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1155,6 +1155,8 @@ github.com/strangelove-ventures/lens v0.2.2-0.20220131192754-f2a69f2e3fd7 h1:3vw
 github.com/strangelove-ventures/lens v0.2.2-0.20220131192754-f2a69f2e3fd7/go.mod h1:QSKpnL9bDirjJsMApJoHmVU3ZBujFnbXsvY9d5JG8M8=
 github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa h1:FQn08E51NxPrr63H92v7p4K884hCeKto6Li62/dEy30=
 github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa/go.mod h1:3z9i7FTh9xk8uJQ+de0+f2XbZ1PP2spEV3pXcKZl2b8=
+github.com/strangelove-ventures/lens v0.3.0 h1:BCF8sPzsV059x+oUNNGcpYR0RH+2Og+oztxVjYkn65I=
+github.com/strangelove-ventures/lens v0.3.0/go.mod h1:3z9i7FTh9xk8uJQ+de0+f2XbZ1PP2spEV3pXcKZl2b8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/cosmos/cosmos-sdk v0.44.3/go.mod h1:bA3+VenaR/l/vDiYzaiwbWvRPWHMBX2jG
 github.com/cosmos/cosmos-sdk v0.44.5/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/cosmos/cosmos-sdk v0.45.0 h1:DHD+CIRZ+cYgiLXuTEUL/aprnfPsWSwaww/fIZEsZlk=
 github.com/cosmos/cosmos-sdk v0.45.0/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
+github.com/cosmos/cosmos-sdk v0.45.1 h1:PY79YxPea5qlRLExRnzg8/rT1Scc8GGgRs22p7DX99Q=
+github.com/cosmos/cosmos-sdk v0.45.1/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -271,6 +273,8 @@ github.com/cosmos/iavl v0.17.3/go.mod h1:prJoErZFABYZGDHka1R6Oay4z9PrNeFFiMKHDAM
 github.com/cosmos/ibc-go/v2 v2.0.0-rc0/go.mod h1:z1LmpWwZF8YBeA3w2ibYG53R4HkhQGWjdUew/EfTSDw=
 github.com/cosmos/ibc-go/v2 v2.0.2 h1:y7eUgggMEVe43wHLw9XrGbeaTWtfkJYMoL3m6YW4fIY=
 github.com/cosmos/ibc-go/v2 v2.0.2/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
+github.com/cosmos/ibc-go/v2 v2.0.3 h1:kZ6SAj7hyxoixsLEUBx431bVGiBW22PCHwkWHafWhXs=
+github.com/cosmos/ibc-go/v2 v2.0.3/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
@@ -1149,6 +1153,8 @@ github.com/strangelove-ventures/lens v0.2.2-0.20220131191229-2c7ba13ad8c8 h1:M5m
 github.com/strangelove-ventures/lens v0.2.2-0.20220131191229-2c7ba13ad8c8/go.mod h1:QSKpnL9bDirjJsMApJoHmVU3ZBujFnbXsvY9d5JG8M8=
 github.com/strangelove-ventures/lens v0.2.2-0.20220131192754-f2a69f2e3fd7 h1:3vwNTIh39q4Vl8tkmV02lAS37SZ6WrkKX/GlsjdVqqg=
 github.com/strangelove-ventures/lens v0.2.2-0.20220131192754-f2a69f2e3fd7/go.mod h1:QSKpnL9bDirjJsMApJoHmVU3ZBujFnbXsvY9d5JG8M8=
+github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa h1:FQn08E51NxPrr63H92v7p4K884hCeKto6Li62/dEy30=
+github.com/strangelove-ventures/lens v0.2.2-0.20220211175529-5448f80144aa/go.mod h1:3z9i7FTh9xk8uJQ+de0+f2XbZ1PP2spEV3pXcKZl2b8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -320,7 +320,7 @@ func (c *Chain) GetRPCPort() string {
 // CreateTestKey creates a key for test chain
 func (c *Chain) CreateTestKey() error {
 	if c.ChainProvider.KeyExists(c.ChainProvider.Key()) {
-		return fmt.Errorf("key %s exists for chain %s", c.ChainID(), c.ChainProvider.Key())
+		return fmt.Errorf("key {%s} exists for chain {%s}", c.ChainProvider.Key(), c.ChainID())
 	}
 	_, err := c.ChainProvider.AddKey(c.ChainProvider.Key())
 	return err

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -3,11 +3,12 @@ package relayer
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cosmos/relayer/relayer/provider"
-	"github.com/strangelove-ventures/lens/client"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cosmos/relayer/relayer/provider"
+	"github.com/cosmos/relayer/relayer/provider/cosmos"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	conntypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
@@ -19,7 +20,7 @@ func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []p
 	if c.debug {
 		c.Log(fmt.Sprintf("- [%s] -> failed sending transaction:", c.ChainID()))
 		for _, msg := range msgs {
-			_ = c.Print(client.CosmosMsg(msg), false, false)
+			_ = c.Print(cosmos.CosmosMsg(msg), false, false)
 		}
 	}
 

--- a/relayer/provider/cosmos/log.go
+++ b/relayer/provider/cosmos/log.go
@@ -1,0 +1,48 @@
+package cosmos
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/relayer/relayer/provider"
+)
+
+// LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
+func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+	if cc.PCfg.Debug {
+		cc.Log(fmt.Sprintf("- [%s] -> failed sending transaction:", cc.ChainId()))
+		for _, msg := range msgs {
+			_ = cc.PrintObject(msg)
+		}
+	}
+
+	if err != nil {
+		cc.Logger.Error(fmt.Errorf("- [%s] -> err(%v)", cc.ChainId(), err).Error())
+		if res == nil {
+			return
+		}
+	}
+
+	if res.Code != 0 && res.Data != "" {
+		cc.Log(fmt.Sprintf("✘ [%s]@{%d} - msg(%s) err(%d:%s)", cc.ChainId(), res.Height, getMsgTypes(msgs), res.Code, res.Data))
+	}
+
+	if cc.PCfg.Debug && res != nil {
+		cc.Log("- transaction response:")
+		_ = cc.PrintObject(res)
+	}
+}
+
+// LogSuccessTx take the transaction and the messages to create it and logs the appropriate data
+func (cc *CosmosProvider) LogSuccessTx(res *sdk.TxResponse, msgs []provider.RelayerMessage) {
+	cc.Logger.Info(fmt.Sprintf("✔ [%s]@{%d} - msg(%s) hash(%s)", cc.ChainId(), res.Height, getMsgTypes(msgs), res.TxHash))
+}
+
+func getMsgTypes(msgs []provider.RelayerMessage) string {
+	var out string
+	for i, msg := range msgs {
+		out += fmt.Sprintf("%d:%s,", i, msg.Type())
+	}
+	return strings.TrimSuffix(out, ",")
+}

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1,11 +1,64 @@
 package cosmos
 
 import (
+	"context"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"math"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	transfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	conntypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
+	chantypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
+	host "github.com/cosmos/ibc-go/v2/modules/core/24-host"
+	ibcexported "github.com/cosmos/ibc-go/v2/modules/core/exported"
+	tmclient "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
 	"github.com/cosmos/relayer/relayer/provider"
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 	lens "github.com/strangelove-ventures/lens/client"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+var (
+	_ provider.ChainProvider = &CosmosProvider{}
+	_ provider.KeyProvider   = &CosmosProvider{}
+	_ provider.QueryProvider = &CosmosProvider{}
+
+	// Default IBC settings
+	defaultChainPrefix = commitmenttypes.NewMerklePrefix([]byte("ibc"))
+	defaultDelayPeriod = uint64(0)
+
+	// Variables used for retries
+	RtyAttNum = uint(5)
+	RtyAtt    = retry.Attempts(RtyAttNum)
+	RtyDel    = retry.Delay(time.Millisecond * 400)
+	RtyErr    = retry.LastErrorOnly(true)
+
+	// Strings for parsing events
+	spTag       = "send_packet"
+	waTag       = "write_acknowledgement"
+	srcChanTag  = "packet_src_channel"
+	dstChanTag  = "packet_dst_channel"
+	srcPortTag  = "packet_src_port"
+	dstPortTag  = "packet_dst_port"
+	dataTag     = "packet_data"
+	ackTag      = "packet_ack"
+	toHeightTag = "packet_timeout_height"
+	toTSTag     = "packet_timeout_timestamp"
+	seqTag      = "packet_sequence"
 )
 
 type CosmosMessage struct {
@@ -50,4 +103,1414 @@ func (cm CosmosMessage) MsgBytes() ([]byte, error) {
 
 type CosmosProvider struct {
 	lens.ChainClient
+}
+
+func (cc *CosmosProvider) ProviderConfig() provider.ProviderConfig {
+	return cc.Config
+}
+
+func (cc *CosmosProvider) ChainId() string {
+	return cc.Config.ChainID
+}
+
+func (cc *CosmosProvider) Type() string {
+	return "cosmos"
+}
+
+func (cc *CosmosProvider) Key() string {
+	return cc.Config.Key
+}
+
+func (cc *CosmosProvider) Timeout() string {
+	return cc.Config.Timeout
+}
+
+// Address returns the chains configured address as a string
+func (cc *CosmosProvider) Address() (string, error) {
+	var (
+		err  error
+		info keyring.Info
+	)
+	info, err = cc.Keybase.Key(cc.Config.Key)
+	if err != nil {
+		return "", err
+	}
+	out, err := cc.EncodeBech32AccAddr(info.GetAddress())
+	if err != nil {
+		return "", err
+	}
+
+	return out, err
+}
+
+func (cc *CosmosProvider) TrustingPeriod() (time.Duration, error) {
+	res, err := cc.QueryStakingParams(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	integer, _ := math.Modf(res.UnbondingTime.Hours() * 0.85)
+	trustingStr := fmt.Sprintf("%vh", integer)
+	tp, err := time.ParseDuration(trustingStr)
+	if err != nil {
+		return 0, nil
+	}
+
+	return tp, nil
+}
+
+// CreateClient creates an sdk.Msg to update the client on src with consensus state from dst
+func (cc *CosmosProvider) CreateClient(clientState ibcexported.ClientState, dstHeader ibcexported.Header) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if err := dstHeader.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	tmHeader, ok := dstHeader.(*tmclient.Header)
+	if !ok {
+		return nil, fmt.Errorf("got data of type %T but wanted tmclient.Header \n", dstHeader)
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	anyClientState, err := clienttypes.PackClientState(clientState)
+	if err != nil {
+		return nil, err
+	}
+
+	anyConsensusState, err := clienttypes.PackConsensusState(tmHeader.ConsensusState())
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &clienttypes.MsgCreateClient{
+		ClientState:    anyClientState,
+		ConsensusState: anyConsensusState,
+		Signer:         acc,
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+func (cc *CosmosProvider) SubmitMisbehavior( /*TBD*/ ) (provider.RelayerMessage, error) {
+	return nil, nil
+}
+
+func (cc *CosmosProvider) UpdateClient(srcClientId string, dstHeader ibcexported.Header) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if err := dstHeader.ValidateBasic(); err != nil {
+		return nil, err
+	}
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	anyHeader, err := clienttypes.PackHeader(dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &clienttypes.MsgUpdateClient{
+		ClientId: srcClientId,
+		Header:   anyHeader,
+		Signer:   acc,
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return NewCosmosMessage(msg), nil
+}
+
+func (cc *CosmosProvider) ConnectionOpenInit(srcClientId, dstClientId string, dstHeader ibcexported.Header) ([]provider.RelayerMessage, error) {
+	var (
+		acc     string
+		err     error
+		version *conntypes.Version
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	counterparty := conntypes.Counterparty{
+		ClientId:     dstClientId,
+		ConnectionId: "",
+		Prefix:       defaultChainPrefix,
+	}
+	msg := &conntypes.MsgConnectionOpenInit{
+		ClientId:     srcClientId,
+		Counterparty: counterparty,
+		Version:      version,
+		DelayPeriod:  defaultDelayPeriod,
+		Signer:       acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ConnectionOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	clientState, clientStateProof, consensusStateProof, connStateProof, proofHeight, err := dstQueryProvider.GenerateConnHandshakeProof(cph, dstClientId, dstConnId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	csAny, err := clienttypes.PackClientState(clientState)
+	if err != nil {
+		return nil, err
+	}
+
+	counterparty := conntypes.Counterparty{
+		ClientId:     dstClientId,
+		ConnectionId: dstConnId,
+		Prefix:       defaultChainPrefix,
+	}
+
+	// TODO: Get DelayPeriod from counterparty connection rather than using default value
+	msg := &conntypes.MsgConnectionOpenTry{
+		ClientId:             srcClientId,
+		PreviousConnectionId: srcConnId,
+		ClientState:          csAny,
+		Counterparty:         counterparty,
+		DelayPeriod:          defaultDelayPeriod,
+		CounterpartyVersions: conntypes.ExportedVersionsToProto(conntypes.GetCompatibleVersions()),
+		ProofHeight: clienttypes.Height{
+			RevisionNumber: proofHeight.GetRevisionNumber(),
+			RevisionHeight: proofHeight.GetRevisionHeight(),
+		},
+		ProofInit:       connStateProof,
+		ProofClient:     clientStateProof,
+		ProofConsensus:  consensusStateProof,
+		ConsensusHeight: clientState.GetLatestHeight().(clienttypes.Height),
+		Signer:          acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ConnectionOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	clientState, clientStateProof, consensusStateProof, connStateProof,
+		proofHeight, err := dstQueryProvider.GenerateConnHandshakeProof(cph, dstClientId, dstConnId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	csAny, err := clienttypes.PackClientState(clientState)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &conntypes.MsgConnectionOpenAck{
+		ConnectionId:             srcConnId,
+		CounterpartyConnectionId: dstConnId,
+		Version:                  conntypes.DefaultIBCVersion,
+		ClientState:              csAny,
+		ProofHeight: clienttypes.Height{
+			RevisionNumber: proofHeight.GetRevisionNumber(),
+			RevisionHeight: proofHeight.GetRevisionHeight(),
+		},
+		ProofTry:        connStateProof,
+		ProofClient:     clientStateProof,
+		ProofConsensus:  consensusStateProof,
+		ConsensusHeight: clientState.GetLatestHeight().(clienttypes.Height),
+		Signer:          acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ConnectionOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+	counterpartyConnState, err := dstQueryProvider.QueryConnection(cph, dstConnId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &conntypes.MsgConnectionOpenConfirm{
+		ConnectionId: srcConnId,
+		ProofAck:     counterpartyConnState.Proof,
+		ProofHeight:  counterpartyConnState.ProofHeight,
+		Signer:       acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ChannelOpenInit(srcClientId, srcConnId, srcPortId, srcVersion, dstPortId string, order chantypes.Order, dstHeader ibcexported.Header) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelOpenInit{
+		PortId: srcPortId,
+		Channel: chantypes.Channel{
+			State:    chantypes.INIT,
+			Ordering: order,
+			Counterparty: chantypes.Counterparty{
+				PortId:    dstPortId,
+				ChannelId: "",
+			},
+			ConnectionHops: []string{srcConnId},
+			Version:        srcVersion,
+		},
+		Signer: acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ChannelOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(cph, dstChanId, dstPortId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelOpenTry{
+		PortId:            srcPortId,
+		PreviousChannelId: srcChanId,
+		Channel: chantypes.Channel{
+			State:    chantypes.TRYOPEN,
+			Ordering: counterpartyChannelRes.Channel.Ordering,
+			Counterparty: chantypes.Counterparty{
+				PortId:    dstPortId,
+				ChannelId: dstChanId,
+			},
+			ConnectionHops: []string{srcConnectionId},
+			Version:        srcVersion,
+		},
+		CounterpartyVersion: counterpartyChannelRes.Channel.Version,
+		ProofInit:           counterpartyChannelRes.Proof,
+		ProofHeight:         counterpartyChannelRes.ProofHeight,
+		Signer:              acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ChannelOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(cph, dstChanId, dstPortId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelOpenAck{
+		PortId:                srcPortId,
+		ChannelId:             srcChanId,
+		CounterpartyChannelId: dstChanId,
+		CounterpartyVersion:   counterpartyChannelRes.Channel.Version,
+		ProofTry:              counterpartyChannelRes.Proof,
+		ProofHeight:           counterpartyChannelRes.ProofHeight,
+		Signer:                acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ChannelOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChanId string) ([]provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	updateMsg, err := cc.UpdateClient(srcClientId, dstHeader)
+	if err != nil {
+		return nil, err
+	}
+	cph, err := dstQueryProvider.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	counterpartyChanState, err := dstQueryProvider.QueryChannel(cph, dstChanId, dstPortId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelOpenConfirm{
+		PortId:      srcPortId,
+		ChannelId:   srcChanId,
+		ProofAck:    counterpartyChanState.Proof,
+		ProofHeight: counterpartyChanState.ProofHeight,
+		Signer:      acc,
+	}
+
+	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
+}
+
+func (cc *CosmosProvider) ChannelCloseInit(srcPortId, srcChanId string) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelCloseInit{
+		PortId:    srcPortId,
+		ChannelId: srcChanId,
+		Signer:    acc,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+func (cc *CosmosProvider) ChannelCloseConfirm(dstQueryProvider provider.QueryProvider, dsth int64, dstChanId, dstPortId, srcPortId, srcChanId string) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	dstChanResp, err := dstQueryProvider.QueryChannel(dsth, dstChanId, dstPortId)
+	if err != nil {
+		return nil, err
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgChannelCloseConfirm{
+		PortId:      srcPortId,
+		ChannelId:   srcChanId,
+		ProofInit:   dstChanResp.Proof,
+		ProofHeight: dstChanResp.ProofHeight,
+		Signer:      acc,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+// GetIBCUpdateHeader updates the off chain tendermint light client and
+// returns an IBC Update Header which can be used to update an on chain
+// light client on the destination chain. The source is used to construct
+// the header data.
+func (cc *CosmosProvider) GetIBCUpdateHeader(srch int64, dst provider.ChainProvider, dstClientId string) (ibcexported.Header, error) {
+	// Construct header data from light client representing source.
+	h, err := cc.GetLightSignedHeaderAtHeight(srch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject trusted fields based on previous header data from source
+	return cc.InjectTrustedFields(h, dst, dstClientId)
+}
+
+func (cc *CosmosProvider) GetLightSignedHeaderAtHeight(h int64) (ibcexported.Header, error) {
+	if h == 0 {
+		return nil, errors.New("height cannot be 0")
+	}
+
+	lightBlock, err := cc.LightProvider.LightBlock(context.Background(), h)
+	if err != nil {
+		return nil, err
+	}
+
+	protoVal, err := tmtypes.NewValidatorSet(lightBlock.ValidatorSet.Validators).ToProto()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tmclient.Header{
+		SignedHeader: lightBlock.SignedHeader.ToProto(),
+		ValidatorSet: protoVal,
+	}, nil
+}
+
+// InjectTrustedFields injects the necessary trusted fields for a header to update a light
+// client stored on the destination chain, using the information provided by the source
+// chain.
+// TrustedHeight is the latest height of the IBC client on dst
+// TrustedValidators is the validator set of srcChain at the TrustedHeight
+// InjectTrustedFields returns a copy of the header with TrustedFields modified
+func (cc *CosmosProvider) InjectTrustedFields(header ibcexported.Header, dst provider.ChainProvider, dstClientId string) (ibcexported.Header, error) {
+	// make copy of header stored in mop
+	h, ok := header.(*tmclient.Header)
+	if !ok {
+		return nil, fmt.Errorf("trying to inject fields into non-tendermint headers")
+	}
+
+	// retrieve dst client from src chain
+	// this is the client that will be updated
+	cs, err := dst.QueryClientState(int64(h.TrustedHeight.RevisionHeight), dstClientId)
+	if err != nil {
+		return nil, err
+	}
+
+	// inject TrustedHeight as latest height stored on dst client
+	h.TrustedHeight = cs.GetLatestHeight().(clienttypes.Height)
+
+	// NOTE: We need to get validators from the source chain at height: trustedHeight+1
+	// since the last trusted validators for a header at height h is the NextValidators
+	// at h+1 committed to in header h by NextValidatorsHash
+
+	// TODO: this is likely a source of off by 1 errors but may be impossible to change? Maybe this is the
+	// place where we need to fix the upstream query proof issue?
+	var trustedHeader *tmclient.Header
+	if err := retry.Do(func() error {
+		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(int64(h.TrustedHeight.RevisionHeight + 1))
+		th, ok := tmpHeader.(*tmclient.Header)
+		if !ok {
+			err = errors.New("non-tm client header")
+		}
+		trustedHeader = th
+		return err
+	}, RtyAtt, RtyDel, RtyErr); err != nil {
+		return nil, fmt.Errorf(
+			"failed to get trusted header, please ensure header at the height %d has not been pruned by the connected node: %w",
+			h.TrustedHeight.RevisionHeight, err,
+		)
+	}
+
+	// inject TrustedValidators into header
+	h.TrustedValidators = trustedHeader.ValidatorSet
+	return h, nil
+}
+
+// MsgRelayAcknowledgement constructs the MsgAcknowledgement which is to be sent to the sending chain.
+// The counterparty represents the receiving chain where the acknowledgement would be stored.
+func (cc *CosmosProvider) MsgRelayAcknowledgement(dst provider.ChainProvider, dstChanId, dstPortId, srcChanId, srcPortId string, dsth int64, packet provider.RelayPacket) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	msgPacketAck, ok := packet.(*relayMsgPacketAck)
+	if !ok {
+		return nil, fmt.Errorf("got data of type %T but wanted relayMsgPacketAck \n", packet)
+	}
+
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	ackRes, err := dst.QueryPacketAcknowledgement(dsth, dstChanId, dstPortId, packet.Seq())
+	switch {
+	case err != nil:
+		return nil, err
+	case ackRes.Proof == nil || ackRes.Acknowledgement == nil:
+		return nil, fmt.Errorf("ack packet acknowledgement query seq(%d) is nil", packet.Seq())
+	case ackRes == nil:
+		return nil, fmt.Errorf("ack packet [%s]seq{%d} has no associated proofs", dst.ChainId(), packet.Seq())
+	default:
+		msg := &chantypes.MsgAcknowledgement{
+			Packet: chantypes.Packet{
+				Sequence:           packet.Seq(),
+				SourcePort:         srcPortId,
+				SourceChannel:      srcChanId,
+				DestinationPort:    dstPortId,
+				DestinationChannel: dstChanId,
+				Data:               packet.Data(),
+				TimeoutHeight:      packet.Timeout(),
+				TimeoutTimestamp:   packet.TimeoutStamp(),
+			},
+			Acknowledgement: msgPacketAck.ack,
+			ProofAcked:      ackRes.Proof,
+			ProofHeight:     ackRes.ProofHeight,
+			Signer:          acc,
+		}
+
+		return NewCosmosMessage(msg), nil
+	}
+}
+
+// MsgTransfer creates a new transfer message
+func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcPortId, srcChanId string, timeoutHeight, timeoutTimestamp uint64) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	version := clienttypes.ParseChainID(dstChainId)
+
+	msg := &transfertypes.MsgTransfer{
+		SourcePort:    srcPortId,
+		SourceChannel: srcChanId,
+		Token:         amount,
+		Sender:        acc,
+		Receiver:      dstAddr,
+		TimeoutHeight: clienttypes.Height{
+			RevisionNumber: version,
+			RevisionHeight: timeoutHeight,
+		},
+		TimeoutTimestamp: timeoutTimestamp,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+// MsgRelayTimeout constructs the MsgTimeout which is to be sent to the sending chain.
+// The counterparty represents the receiving chain where the receipts would have been
+// stored.
+func (cc *CosmosProvider) MsgRelayTimeout(dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	recvRes, err := dst.QueryPacketReceipt(dsth, dstChanId, dstPortId, packet.Seq())
+	switch {
+	case err != nil:
+		return nil, err
+	case recvRes.Proof == nil:
+		return nil, fmt.Errorf("timeout packet receipt proof seq(%d) is nil", packet.Seq())
+	case recvRes == nil:
+		return nil, fmt.Errorf("timeout packet [%s]seq{%d} has no associated proofs", cc.Config.ChainID, packet.Seq())
+	default:
+		msg := &chantypes.MsgTimeout{
+			Packet: chantypes.Packet{
+				Sequence:           packet.Seq(),
+				SourcePort:         srcPortId,
+				SourceChannel:      srcChanId,
+				DestinationPort:    dstPortId,
+				DestinationChannel: dstChanId,
+				Data:               packet.Data(),
+				TimeoutHeight:      packet.Timeout(),
+				TimeoutTimestamp:   packet.TimeoutStamp(),
+			},
+			ProofUnreceived:  recvRes.Proof,
+			ProofHeight:      recvRes.ProofHeight,
+			NextSequenceRecv: packet.Seq(),
+			Signer:           acc,
+		}
+
+		return NewCosmosMessage(msg), nil
+	}
+}
+
+// MsgRelayRecvPacket constructs the MsgRecvPacket which is to be sent to the receiving chain.
+// The counterparty represents the sending chain where the packet commitment would be stored.
+func (cc *CosmosProvider) MsgRelayRecvPacket(dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+
+	comRes, err := dst.QueryPacketCommitment(dsth, dstChanId, dstPortId, packet.Seq())
+	switch {
+	case err != nil:
+		return nil, err
+	case comRes.Proof == nil || comRes.Commitment == nil:
+		return nil, fmt.Errorf("recv packet commitment query seq(%d) is nil", packet.Seq())
+	case comRes == nil:
+		return nil, fmt.Errorf("receive packet [%s]seq{%d} has no associated proofs", cc.Config.ChainID, packet.Seq())
+	default:
+		msg := &chantypes.MsgRecvPacket{
+			Packet: chantypes.Packet{
+				Sequence:           packet.Seq(),
+				SourcePort:         dstPortId,
+				SourceChannel:      dstChanId,
+				DestinationPort:    srcPortId,
+				DestinationChannel: srcChanId,
+				Data:               packet.Data(),
+				TimeoutHeight:      packet.Timeout(),
+				TimeoutTimestamp:   packet.TimeoutStamp(),
+			},
+			ProofCommitment: comRes.Proof,
+			ProofHeight:     comRes.ProofHeight,
+			Signer:          acc,
+		}
+
+		return NewCosmosMessage(msg), nil
+	}
+}
+
+// RelayPacketFromSequence relays a packet with a given seq on src and returns recvPacket msgs, timeoutPacketmsgs and error
+func (cc *CosmosProvider) RelayPacketFromSequence(src, dst provider.ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (provider.RelayerMessage, provider.RelayerMessage, error) {
+	txs, err := cc.QueryTxs(1, 1000, rcvPacketQuery(srcChanId, int(seq)))
+	switch {
+	case err != nil:
+		return nil, nil, err
+	case len(txs) == 0:
+		return nil, nil, fmt.Errorf("no transactions returned with query")
+	case len(txs) > 1:
+		return nil, nil, fmt.Errorf("more than one transaction returned with query")
+	}
+
+	rcvPackets, timeoutPackets, err := relayPacketsFromResultTx(src, dst, int64(dsth), txs[0], dstChanId, dstPortId, srcChanId, srcPortId, srcClientId)
+	switch {
+	case err != nil:
+		return nil, nil, err
+	case len(rcvPackets) == 0 && len(timeoutPackets) == 0:
+		return nil, nil, fmt.Errorf("no relay msgs created from query response")
+	case len(rcvPackets)+len(timeoutPackets) > 1:
+		return nil, nil, fmt.Errorf("more than one relay msg found in tx query")
+	}
+
+	if len(rcvPackets) == 1 {
+		pkt := rcvPackets[0]
+		if seq != pkt.Seq() {
+			return nil, nil, fmt.Errorf("wrong sequence: expected(%d) got(%d)", seq, pkt.Seq())
+		}
+
+		packet, err := dst.MsgRelayRecvPacket(src, int64(srch), pkt, srcChanId, srcPortId, dstChanId, dstPortId)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return packet, nil, nil
+	}
+
+	if len(timeoutPackets) == 1 {
+		pkt := timeoutPackets[0]
+		if seq != pkt.Seq() {
+			return nil, nil, fmt.Errorf("wrong sequence: expected(%d) got(%d)", seq, pkt.Seq())
+		}
+
+		timeout, err := src.MsgRelayTimeout(dst, int64(dsth), pkt, dstChanId, dstPortId, srcChanId, srcPortId)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, timeout, nil
+	}
+
+	return nil, nil, fmt.Errorf("should have errored before here")
+}
+
+// AcknowledgementFromSequence relays an acknowledgement with a given seq on src, source is the sending chain, destination is the receiving chain
+func (cc *CosmosProvider) AcknowledgementFromSequence(dst provider.ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+	txs, err := dst.QueryTxs(1, 1000, ackPacketQuery(dstChanId, int(seq)))
+	switch {
+	case err != nil:
+		return nil, err
+	case len(txs) == 0:
+		return nil, fmt.Errorf("no transactions returned with query")
+	case len(txs) > 1:
+		return nil, fmt.Errorf("more than one transaction returned with query")
+	}
+
+	acks, err := acknowledgementsFromResultTx(dstChanId, dstPortId, srcChanId, srcPortId, txs[0])
+	switch {
+	case err != nil:
+		return nil, err
+	case len(acks) == 0:
+		return nil, fmt.Errorf("no ack msgs created from query response")
+	}
+
+	var out provider.RelayerMessage
+	for _, ack := range acks {
+		if seq != ack.Seq() {
+			continue
+		}
+		msg, err := cc.MsgRelayAcknowledgement(dst, dstChanId, dstPortId, srcChanId, srcPortId, int64(dsth), ack)
+		if err != nil {
+			return nil, err
+		}
+		out = msg
+	}
+	return out, nil
+}
+
+func rcvPacketQuery(channelID string, seq int) []string {
+	return []string{fmt.Sprintf("%s.packet_src_channel='%s'", spTag, channelID),
+		fmt.Sprintf("%s.packet_sequence='%d'", spTag, seq)}
+}
+
+func ackPacketQuery(channelID string, seq int) []string {
+	return []string{fmt.Sprintf("%s.packet_dst_channel='%s'", waTag, channelID),
+		fmt.Sprintf("%s.packet_sequence='%d'", waTag, seq)}
+}
+
+// relayPacketsFromResultTx looks through the events in a *ctypes.ResultTx
+// and returns relayPackets with the appropriate data
+func relayPacketsFromResultTx(src, dst provider.ChainProvider, dsth int64, res *ctypes.ResultTx, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) ([]provider.RelayPacket, []provider.RelayPacket, error) {
+	var (
+		rcvPackets     []provider.RelayPacket
+		timeoutPackets []provider.RelayPacket
+	)
+
+	for _, e := range res.TxResult.Events {
+		if e.Type == spTag {
+			// NOTE: Src and Dst are switched here
+			rp := &relayMsgRecvPacket{pass: false}
+			for _, p := range e.Attributes {
+				if string(p.Key) == srcChanTag {
+					if string(p.Value) != srcChanId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == dstChanTag {
+					if string(p.Value) != dstChanId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == srcPortTag {
+					if string(p.Value) != srcPortId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == dstPortTag {
+					if string(p.Value) != dstPortId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == dataTag {
+					rp.packetData = p.Value
+				}
+				if string(p.Key) == toHeightTag {
+					timeout, err := clienttypes.ParseHeight(string(p.Value))
+					if err != nil {
+						return nil, nil, err
+					}
+
+					rp.timeout = timeout
+				}
+				if string(p.Key) == toTSTag {
+					timeout, _ := strconv.ParseUint(string(p.Value), 10, 64)
+					rp.timeoutStamp = timeout
+				}
+				if string(p.Key) == seqTag {
+					seq, _ := strconv.ParseUint(string(p.Value), 10, 64)
+					rp.seq = seq
+				}
+			}
+
+			// fetch the header which represents a block produced on destination
+			block, err := dst.GetIBCUpdateHeader(dsth, src, srcClientId)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			switch {
+			// If the packet has a timeout height, and it has been reached, return a timeout packet
+			case !rp.timeout.IsZero() && block.GetHeight().GTE(rp.timeout):
+				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())
+			// If the packet matches the relay constraints relay it as a MsgReceivePacket
+			case !rp.pass:
+				rcvPackets = append(rcvPackets, rp)
+			}
+		}
+	}
+
+	// If there is a relayPacket, return it
+	if len(rcvPackets)+len(timeoutPackets) > 0 {
+		return rcvPackets, timeoutPackets, nil
+	}
+
+	return nil, nil, fmt.Errorf("no packet data found")
+}
+
+// acknowledgementsFromResultTx looks through the events in a *ctypes.ResultTx and returns
+// relayPackets with the appropriate data
+func acknowledgementsFromResultTx(dstChanId, dstPortId, srcChanId, srcPortId string, res *ctypes.ResultTx) ([]provider.RelayPacket, error) {
+	var ackPackets []provider.RelayPacket
+	for _, e := range res.TxResult.Events {
+		if e.Type == waTag {
+			// NOTE: Src and Dst are switched here
+			rp := &relayMsgPacketAck{pass: false}
+			for _, p := range e.Attributes {
+				if string(p.Key) == srcChanTag {
+					if string(p.Value) != srcChanId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == dstChanTag {
+					if string(p.Value) != dstChanId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == srcPortTag {
+					if string(p.Value) != srcPortId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == dstPortTag {
+					if string(p.Value) != dstPortId {
+						rp.pass = true
+						continue
+					}
+				}
+				if string(p.Key) == ackTag {
+					rp.ack = p.Value
+				}
+				if string(p.Key) == dataTag {
+					rp.packetData = p.Value
+				}
+				if string(p.Key) == toHeightTag {
+					timeout, err := clienttypes.ParseHeight(string(p.Value))
+					if err != nil {
+						return nil, err
+					}
+					rp.timeout = timeout
+				}
+				if string(p.Key) == toTSTag {
+					timeout, _ := strconv.ParseUint(string(p.Value), 10, 64)
+					rp.timeoutStamp = timeout
+				}
+				if string(p.Key) == seqTag {
+					seq, _ := strconv.ParseUint(string(p.Value), 10, 64)
+					rp.seq = seq
+				}
+			}
+			if !rp.pass {
+				ackPackets = append(ackPackets, rp)
+			}
+		}
+	}
+
+	// If there is a relayPacket, return it
+	if len(ackPackets) > 0 {
+		return ackPackets, nil
+	}
+
+	return nil, fmt.Errorf("no packet data found")
+}
+
+func (cc *CosmosProvider) MsgUpgradeClient(srcClientId string, consRes *clienttypes.QueryConsensusStateResponse, clientRes *clienttypes.QueryClientStateResponse) (provider.RelayerMessage, error) {
+	var (
+		acc string
+		err error
+	)
+	if acc, err = cc.Address(); err != nil {
+		return nil, err
+	}
+	return NewCosmosMessage(&clienttypes.MsgUpgradeClient{ClientId: srcClientId, ClientState: clientRes.ClientState,
+		ConsensusState: consRes.ConsensusState, ProofUpgradeClient: consRes.GetProof(),
+		ProofUpgradeConsensusState: consRes.ConsensusState.Value, Signer: acc}), nil
+}
+
+// AutoUpdateClient update client automatically to prevent expiry
+func (cc *CosmosProvider) AutoUpdateClient(dst provider.ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error) {
+	srch, err := cc.QueryLatestHeight()
+	if err != nil {
+		return 0, err
+	}
+	dsth, err := dst.QueryLatestHeight()
+	if err != nil {
+		return 0, err
+	}
+
+	clientState, err := cc.queryTMClientState(srch, srcClientId)
+	if err != nil {
+		return 0, err
+	}
+
+	if clientState.TrustingPeriod <= thresholdTime {
+		return 0, fmt.Errorf("client (%s) trusting period time is less than or equal to threshold time", srcClientId)
+	}
+
+	// query the latest consensus state of the potential matching client
+	consensusStateResp, err := cc.QueryConsensusStateABCI(srcClientId, clientState.GetLatestHeight())
+	if err != nil {
+		return 0, err
+	}
+
+	exportedConsState, err := clienttypes.UnpackConsensusState(consensusStateResp.ConsensusState)
+	if err != nil {
+		return 0, err
+	}
+
+	consensusState, ok := exportedConsState.(*tmclient.ConsensusState)
+	if !ok {
+		return 0, fmt.Errorf("consensus state with clientID %s from chain %s is not IBC tendermint type",
+			srcClientId, cc.Config.ChainID)
+	}
+
+	expirationTime := consensusState.Timestamp.Add(clientState.TrustingPeriod)
+
+	timeToExpiry := time.Until(expirationTime)
+
+	if timeToExpiry > thresholdTime {
+		return timeToExpiry, nil
+	}
+
+	if clientState.IsExpired(consensusState.Timestamp, time.Now()) {
+		return 0, fmt.Errorf("client (%s) is already expired on chain: %s", srcClientId, cc.Config.ChainID)
+	}
+
+	srcUpdateHeader, err := cc.GetIBCUpdateHeader(srch, dst, dstClientId)
+	if err != nil {
+		return 0, err
+	}
+
+	dstUpdateHeader, err := dst.GetIBCUpdateHeader(dsth, cc, srcClientId)
+	if err != nil {
+		return 0, err
+	}
+
+	updateMsg, err := cc.UpdateClient(srcClientId, dstUpdateHeader)
+	if err != nil {
+		return 0, err
+	}
+
+	msgs := []provider.RelayerMessage{updateMsg}
+
+	res, success, err := cc.SendMessages(msgs)
+	if err != nil {
+		// cp.LogFailedTx(res, err, CosmosMsgs(msgs...))
+		return 0, err
+	}
+	if !success {
+		return 0, fmt.Errorf("tx failed: %s", res.Data)
+	}
+	cc.Log(fmt.Sprintf("★ Client updated: [%s]client(%s) {%d}->{%d}",
+		cc.Config.ChainID,
+		srcClientId,
+		MustGetHeight(srcUpdateHeader.GetHeight()),
+		srcUpdateHeader.GetHeight().GetRevisionHeight(),
+	))
+
+	return clientState.TrustingPeriod, nil
+}
+
+// FindMatchingClient will determine if there exists a client with identical client and consensus states
+// to the client which would have been created. Source is the chain that would be adding a client
+// which would track the counterparty. Therefore we query source for the existing clients
+// and check if any match the counterparty. The counterparty must have a matching consensus state
+// to the latest consensus state of a potential match. The provided client state is the client
+// state that will be created if there exist no matches.
+func (cc *CosmosProvider) FindMatchingClient(counterparty provider.ChainProvider, clientState ibcexported.ClientState) (string, bool) {
+	// TODO: add appropriate offset and limits
+	var (
+		clientsResp clienttypes.IdentifiedClientStates
+		err         error
+	)
+
+	if err = retry.Do(func() error {
+		clientsResp, err = cc.QueryClients()
+		if err != nil {
+			if cc.Config.Debug {
+				cc.Log(fmt.Sprintf("Error: querying clients on %s failed: %v", cc.Config.ChainID, err))
+			}
+			return err
+		}
+		return err
+	}, RtyAtt, RtyDel, RtyErr); err != nil {
+		if cc.Config.Debug {
+			cc.Log(fmt.Sprintf("Error: querying clients on %s failed: %v", cc.Config.ChainID, err))
+		}
+		return "", false
+	}
+
+	for _, identifiedClientState := range clientsResp {
+		// unpack any into ibc tendermint client state
+		existingClientState, err := castClientStateToTMType(identifiedClientState.ClientState)
+		if err != nil {
+			return "", false
+		}
+
+		tmClientState, ok := clientState.(*tmclient.ClientState)
+		if !ok {
+			if cc.Config.Debug {
+				fmt.Printf("got data of type %T but wanted tmclient.ClientState \n", clientState)
+			}
+			return "", false
+		}
+
+		// check if the client states match
+		// NOTE: FrozenHeight.IsZero() is a sanity check, the client to be created should always
+		// have a zero frozen height and therefore should never match with a frozen client
+		if isMatchingClient(tmClientState, existingClientState) && existingClientState.FrozenHeight.IsZero() {
+
+			// query the latest consensus state of the potential matching client
+			consensusStateResp, err := cc.QueryConsensusStateABCI(identifiedClientState.ClientId, existingClientState.GetLatestHeight())
+			if err != nil {
+				if cc.Config.Debug {
+					cc.Log(fmt.Sprintf("Error: failed to query latest consensus state for existing client on chain %s: %v",
+						cc.Config.ChainID, err))
+				}
+				continue
+			}
+
+			//nolint:lll
+			header, err := counterparty.GetLightSignedHeaderAtHeight(int64(existingClientState.GetLatestHeight().GetRevisionHeight()))
+			if err != nil {
+				if cc.Config.Debug {
+					cc.Log(fmt.Sprintf("Error: failed to query header for chain %s at height %d: %v",
+						counterparty.ChainId(), existingClientState.GetLatestHeight().GetRevisionHeight(), err))
+				}
+				continue
+			}
+
+			exportedConsState, err := clienttypes.UnpackConsensusState(consensusStateResp.ConsensusState)
+			if err != nil {
+				if cc.Config.Debug {
+					cc.Log(fmt.Sprintf("Error: failed to consensus state on chain %s: %v", counterparty.ChainId(), err))
+				}
+				continue
+			}
+			existingConsensusState, ok := exportedConsState.(*tmclient.ConsensusState)
+			if !ok {
+				if cc.Config.Debug {
+					cc.Log(fmt.Sprintf("Error: consensus state is not tendermint type on chain %s", counterparty.ChainId()))
+				}
+				continue
+			}
+
+			if existingClientState.IsExpired(existingConsensusState.Timestamp, time.Now()) {
+				continue
+			}
+
+			tmHeader, ok := header.(*tmclient.Header)
+			if !ok {
+				if cc.Config.Debug {
+					fmt.Printf("got data of type %T but wanted tmclient.Header \n", header)
+				}
+				return "", false
+			}
+
+			if isMatchingConsensusState(existingConsensusState, tmHeader.ConsensusState()) {
+				// found matching client
+				return identifiedClientState.ClientId, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (cc *CosmosProvider) QueryConsensusStateABCI(clientID string, height ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error) {
+	key := host.FullConsensusStateKey(clientID, height)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(int64(height.GetRevisionHeight()), key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if consensus state exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrap(clienttypes.ErrConsensusStateNotFound, clientID)
+	}
+
+	// TODO do we really want to create a new codec? ChainClient exposes proto.Marshaler
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	cs, err := clienttypes.UnmarshalConsensusState(cdc, value)
+	if err != nil {
+		return nil, err
+	}
+
+	anyConsensusState, err := clienttypes.PackConsensusState(cs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clienttypes.QueryConsensusStateResponse{
+		ConsensusState: anyConsensusState,
+		Proof:          proofBz,
+		ProofHeight:    proofHeight,
+	}, nil
+}
+
+// isMatchingClient determines if the two provided clients match in all fields
+// except latest height. They are assumed to be IBC tendermint light clients.
+// NOTE: we don't pass in a pointer so upstream references don't have a modified
+// latest height set to zero.
+func isMatchingClient(clientStateA, clientStateB *tmclient.ClientState) bool {
+	// zero out latest client height since this is determined and incremented
+	// by on-chain updates. Changing the latest height does not fundamentally
+	// change the client. The associated consensus state at the latest height
+	// determines this last check
+	clientStateA.LatestHeight = clienttypes.ZeroHeight()
+	clientStateB.LatestHeight = clienttypes.ZeroHeight()
+
+	return reflect.DeepEqual(clientStateA, clientStateB)
+}
+
+// isMatchingConsensusState determines if the two provided consensus states are
+// identical. They are assumed to be IBC tendermint light clients.
+func isMatchingConsensusState(consensusStateA, consensusStateB *tmclient.ConsensusState) bool {
+	return reflect.DeepEqual(*consensusStateA, *consensusStateB)
+}
+
+// queryTMClientState retrieves the latest consensus state for a client in state at a given height
+// and unpacks/cast it to tendermint clientstate
+func (cc *CosmosProvider) queryTMClientState(srch int64, srcClientId string) (*tmclient.ClientState, error) {
+	clientStateRes, err := cc.QueryClientStateResponse(srch, srcClientId)
+	if err != nil {
+		return &tmclient.ClientState{}, err
+	}
+
+	return castClientStateToTMType(clientStateRes.ClientState)
+}
+
+// castClientStateToTMType casts client state to tendermint type
+func castClientStateToTMType(cs *codectypes.Any) (*tmclient.ClientState, error) {
+	clientStateExported, err := clienttypes.UnpackClientState(cs)
+	if err != nil {
+		return &tmclient.ClientState{}, err
+	}
+
+	// cast from interface to concrete type
+	clientState, ok := clientStateExported.(*tmclient.ClientState)
+	if !ok {
+		return &tmclient.ClientState{},
+			fmt.Errorf("error when casting exported clientstate to tendermint type")
+	}
+
+	return clientState, nil
+}
+
+// WaitForNBlocks blocks until the next block on a given chain
+func (cc *CosmosProvider) WaitForNBlocks(n int64) error {
+	var initial int64
+	h, err := cc.RPCClient.Status(context.Background())
+	if err != nil {
+		return err
+	}
+	if h.SyncInfo.CatchingUp {
+		return fmt.Errorf("chain catching up")
+	}
+	initial = h.SyncInfo.LatestBlockHeight
+	for {
+		h, err = cc.RPCClient.Status(context.Background())
+		if err != nil {
+			return err
+		}
+		if h.SyncInfo.LatestBlockHeight > initial+n {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// MustGetHeight takes the height inteface and returns the actual height
+func MustGetHeight(h ibcexported.Height) clienttypes.Height {
+	height, ok := h.(clienttypes.Height)
+	if !ok {
+		panic("height is not an instance of height!")
+	}
+	return height
+}
+
+// SendMessage attempts to sign, encode & send a RelayerMessage
+// This is used extensively in the relayer as an extension of the Provider interface
+func (cc *CosmosProvider) SendMessage(msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+	return cc.SendMessages([]provider.RelayerMessage{msg})
+}
+
+// SendMessages attempts to sign, encode, & send a slice of RelayerMessages
+// This is used extensively in the relayer as an extension of the Provider interface
+//
+// NOTE: An error is returned if there was an issue sending the transaction. A successfully sent, but failed
+// transaction will not return an error. If a transaction is successfully sent, the result of the execution
+// of that transaction will be logged. A boolean indicating if a transaction was successfully
+// sent and executed successfully is returned.
+func (cc *CosmosProvider) SendMessages(msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+	var (
+		txb     client.TxBuilder
+		txBytes []byte
+		res     *sdk.TxResponse
+	)
+
+	// Query account details
+	txf, err := cc.PrepareFactory(cc.TxFactory())
+	if err != nil {
+		return nil, false, err
+	}
+
+	// TODO: Make this work with new CalculateGas method
+	// TODO: This is related to GRPC client stuff?
+	// https://github.com/cosmos/cosmos-sdk/blob/5725659684fc93790a63981c653feee33ecf3225/client/tx/tx.go#L297
+	// If users pass gas adjustment, then calculate gas
+	_, adjusted, err := cc.CalculateGas(txf, CosmosMsgs(msgs...)...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Set the gas amount on the transaction factory
+	txf = txf.WithGas(adjusted)
+
+	// Build the transaction builder & retry on failures
+	if err = retry.Do(func() error {
+		txb, err = tx.BuildUnsignedTx(txf, CosmosMsgs(msgs...)...)
+		if err != nil {
+			return err
+		}
+		return err
+	}, RtyAtt, RtyDel, RtyErr); err != nil {
+		return nil, false, err
+	}
+
+	// Attach the signature to the transaction
+	// Force encoding in the chain specific address
+	for _, msg := range msgs {
+		cc.Codec.Marshaler.MustMarshalJSON(CosmosMsg(msg))
+	}
+
+	done := cc.SetSDKContext()
+
+	if err = retry.Do(func() error {
+		if err = tx.Sign(txf, cc.Config.Key, txb, false); err != nil {
+			return err
+		}
+		return err
+	}, RtyAtt, RtyDel, RtyErr); err != nil {
+		return nil, false, err
+	}
+
+	done()
+
+	// Generate the transaction bytes
+	if err = retry.Do(func() error {
+		txBytes, err = cc.Codec.TxConfig.TxEncoder()(txb.GetTx())
+		if err != nil {
+			return err
+		}
+		return err
+	}, RtyAtt, RtyDel, RtyErr); err != nil {
+		return nil, false, err
+	}
+
+	res, err = cc.BroadcastTx(context.Background(), txBytes)
+	if err != nil || res == nil {
+		return nil, false, err
+	}
+
+	// Parse events and build a map where the key is event.Type+"."+attribute.Key
+	events := make(map[string]string, 1)
+	for _, logs := range res.Logs {
+		for _, ev := range logs.Events {
+			for _, attr := range ev.Attributes {
+				key := ev.Type + "." + attr.Key
+				events[key] = attr.Value
+			}
+		}
+	}
+
+	rlyRes := &provider.RelayerTxResponse{
+		Height: res.Height,
+		TxHash: res.TxHash,
+		Code:   res.Code,
+		Data:   res.Data,
+		Events: events,
+	}
+
+	// transaction was executed, log the success or failure using the tx response code
+	// NOTE: error is nil, logic should use the returned error to determine if the
+	// transaction was successfully executed.
+	if rlyRes.Code != 0 {
+		cc.LogFailedTx(rlyRes, err, msgs)
+		return rlyRes, false, fmt.Errorf("transaction failed with code: %d", res.Code)
+	}
+
+	cc.LogSuccessTx(res, msgs)
+	return rlyRes, true, nil
 }

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1,0 +1,53 @@
+package cosmos
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/relayer/relayer/provider"
+	"github.com/gogo/protobuf/proto"
+	lens "github.com/strangelove-ventures/lens/client"
+)
+
+type CosmosMessage struct {
+	Msg sdk.Msg
+}
+
+func NewCosmosMessage(msg sdk.Msg) provider.RelayerMessage {
+	return CosmosMessage{
+		Msg: msg,
+	}
+}
+
+func CosmosMsg(rm provider.RelayerMessage) sdk.Msg {
+	if val, ok := rm.(CosmosMessage); !ok {
+		fmt.Printf("got data of type %T but wanted provider.CosmosMessage \n", val)
+		return nil
+	} else {
+		return val.Msg
+	}
+}
+
+func CosmosMsgs(rm ...provider.RelayerMessage) []sdk.Msg {
+	sdkMsgs := make([]sdk.Msg, 0)
+	for _, rMsg := range rm {
+		if val, ok := rMsg.(CosmosMessage); !ok {
+			fmt.Printf("got data of type %T but wanted provider.CosmosMessage \n", val)
+			return nil
+		} else {
+			sdkMsgs = append(sdkMsgs, val.Msg)
+		}
+	}
+	return sdkMsgs
+}
+
+func (cm CosmosMessage) Type() string {
+	return sdk.MsgTypeURL(cm.Msg)
+}
+
+func (cm CosmosMessage) MsgBytes() ([]byte, error) {
+	return proto.Marshal(cm.Msg)
+}
+
+type CosmosProvider struct {
+	lens.ChainClient
+}

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -125,7 +125,7 @@ func (pc CosmosProviderConfig) Validate() error {
 	return nil
 }
 
-// NewProvider validates the ChainClientConfig, instantiates a ChainClient and instantiates a CosmosProvider
+// NewProvider validates the CosmosProviderConfig, instantiates a ChainClient and then instantiates a CosmosProvider
 func (pc CosmosProviderConfig) NewProvider(homepath string, debug bool) (provider.ChainProvider, error) {
 	if err := pc.Validate(); err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (pc CosmosProviderConfig) NewProvider(homepath string, debug bool) (provide
 }
 
 // ChainClientConfig builds a ChainClientConfig struct from a CosmosProviderConfig, this is used
-// to instantiate and instance of ChainClient from lens which is how we build the CosmosProvider
+// to instantiate an instance of ChainClient from lens which is how we build the CosmosProvider
 func ChainClientConfig(pcfg *CosmosProviderConfig) *lens.ChainClientConfig {
 	return &lens.ChainClientConfig{
 		Key:            pcfg.Key,

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -1,0 +1,1002 @@
+package cosmos
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	transfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	conntypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
+	chantypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
+	committypes "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
+	host "github.com/cosmos/ibc-go/v2/modules/core/24-host"
+	ibcexported "github.com/cosmos/ibc-go/v2/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
+	tmclient "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
+	"github.com/pkg/errors"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/light"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+	"golang.org/x/sync/errgroup"
+)
+
+// QueryTx takes a transaction hash and returns the transaction
+func (cc *CosmosProvider) QueryTx(hashHex string) (*ctypes.ResultTx, error) {
+	hash, err := hex.DecodeString(hashHex)
+	if err != nil {
+		return &ctypes.ResultTx{}, err
+	}
+
+	return cc.RPCClient.Tx(context.Background(), hash, true)
+}
+
+// QueryTxs returns an array of transactions given a tag
+func (cc *CosmosProvider) QueryTxs(page, limit int, events []string) ([]*ctypes.ResultTx, error) {
+	if len(events) == 0 {
+		return nil, errors.New("must declare at least one event to search")
+	}
+
+	if page <= 0 {
+		return nil, errors.New("page must greater than 0")
+	}
+
+	if limit <= 0 {
+		return nil, errors.New("limit must greater than 0")
+	}
+
+	res, err := cc.RPCClient.TxSearch(context.Background(), strings.Join(events, " AND "), true, &page, &limit, "")
+	if err != nil {
+		return nil, err
+	}
+	return res.Txs, nil
+}
+
+// QueryBalance returns the amount of coins in the relayer account
+func (cc *CosmosProvider) QueryBalance(keyName string) (sdk.Coins, error) {
+	var (
+		addr string
+		err  error
+	)
+	if keyName == "" {
+		addr, err = cc.Address()
+	} else {
+		cc.Config.Key = keyName
+		addr, err = cc.Address()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return cc.QueryBalanceWithAddress(addr)
+}
+
+// QueryBalanceWithAddress returns the amount of coins in the relayer account with address as input
+// TODO add pagination support
+func (cc *CosmosProvider) QueryBalanceWithAddress(address string) (sdk.Coins, error) {
+	p := &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: DefaultPageRequest()}
+	queryClient := bankTypes.NewQueryClient(cc)
+
+	res, err := queryClient.AllBalances(context.Background(), p)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Balances, nil
+}
+
+// QueryUnbondingPeriod returns the unbonding period of the chain
+func (cc *CosmosProvider) QueryUnbondingPeriod() (time.Duration, error) {
+	req := stakingtypes.QueryParamsRequest{}
+	queryClient := stakingtypes.NewQueryClient(cc)
+
+	res, err := queryClient.Params(context.Background(), &req)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.Params.UnbondingTime, nil
+}
+
+// QueryTendermintProof performs an ABCI query with the given key and returns
+// the value of the query, the proto encoded merkle proof, and the height of
+// the Tendermint block containing the state root. The desired tendermint height
+// to perform the query should be set in the client context. The query will be
+// performed at one below this height (at the IAVL version) in order to obtain
+// the correct merkle proof. Proof queries at height less than or equal to 2 are
+// not supported. Queries with a client context height of 0 will perform a query
+// at the lastest state available.
+// Issue: https://github.com/cosmos/cosmos-sdk/issues/6567
+func (cc *CosmosProvider) QueryTendermintProof(height int64, key []byte) ([]byte, []byte, clienttypes.Height, error) {
+	// ABCI queries at heights 1, 2 or less than or equal to 0 are not supported.
+	// Base app does not support queries for height less than or equal to 1.
+	// Therefore, a query at height 2 would be equivalent to a query at height 3.
+	// A height of 0 will query with the lastest state.
+	if height != 0 && height <= 2 {
+		return nil, nil, clienttypes.Height{}, fmt.Errorf("proof queries at height <= 2 are not supported")
+	}
+
+	// Use the IAVL height if a valid tendermint height is passed in.
+	// A height of 0 will query with the latest state.
+	if height != 0 {
+		height--
+	}
+
+	req := abci.RequestQuery{
+		Path:   fmt.Sprintf("store/%s/key", host.StoreKey),
+		Height: height,
+		Data:   key,
+		Prove:  true,
+	}
+
+	res, err := cc.QueryABCI(req)
+	if err != nil {
+		return nil, nil, clienttypes.Height{}, err
+	}
+
+	merkleProof, err := commitmenttypes.ConvertProofs(res.ProofOps)
+	if err != nil {
+		return nil, nil, clienttypes.Height{}, err
+	}
+
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	proofBz, err := cdc.Marshal(&merkleProof)
+	if err != nil {
+		return nil, nil, clienttypes.Height{}, err
+	}
+
+	revision := clienttypes.ParseChainID(cc.Config.ChainID)
+	return res.Value, proofBz, clienttypes.NewHeight(revision, uint64(res.Height)+1), nil
+}
+
+// QueryClientStateResponse retrieves the latest consensus state for a client in state at a given height
+func (cc *CosmosProvider) QueryClientStateResponse(height int64, srcClientId string) (*clienttypes.QueryClientStateResponse, error) {
+	key := host.FullClientStateKey(srcClientId)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if client exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrap(clienttypes.ErrClientNotFound, srcClientId)
+	}
+
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	clientState, err := clienttypes.UnmarshalClientState(cdc, value)
+	if err != nil {
+		return nil, err
+	}
+
+	anyClientState, err := clienttypes.PackClientState(clientState)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clienttypes.QueryClientStateResponse{
+		ClientState: anyClientState,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+// QueryClientState retrieves the latest consensus state for a client in state at a given height
+// and unpacks it to exported client state interface
+func (cc *CosmosProvider) QueryClientState(height int64, clientid string) (ibcexported.ClientState, error) {
+	clientStateRes, err := cc.QueryClientStateResponse(height, clientid)
+	if err != nil {
+		return nil, err
+	}
+
+	clientStateExported, err := clienttypes.UnpackClientState(clientStateRes.ClientState)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientStateExported, nil
+}
+
+// QueryClientConsensusState retrieves the latest consensus state for a client in state at a given height
+func (cc *CosmosProvider) QueryClientConsensusState(chainHeight int64, clientid string, clientHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error) {
+	key := host.FullConsensusStateKey(clientid, clientHeight)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(chainHeight, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if consensus state exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrap(clienttypes.ErrConsensusStateNotFound, clientid)
+	}
+
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	cs, err := clienttypes.UnmarshalConsensusState(cdc, value)
+	if err != nil {
+		return nil, err
+	}
+
+	anyConsensusState, err := clienttypes.PackConsensusState(cs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clienttypes.QueryConsensusStateResponse{
+		ConsensusState: anyConsensusState,
+		Proof:          proofBz,
+		ProofHeight:    proofHeight,
+	}, nil
+}
+
+//DefaultUpgradePath is the default IBC upgrade path set for an on-chain light client
+var defaultUpgradePath = []string{"upgrade", "upgradedIBCState"}
+
+func (cc *CosmosProvider) NewClientState(dstUpdateHeader ibcexported.Header, dstTrustingPeriod, dstUbdPeriod time.Duration, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour bool) (ibcexported.ClientState, error) {
+	dstTmHeader, ok := dstUpdateHeader.(*tmclient.Header)
+	if !ok {
+		return nil, fmt.Errorf("got data of type %T but wanted  tmclient.Header \n", dstUpdateHeader)
+	}
+
+	// Create the ClientState we want on 'c' tracking 'dst'
+	return &tmclient.ClientState{
+		ChainId:                      dstTmHeader.GetHeader().GetChainID(),
+		TrustLevel:                   tmclient.NewFractionFromTm(light.DefaultTrustLevel),
+		TrustingPeriod:               dstTrustingPeriod,
+		UnbondingPeriod:              dstUbdPeriod,
+		MaxClockDrift:                time.Minute * 10,
+		FrozenHeight:                 clienttypes.ZeroHeight(),
+		LatestHeight:                 dstUpdateHeader.GetHeight().(clienttypes.Height),
+		ProofSpecs:                   committypes.GetSDKSpecs(),
+		UpgradePath:                  defaultUpgradePath,
+		AllowUpdateAfterExpiry:       allowUpdateAfterExpiry,
+		AllowUpdateAfterMisbehaviour: allowUpdateAfterMisbehaviour,
+	}, nil
+}
+
+// QueryUpgradeProof performs an abci query with the given key and returns the proto encoded merkle proof
+// for the query and the height at which the proof will succeed on a tendermint verifier.
+func (cc *CosmosProvider) QueryUpgradeProof(key []byte, height uint64) ([]byte, clienttypes.Height, error) {
+	res, err := cc.QueryABCI(abci.RequestQuery{
+		Path:   "store/upgrade/key",
+		Height: int64(height - 1),
+		Data:   key,
+		Prove:  true,
+	})
+	if err != nil {
+		return nil, clienttypes.Height{}, err
+	}
+
+	merkleProof, err := committypes.ConvertProofs(res.ProofOps)
+	if err != nil {
+		return nil, clienttypes.Height{}, err
+	}
+
+	proof, err := cc.Codec.Marshaler.Marshal(&merkleProof)
+	if err != nil {
+		return nil, clienttypes.Height{}, err
+	}
+
+	revision := clienttypes.ParseChainID(cc.Config.ChainID)
+
+	// proof height + 1 is returned as the proof created corresponds to the height the proof
+	// was created in the IAVL tree. Tendermint and subsequently the clients that rely on it
+	// have heights 1 above the IAVL tree. Thus we return proof height + 1
+	return proof, clienttypes.Height{
+		RevisionNumber: revision,
+		RevisionHeight: uint64(res.Height + 1),
+	}, nil
+}
+
+// QueryUpgradedClient returns upgraded client info
+func (cc *CosmosProvider) QueryUpgradedClient(height int64) (*clienttypes.QueryClientStateResponse, error) {
+	req := clienttypes.QueryUpgradedClientStateRequest{}
+
+	queryClient := clienttypes.NewQueryClient(cc)
+
+	res, err := queryClient.UpgradedClientState(context.Background(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil || res.UpgradedClientState == nil {
+		return nil, fmt.Errorf("upgraded client state plan does not exist at height %d", height)
+	}
+
+	proof, proofHeight, err := cc.QueryUpgradeProof(upgradetypes.UpgradedClientKey(height), uint64(height))
+	if err != nil {
+		return nil, err
+	}
+
+	return &clienttypes.QueryClientStateResponse{
+		ClientState: res.UpgradedClientState,
+		Proof:       proof,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+// QueryUpgradedConsState returns upgraded consensus state and height of client
+func (cc *CosmosProvider) QueryUpgradedConsState(height int64) (*clienttypes.QueryConsensusStateResponse, error) {
+	req := clienttypes.QueryUpgradedConsensusStateRequest{}
+
+	queryClient := clienttypes.NewQueryClient(cc)
+
+	res, err := queryClient.UpgradedConsensusState(context.Background(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil || res.UpgradedConsensusState == nil {
+		return nil, fmt.Errorf("upgraded consensus state plan does not exist at height %d", height)
+	}
+
+	proof, proofHeight, err := cc.QueryUpgradeProof(upgradetypes.UpgradedConsStateKey(height), uint64(height))
+	if err != nil {
+		return nil, err
+	}
+
+	return &clienttypes.QueryConsensusStateResponse{
+		ConsensusState: res.UpgradedConsensusState,
+		Proof:          proof,
+		ProofHeight:    proofHeight,
+	}, nil
+}
+
+// QueryConsensusState returns a consensus state for a given chain to be used as a
+// client in another chain, fetches latest height when passed 0 as arg
+func (cc *CosmosProvider) QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error) {
+	commit, err := cc.RPCClient.Commit(context.Background(), &height)
+	if err != nil {
+		return &ibctmtypes.ConsensusState{}, 0, err
+	}
+
+	page := 1
+	count := 10_000
+
+	nextHeight := height + 1
+	nextVals, err := cc.RPCClient.Validators(context.Background(), &nextHeight, &page, &count)
+	if err != nil {
+		return &ibctmtypes.ConsensusState{}, 0, err
+	}
+
+	state := &ibctmtypes.ConsensusState{
+		Timestamp:          commit.Time,
+		Root:               commitmenttypes.NewMerkleRoot(commit.AppHash),
+		NextValidatorsHash: tmtypes.NewValidatorSet(nextVals.Validators).Hash(),
+	}
+
+	return state, height, nil
+}
+
+// QueryClients queries all the clients!
+// TODO add pagination support
+func (cc *CosmosProvider) QueryClients() (clienttypes.IdentifiedClientStates, error) {
+	qc := clienttypes.NewQueryClient(cc)
+	state, err := qc.ClientStates(context.Background(), &clienttypes.QueryClientStatesRequest{
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return state.ClientStates, nil
+}
+
+// QueryConnection returns the remote end of a given connection
+func (cc *CosmosProvider) QueryConnection(height int64, connectionid string) (*conntypes.QueryConnectionResponse, error) {
+	res, err := cc.queryConnectionABCI(height, connectionid)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return &conntypes.QueryConnectionResponse{
+			Connection: &conntypes.ConnectionEnd{
+				ClientId: "client",
+				Versions: []*conntypes.Version{},
+				State:    conntypes.UNINITIALIZED,
+				Counterparty: conntypes.Counterparty{
+					ClientId:     "client",
+					ConnectionId: "connection",
+					Prefix:       committypes.MerklePrefix{KeyPrefix: []byte{}},
+				},
+				DelayPeriod: 0,
+			},
+			Proof:       []byte{},
+			ProofHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 0},
+		}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (cc *CosmosProvider) queryConnectionABCI(height int64, connectionID string) (*conntypes.QueryConnectionResponse, error) {
+	key := host.ConnectionKey(connectionID)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if connection exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrap(conntypes.ErrConnectionNotFound, connectionID)
+	}
+
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	var connection conntypes.ConnectionEnd
+	if err := cdc.Unmarshal(value, &connection); err != nil {
+		return nil, err
+	}
+
+	return &conntypes.QueryConnectionResponse{
+		Connection:  &connection,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+// QueryConnections gets any connections on a chain
+// TODO add pagination support
+func (cc *CosmosProvider) QueryConnections() (conns []*conntypes.IdentifiedConnection, err error) {
+	qc := conntypes.NewQueryClient(cc)
+	res, err := qc.Connections(context.Background(), &conntypes.QueryConnectionsRequest{
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil || res == nil {
+		return nil, err
+	}
+	return res.Connections, err
+}
+
+// QueryConnectionsUsingClient gets any connections that exist between chain and counterparty
+// TODO add pagination support
+func (cc *CosmosProvider) QueryConnectionsUsingClient(height int64, clientid string) (*conntypes.QueryConnectionsResponse, error) {
+	qc := conntypes.NewQueryClient(cc)
+	res, err := qc.Connections(context.Background(), &conntypes.QueryConnectionsRequest{
+		Pagination: DefaultPageRequest(),
+	})
+	return res, err
+}
+
+// GenerateConnHandshakeProof generates all the proofs needed to prove the existence of the
+// connection state on this chain. A counterparty should use these generated proofs.
+func (cc *CosmosProvider) GenerateConnHandshakeProof(height int64, clientId, connId string) (clientState ibcexported.ClientState, clientStateProof []byte, consensusProof []byte, connectionProof []byte, connectionProofHeight ibcexported.Height, err error) {
+	var (
+		clientStateRes     *clienttypes.QueryClientStateResponse
+		consensusStateRes  *clienttypes.QueryConsensusStateResponse
+		connectionStateRes *conntypes.QueryConnectionResponse
+		eg                 = new(errgroup.Group)
+	)
+
+	// query for the client state for the proof and get the height to query the consensus state at.
+	clientStateRes, err = cc.QueryClientStateResponse(height, clientId)
+	if err != nil {
+		return nil, nil, nil, nil, clienttypes.Height{}, err
+	}
+
+	clientState, err = clienttypes.UnpackClientState(clientStateRes.ClientState)
+	if err != nil {
+		return nil, nil, nil, nil, clienttypes.Height{}, err
+	}
+
+	eg.Go(func() error {
+		var err error
+		consensusStateRes, err = cc.QueryClientConsensusState(height, clientId, clientState.GetLatestHeight())
+		return err
+	})
+	eg.Go(func() error {
+		var err error
+		connectionStateRes, err = cc.QueryConnection(height, connId)
+		return err
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, nil, nil, nil, clienttypes.Height{}, err
+	}
+
+	return clientState, clientStateRes.Proof, consensusStateRes.Proof, connectionStateRes.Proof, connectionStateRes.ProofHeight, nil
+}
+
+// QueryChannel returns the channel associated with a channelID
+func (cc *CosmosProvider) QueryChannel(height int64, channelid, portid string) (chanRes *chantypes.QueryChannelResponse, err error) {
+	res, err := cc.queryChannelABCI(height, portid, channelid)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+
+		return &chantypes.QueryChannelResponse{
+			Channel: &chantypes.Channel{
+				State:    chantypes.UNINITIALIZED,
+				Ordering: chantypes.UNORDERED,
+				Counterparty: chantypes.Counterparty{
+					PortId:    "port",
+					ChannelId: "channel",
+				},
+				ConnectionHops: []string{},
+				Version:        "version",
+			},
+			Proof: []byte{},
+			ProofHeight: clienttypes.Height{
+				RevisionNumber: 0,
+				RevisionHeight: 0,
+			},
+		}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (cc *CosmosProvider) queryChannelABCI(height int64, portID, channelID string) (*chantypes.QueryChannelResponse, error) {
+	key := host.ChannelKey(portID, channelID)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if channel exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrapf(chantypes.ErrChannelNotFound, "portID (%s), channelID (%s)", portID, channelID)
+	}
+
+	cdc := codec.NewProtoCodec(cc.Codec.InterfaceRegistry)
+
+	var channel chantypes.Channel
+	if err := cdc.Unmarshal(value, &channel); err != nil {
+		return nil, err
+	}
+
+	return &chantypes.QueryChannelResponse{
+		Channel:     &channel,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+// QueryChannelClient returns the client state of the client supporting a given channel
+func (cc *CosmosProvider) QueryChannelClient(height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error) {
+	qc := chantypes.NewQueryClient(cc)
+	cState, err := qc.ChannelClientState(context.Background(), &chantypes.QueryChannelClientStateRequest{
+		PortId:    portid,
+		ChannelId: channelid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cState.IdentifiedClientState, nil
+}
+
+// QueryConnectionChannels queries the channels associated with a connection
+func (cc *CosmosProvider) QueryConnectionChannels(height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error) {
+	qc := chantypes.NewQueryClient(cc)
+	chans, err := qc.ConnectionChannels(context.Background(), &chantypes.QueryConnectionChannelsRequest{
+		Connection: connectionid,
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return chans.Channels, nil
+}
+
+// QueryChannels returns all the channels that are registered on a chain
+// TODO add pagination support
+func (cc *CosmosProvider) QueryChannels() ([]*chantypes.IdentifiedChannel, error) {
+	qc := chantypes.NewQueryClient(cc)
+	res, err := qc.Channels(context.Background(), &chantypes.QueryChannelsRequest{
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Channels, err
+}
+
+// QueryPacketCommitments returns an array of packet commitments
+// TODO add pagination support
+func (cc *CosmosProvider) QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error) {
+	qc := chantypes.NewQueryClient(cc)
+	c, err := qc.PacketCommitments(context.Background(), &chantypes.QueryPacketCommitmentsRequest{
+		PortId:     portid,
+		ChannelId:  channelid,
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// QueryPacketAcknowledgements returns an array of packet acks
+// TODO add pagination support
+func (cc *CosmosProvider) QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error) {
+	qc := chantypes.NewQueryClient(cc)
+	acks, err := qc.PacketAcknowledgements(context.Background(), &chantypes.QueryPacketAcknowledgementsRequest{
+		PortId:     portid,
+		ChannelId:  channelid,
+		Pagination: DefaultPageRequest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return acks.Acknowledgements, nil
+}
+
+// QueryUnreceivedPackets returns a list of unrelayed packet commitments
+func (cc *CosmosProvider) QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
+	qc := chantypes.NewQueryClient(cc)
+	res, err := qc.UnreceivedPackets(context.Background(), &chantypes.QueryUnreceivedPacketsRequest{
+		PortId:                    portid,
+		ChannelId:                 channelid,
+		PacketCommitmentSequences: seqs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Sequences, nil
+}
+
+// QueryUnreceivedAcknowledgements returns a list of unrelayed packet acks
+func (cc *CosmosProvider) QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
+	qc := chantypes.NewQueryClient(cc)
+	res, err := qc.UnreceivedAcks(context.Background(), &chantypes.QueryUnreceivedAcksRequest{
+		PortId:             portid,
+		ChannelId:          channelid,
+		PacketAckSequences: seqs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Sequences, nil
+}
+
+// QueryNextSeqRecv returns the next seqRecv for a configured channel
+func (cc *CosmosProvider) QueryNextSeqRecv(height int64, channelid, portid string) (recvRes *chantypes.QueryNextSequenceReceiveResponse, err error) {
+	key := host.NextSequenceRecvKey(portid, channelid)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if next sequence receive exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrapf(chantypes.ErrChannelNotFound, "portID (%s), channelID (%s)", portid, channelid)
+	}
+
+	sequence := binary.BigEndian.Uint64(value)
+
+	return &chantypes.QueryNextSequenceReceiveResponse{
+		NextSequenceReceive: sequence,
+		Proof:               proofBz,
+		ProofHeight:         proofHeight,
+	}, nil
+}
+
+// QueryPacketCommitment returns the packet commitment proof at a given height
+func (cc *CosmosProvider) QueryPacketCommitment(height int64, channelid, portid string, seq uint64) (comRes *chantypes.QueryPacketCommitmentResponse, err error) {
+	key := host.PacketCommitmentKey(portid, channelid, seq)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if packet commitment exists
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrapf(chantypes.ErrPacketCommitmentNotFound, "portID (%s), channelID (%s), sequence (%d)", portid, channelid, seq)
+	}
+
+	return &chantypes.QueryPacketCommitmentResponse{
+		Commitment:  value,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+// QueryPacketAcknowledgement returns the packet ack proof at a given height
+func (cc *CosmosProvider) QueryPacketAcknowledgement(height int64, channelid, portid string, seq uint64) (ackRes *chantypes.QueryPacketAcknowledgementResponse, err error) {
+	key := host.PacketAcknowledgementKey(portid, channelid, seq)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(value) == 0 {
+		return nil, sdkerrors.Wrapf(chantypes.ErrInvalidAcknowledgement, "portID (%s), channelID (%s), sequence (%d)", portid, channelid, seq)
+	}
+
+	return &chantypes.QueryPacketAcknowledgementResponse{
+		Acknowledgement: value,
+		Proof:           proofBz,
+		ProofHeight:     proofHeight,
+	}, nil
+}
+
+// QueryPacketReceipt returns the packet receipt proof at a given height
+func (cc *CosmosProvider) QueryPacketReceipt(height int64, channelid, portid string, seq uint64) (recRes *chantypes.QueryPacketReceiptResponse, err error) {
+	key := host.PacketReceiptKey(portid, channelid, seq)
+
+	value, proofBz, proofHeight, err := cc.QueryTendermintProof(height, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chantypes.QueryPacketReceiptResponse{
+		Received:    value != nil,
+		Proof:       proofBz,
+		ProofHeight: proofHeight,
+	}, nil
+}
+
+func (cc *CosmosProvider) QueryLatestHeight() (int64, error) {
+	stat, err := cc.RPCClient.Status(context.Background())
+	if err != nil {
+		return -1, err
+	} else if stat.SyncInfo.CatchingUp {
+		return -1, fmt.Errorf("node at %s running chain %s not caught up", cc.Config.RPCAddr, cc.Config.ChainID)
+	}
+	return stat.SyncInfo.LatestBlockHeight, nil
+}
+
+// QueryHeaderAtHeight returns the header at a given height
+func (cc *CosmosProvider) QueryHeaderAtHeight(height int64) (ibcexported.Header, error) {
+	var (
+		page    = 1
+		perPage = 100000
+	)
+	if height <= 0 {
+		return nil, fmt.Errorf("must pass in valid height, %d not valid", height)
+	}
+
+	res, err := cc.RPCClient.Commit(context.Background(), &height)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := cc.RPCClient.Validators(context.Background(), &height, &page, &perPage)
+	if err != nil {
+		return nil, err
+	}
+
+	protoVal, err := tmtypes.NewValidatorSet(val.Validators).ToProto()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tmclient.Header{
+		// NOTE: This is not a SignedHeader
+		// We are missing a light.Commit type here
+		SignedHeader: res.SignedHeader.ToProto(),
+		ValidatorSet: protoVal,
+	}, nil
+}
+
+// QueryDenomTrace takes a denom from IBC and queries the information about it
+func (cc *CosmosProvider) QueryDenomTrace(denom string) (*transfertypes.DenomTrace, error) {
+	transfers, err := transfertypes.NewQueryClient(cc).DenomTrace(context.Background(),
+		&transfertypes.QueryDenomTraceRequest{
+			Hash: denom,
+		})
+	if err != nil {
+		return nil, err
+	}
+	return transfers.DenomTrace, nil
+}
+
+// QueryDenomTraces returns all the denom traces from a given chain
+// TODO add pagination support
+func (cc *CosmosProvider) QueryDenomTraces(offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error) {
+	transfers, err := transfertypes.NewQueryClient(cc).DenomTraces(context.Background(),
+		&transfertypes.QueryDenomTracesRequest{
+			Pagination: DefaultPageRequest(),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return transfers.DenomTraces, nil
+}
+
+// QueryDenomTraces returns all the denom traces from a given chain
+//func (cc *CosmosProvider) QueryDenomTraces(pageReq *querytypes.PageRequest, height int64) (*transfertypes.QueryDenomTracesResponse, error) {
+//	ctx := SetHeightOnContext(context.Background(), height)
+//	return transfertypes.NewQueryClient(cc).DenomTraces(ctx, &transfertypes.QueryDenomTracesRequest{
+//		Pagination: pageReq,
+//	})
+//}
+
+func (cc *CosmosProvider) QueryAccount(address sdk.AccAddress) (authtypes.AccountI, error) {
+	addr, err := cc.EncodeBech32AccAddr(address)
+	if err != nil {
+		return nil, err
+	}
+	res, err := authtypes.NewQueryClient(cc).Account(context.Background(), &authtypes.QueryAccountRequest{Address: addr})
+	if err != nil {
+		return nil, err
+	}
+	var acc authtypes.AccountI
+	if err := cc.Codec.InterfaceRegistry.UnpackAny(res.Account, &acc); err != nil {
+		return nil, err
+	}
+	return acc, nil
+}
+
+// QueryBalanceWithDenomTraces is a helper function for query balance
+func (cc *CosmosProvider) QueryBalanceWithDenomTraces(ctx context.Context, address sdk.AccAddress, pageReq *query.PageRequest) (sdk.Coins, error) {
+	coins, err := cc.QueryBalanceWithAddress(cc.MustEncodeAccAddr(address))
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := cc.QueryLatestHeight()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: figure out how to handle this
+	// we don't want to expose user to this
+	// so maybe we need a QueryAllDenomTraces function
+	// that will paginate the responses automatically
+	// TODO fix pagination here later
+	dts, err := cc.QueryDenomTraces(0, 1000, h)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(dts) == 0 {
+		return coins, nil
+	}
+
+	var out sdk.Coins
+	for _, c := range coins {
+		if c.Amount.Equal(sdk.NewInt(0)) {
+			continue
+		}
+
+		for i, d := range dts {
+			if c.Denom == d.IBCDenom() {
+				out = append(out, sdk.Coin{Denom: d.GetFullDenomPath(), Amount: c.Amount})
+				break
+			}
+
+			if i == len(dts)-1 {
+				out = append(out, c)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (cc *CosmosProvider) QueryDelegatorValidators(ctx context.Context, address sdk.AccAddress) ([]string, error) {
+	res, err := distTypes.NewQueryClient(cc).DelegatorValidators(ctx, &distTypes.QueryDelegatorValidatorsRequest{
+		DelegatorAddress: cc.MustEncodeAccAddr(address),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Validators, nil
+}
+
+func (cc *CosmosProvider) QueryDistributionCommission(ctx context.Context, address sdk.ValAddress) (sdk.DecCoins, error) {
+	valAddr, err := cc.EncodeBech32ValAddr(address)
+	if err != nil {
+		return nil, err
+	}
+	request := distTypes.QueryValidatorCommissionRequest{
+		ValidatorAddress: valAddr,
+	}
+	res, err := distTypes.NewQueryClient(cc).ValidatorCommission(ctx, &request)
+	if err != nil {
+		return nil, err
+	}
+	return res.Commission.Commission, nil
+}
+
+func (cc *CosmosProvider) QueryDistributionCommunityPool(ctx context.Context) (sdk.DecCoins, error) {
+	res, err := distTypes.NewQueryClient(cc).CommunityPool(ctx, &distTypes.QueryCommunityPoolRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return res.Pool, err
+}
+
+func (cc *CosmosProvider) QueryDistributionParams(ctx context.Context) (*distTypes.Params, error) {
+	res, err := distTypes.NewQueryClient(cc).Params(ctx, &distTypes.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return &res.Params, nil
+}
+
+func (cc *CosmosProvider) QueryDistributionRewards(ctx context.Context, delegatorAddress sdk.AccAddress, validatorAddress sdk.ValAddress) (sdk.DecCoins, error) {
+	delAddr, err := cc.EncodeBech32AccAddr(delegatorAddress)
+	if err != nil {
+		return nil, err
+	}
+	valAddr, err := cc.EncodeBech32ValAddr(validatorAddress)
+	if err != nil {
+		return nil, err
+	}
+	request := distTypes.QueryDelegationRewardsRequest{
+		DelegatorAddress: delAddr,
+		ValidatorAddress: valAddr,
+	}
+	res, err := distTypes.NewQueryClient(cc).DelegationRewards(ctx, &request)
+	if err != nil {
+		return nil, err
+	}
+	return res.Rewards, nil
+}
+
+// QueryDistributionSlashes returns all slashes of a validator, optionally pass the start and end height
+func (cc *CosmosProvider) QueryDistributionSlashes(ctx context.Context, validatorAddress sdk.ValAddress, startHeight, endHeight uint64, pageReq *querytypes.PageRequest) (*distTypes.QueryValidatorSlashesResponse, error) {
+	valAddr, err := cc.EncodeBech32ValAddr(validatorAddress)
+	if err != nil {
+		return nil, err
+	}
+	request := distTypes.QueryValidatorSlashesRequest{
+		ValidatorAddress: valAddr,
+		StartingHeight:   startHeight,
+		EndingHeight:     endHeight,
+		Pagination:       pageReq,
+	}
+	return distTypes.NewQueryClient(cc).ValidatorSlashes(ctx, &request)
+}
+
+// QueryDistributionValidatorRewards returns all the validator distribution rewards from a given height
+func (cc *CosmosProvider) QueryDistributionValidatorRewards(ctx context.Context, validatorAddress sdk.ValAddress) (sdk.DecCoins, error) {
+	valAddr, err := cc.EncodeBech32ValAddr(validatorAddress)
+	if err != nil {
+		return nil, err
+	}
+	request := distTypes.QueryValidatorOutstandingRewardsRequest{
+		ValidatorAddress: valAddr,
+	}
+	res, err := distTypes.NewQueryClient(cc).ValidatorOutstandingRewards(ctx, &request)
+	if err != nil {
+		return nil, err
+	}
+	return res.Rewards.Rewards, nil
+}
+
+// QueryTotalSupply returns the total supply of coins on a chain
+func (cc *CosmosProvider) QueryTotalSupply(ctx context.Context, pageReq *query.PageRequest) (*bankTypes.QueryTotalSupplyResponse, error) {
+	return bankTypes.NewQueryClient(cc).TotalSupply(ctx, &bankTypes.QueryTotalSupplyRequest{Pagination: pageReq})
+}
+
+func (cc *CosmosProvider) QueryDenomsMetadata(ctx context.Context, pageReq *query.PageRequest) (*bankTypes.QueryDenomsMetadataResponse, error) {
+	return bankTypes.NewQueryClient(cc).DenomsMetadata(ctx, &bankTypes.QueryDenomsMetadataRequest{Pagination: pageReq})
+}
+
+func (cc *CosmosProvider) QueryStakingParams(ctx context.Context) (*stakingtypes.Params, error) {
+	res, err := stakingtypes.NewQueryClient(cc).Params(ctx, &stakingtypes.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return &res.Params, nil
+}
+
+func DefaultPageRequest() *querytypes.PageRequest {
+	return &querytypes.PageRequest{
+		Key:        []byte(""),
+		Offset:     0,
+		Limit:      1000,
+		CountTotal: true,
+	}
+}

--- a/relayer/provider/cosmos/relayer_packets.go
+++ b/relayer/provider/cosmos/relayer_packets.go
@@ -1,0 +1,232 @@
+package cosmos
+
+import (
+	"fmt"
+	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	chantypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
+	"github.com/cosmos/relayer/relayer/provider"
+)
+
+var (
+	_ provider.RelayPacket = relayMsgTimeout{}
+	_ provider.RelayPacket = relayMsgRecvPacket{}
+	_ provider.RelayPacket = relayMsgPacketAck{}
+)
+
+type relayMsgTimeout struct {
+	packetData   []byte
+	seq          uint64
+	timeout      clienttypes.Height
+	timeoutStamp uint64
+	dstRecvRes   *chantypes.QueryPacketReceiptResponse
+
+	pass bool
+}
+
+func (rp relayMsgTimeout) Data() []byte {
+	return rp.packetData
+}
+
+func (rp relayMsgTimeout) Seq() uint64 {
+	return rp.seq
+}
+
+func (rp relayMsgTimeout) Timeout() clienttypes.Height {
+	return rp.timeout
+}
+
+func (rp relayMsgTimeout) TimeoutStamp() uint64 {
+	return rp.timeoutStamp
+}
+
+func (rp relayMsgTimeout) FetchCommitResponse(dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
+	dstRecvRes, err := dst.QueryPacketReceipt(int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+	switch {
+	case err != nil:
+		return err
+	case dstRecvRes.Proof == nil:
+		return fmt.Errorf("timeout packet receipt proof seq(%d) is nil", rp.seq)
+	default:
+		rp.dstRecvRes = dstRecvRes
+		return nil
+	}
+}
+
+func (rp relayMsgTimeout) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+	if rp.dstRecvRes == nil {
+		return nil, fmt.Errorf("timeout packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
+	}
+	addr, err := src.Address()
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgTimeout{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         srcPortId,
+			SourceChannel:      srcChanId,
+			DestinationPort:    dstPortId,
+			DestinationChannel: dstChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		ProofUnreceived:  rp.dstRecvRes.Proof,
+		ProofHeight:      rp.dstRecvRes.ProofHeight,
+		NextSequenceRecv: rp.seq,
+		Signer:           addr,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+type relayMsgRecvPacket struct {
+	packetData   []byte
+	seq          uint64
+	timeout      clienttypes.Height
+	timeoutStamp uint64
+	dstComRes    *chantypes.QueryPacketCommitmentResponse
+
+	pass bool
+}
+
+func (rp relayMsgRecvPacket) timeoutPacket() *relayMsgTimeout {
+	return &relayMsgTimeout{
+		packetData:   rp.packetData,
+		seq:          rp.seq,
+		timeout:      rp.timeout,
+		timeoutStamp: rp.timeoutStamp,
+		dstRecvRes:   nil,
+		pass:         false,
+	}
+}
+
+func (rp relayMsgRecvPacket) Data() []byte {
+	return rp.packetData
+}
+
+func (rp relayMsgRecvPacket) Seq() uint64 {
+	return rp.seq
+}
+
+func (rp relayMsgRecvPacket) Timeout() clienttypes.Height {
+	return rp.timeout
+}
+
+func (rp relayMsgRecvPacket) TimeoutStamp() uint64 {
+	return rp.timeoutStamp
+}
+
+func (rp relayMsgRecvPacket) FetchCommitResponse(dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
+	dstCommitRes, err := dst.QueryPacketCommitment(int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+	switch {
+	case err != nil:
+		return err
+	case dstCommitRes.Proof == nil:
+		return fmt.Errorf("recv packet commitment proof seq(%d) is nil", rp.seq)
+	case dstCommitRes.Commitment == nil:
+		return fmt.Errorf("recv packet commitment query seq(%d) is nil", rp.seq)
+	default:
+		rp.dstComRes = dstCommitRes
+		return nil
+	}
+}
+
+func (rp relayMsgRecvPacket) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+	if rp.dstComRes == nil {
+		return nil, fmt.Errorf("receive packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
+	}
+	addr, err := src.Address()
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgRecvPacket{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         dstPortId,
+			SourceChannel:      dstChanId,
+			DestinationPort:    srcPortId,
+			DestinationChannel: srcChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		ProofCommitment: rp.dstComRes.Proof,
+		ProofHeight:     rp.dstComRes.ProofHeight,
+		Signer:          addr,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+type relayMsgPacketAck struct {
+	packetData   []byte
+	ack          []byte
+	seq          uint64
+	timeout      clienttypes.Height
+	timeoutStamp uint64
+	dstComRes    *chantypes.QueryPacketAcknowledgementResponse
+
+	pass bool
+}
+
+func (rp relayMsgPacketAck) Data() []byte {
+	return rp.packetData
+}
+func (rp relayMsgPacketAck) Seq() uint64 {
+	return rp.seq
+}
+func (rp relayMsgPacketAck) Timeout() clienttypes.Height {
+	return rp.timeout
+}
+
+func (rp relayMsgPacketAck) TimeoutStamp() uint64 {
+	return rp.timeoutStamp
+}
+
+func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+	if rp.dstComRes == nil {
+		return nil, fmt.Errorf("ack packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
+	}
+
+	addr, err := src.Address()
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &chantypes.MsgAcknowledgement{
+		Packet: chantypes.Packet{
+			Sequence:           rp.seq,
+			SourcePort:         srcPortId,
+			SourceChannel:      srcChanId,
+			DestinationPort:    dstPortId,
+			DestinationChannel: dstChanId,
+			Data:               rp.packetData,
+			TimeoutHeight:      rp.timeout,
+			TimeoutTimestamp:   rp.timeoutStamp,
+		},
+		Acknowledgement: rp.ack,
+		ProofAcked:      rp.dstComRes.Proof,
+		ProofHeight:     rp.dstComRes.ProofHeight,
+		Signer:          addr,
+	}
+
+	return NewCosmosMessage(msg), nil
+}
+
+func (rp relayMsgPacketAck) FetchCommitResponse(dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
+	dstCommitRes, err := dst.QueryPacketAcknowledgement(int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+	switch {
+	case err != nil:
+		return err
+	case dstCommitRes.Proof == nil:
+		return fmt.Errorf("ack packet acknowledgement proof seq(%d) is nil", rp.seq)
+	case dstCommitRes.Acknowledgement == nil:
+		return fmt.Errorf("ack packet acknowledgement query seq(%d) is nil", rp.seq)
+	default:
+		rp.dstComRes = dstCommitRes
+		return nil
+	}
+}

--- a/relayer/provider/cosmos/relayer_packets.go
+++ b/relayer/provider/cosmos/relayer_packets.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"fmt"
+
 	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
 	chantypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/relayer/provider"

--- a/test/test_chains.go
+++ b/test/test_chains.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/relayer/relayer"
+	"github.com/cosmos/relayer/relayer/provider/cosmos"
 	dc "github.com/ory/dockertest/v3/docker"
-	lens "github.com/strangelove-ventures/lens/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,16 +22,14 @@ const (
 )
 
 var (
-	gaiaProviderCfg = lens.ChainClientConfig{
+	gaiaProviderCfg = cosmos.CosmosProviderConfig{
 		Key:            "",
 		ChainID:        "",
 		RPCAddr:        "",
-		GRPCAddr:       "",
 		AccountPrefix:  "cosmos",
 		KeyringBackend: "test",
 		GasAdjustment:  1.3,
 		GasPrices:      "0.00samoleans",
-		KeyDirectory:   "",
 		Debug:          true,
 		Timeout:        "10s",
 		OutputFormat:   "json",
@@ -45,16 +43,14 @@ var (
 		},
 	}
 
-	akashProviderCfg = lens.ChainClientConfig{
+	akashProviderCfg = cosmos.CosmosProviderConfig{
 		Key:            "",
 		ChainID:        "",
 		RPCAddr:        "",
-		GRPCAddr:       "",
 		AccountPrefix:  "akash",
 		KeyringBackend: "test",
 		GasAdjustment:  1.3,
 		GasPrices:      "0.00samoleans",
-		KeyDirectory:   "",
 		Debug:          true,
 		Timeout:        "10s",
 		OutputFormat:   "json",
@@ -68,16 +64,14 @@ var (
 		},
 	}
 
-	osmosisProviderCfg = lens.ChainClientConfig{
+	osmosisProviderCfg = cosmos.CosmosProviderConfig{
 		Key:            "",
 		ChainID:        "",
 		RPCAddr:        "",
-		GRPCAddr:       "",
 		AccountPrefix:  "osmo",
 		KeyringBackend: "test",
 		GasAdjustment:  1.3,
 		GasPrices:      "0.00samoleans",
-		KeyDirectory:   "",
 		Debug:          true,
 		Timeout:        "10s",
 		OutputFormat:   "json",
@@ -101,7 +95,7 @@ type (
 		chainID string
 		seed    int
 		t       testChainConfig
-		pcfg    lens.ChainClientConfig
+		pcfg    cosmos.CosmosProviderConfig
 	}
 
 	// testChainConfig represents the chain specific docker and codec configurations


### PR DESCRIPTION
We had moved the `Provider` implementation into [lens](https://github.com/strangelove-ventures/lens) but this created more overhead than it is maybe worth and created some confusion for other contributors.

The idea here is that we will create a `CosmosProvider` struct in the relayer that has an embedded `ChainClient` type so that we can still utilize functionality from `lens` inside of the relayer

```
type CosmosProvider struct {
	lens.ChainClient
}
```

Since this still provides us with functionality from `lens` behind our `Provider` implementation we can leave key management in lens, which allows us to utilize any of the proposed enhancements to keyring software in `lens` without having duplicate code. 

Closes #571 
Closes #550 