### PR TITLE
Avoid ioutil package

### DIFF
--- a/.github/workflows/akash-tests.yml
+++ b/.github/workflows/akash-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.17
         id: go
 
       # checkout relayer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       # setup gopath
       - name: Set PATH

--- a/.github/workflows/gaia-tests.yml
+++ b/.github/workflows/gaia-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.17
         id: go
 
       # checkout relayer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - run: echo https://github.com/cosmos/relayer/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md 
 

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -329,7 +328,7 @@ func fileInputAdd(file string) (cfg *Config, err error) {
 		return nil, err
 	}
 
-	byt, err := ioutil.ReadFile(file)
+	byt, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -231,7 +231,7 @@ func cfgFilesAddChains(dir string) (cfg *Config, err error) {
 			continue
 		}
 
-		byt, err := ioutil.ReadFile(pth)
+		byt, err := os.ReadFile(pth)
 		if err != nil {
 			fmt.Printf("failed to read file %s. Err: %v skipping...\n", pth, err)
 			continue
@@ -274,7 +274,7 @@ func cfgFilesAddPaths(dir string) (cfg *Config, err error) {
 			continue
 		}
 
-		byt, err := ioutil.ReadFile(pth)
+		byt, err := os.ReadFile(pth)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %w", pth, err)
 		}
@@ -599,7 +599,7 @@ func initConfig(cmd *cobra.Command) error {
 		viper.SetConfigFile(cfgPath)
 		if err := viper.ReadInConfig(); err == nil {
 			// read the config file bytes
-			file, err := ioutil.ReadFile(viper.ConfigFileUsed())
+			file, err := os.ReadFile(viper.ConfigFileUsed())
 			if err != nil {
 				fmt.Println("Error reading file:", err)
 				os.Exit(1)
@@ -661,7 +661,7 @@ func overWriteConfig(cfg *Config) (err error) {
 			}
 
 			// overwrite the config file
-			err = ioutil.WriteFile(viper.ConfigFileUsed(), out, 0600)
+			err = os.WriteFile(viper.ConfigFileUsed(), out, 0600)
 			if err != nil {
 				return err
 			}

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -265,14 +266,14 @@ $ %s paths fetch --home %s
 $ %s pth fch`, appName, defaultHome, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Clone the GH repo to tmp dir, we will extract the path files from here
-			localRepo, err := ioutil.TempDir("", "")
+			localRepo, err := os.MkdirTemp("", "")
 			if err != nil {
 				return err
 			}
 
 			if _, err = git.PlainClone(localRepo, false, &git.CloneOptions{
 				URL:           REPOURL,
-				Progress:      ioutil.Discard,
+				Progress:      io.Discard,
 				ReferenceName: "refs/heads/main",
 			}); err != nil {
 				return err
@@ -302,7 +303,7 @@ $ %s pth fch`, appName, defaultHome, appName)),
 							continue
 						}
 
-						byt, err := ioutil.ReadFile(pth)
+						byt, err := os.ReadFile(pth)
 						if err != nil {
 							cleanupDir(localRepo)
 							return fmt.Errorf("failed to read file %s: %w", pth, err)
@@ -362,7 +363,7 @@ func fileInputPathAdd(file, name string) (cfg *Config, err error) {
 		return nil, err
 	}
 
-	byt, err := ioutil.ReadFile(file)
+	byt, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -720,7 +720,7 @@ $ %s tx relay-acks demo-path -l 3 -s 6`,
 //				return err
 //			}
 //
-//			byt, err := ioutil.ReadFile(path)
+//			byt, err := os.ReadFile(path)
 //			if err != nil {
 //				return err
 //			}

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -41,8 +41,7 @@ func spinUpTestChains(t *testing.T, testChains ...testChain) relayer.Chains {
 	)
 
 	// Create temporary relayer test directory
-	dir, err := ioutil.TempDir("", "relayer-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
 	pool, err := dockertest.NewPool("")
@@ -96,7 +95,7 @@ func removeTestContainer(pool *dockertest.Pool, containerName string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error while listing containers with name %s %w", containerName, err)
+		return fmt.Errorf("error while listing containers with name %s: %w", containerName, err)
 	}
 
 	if len(containers) == 0 {
@@ -109,7 +108,7 @@ func removeTestContainer(pool *dockertest.Pool, containerName string) error {
 		RemoveVolumes: true,
 	})
 	if err != nil {
-		return fmt.Errorf("error while removing container with name %s %w", containerName, err)
+		return fmt.Errorf("error while removing container with name %s: %w", containerName, err)
 	}
 
 	return nil
@@ -282,7 +281,7 @@ func BuildAndRunWithBuildOptions(pool *dockertest.Pool, buildOpts *BuildOptions,
 	err := pool.Client.BuildImage(dc.BuildImageOptions{
 		Name:         runOpts.Name,
 		Dockerfile:   buildOpts.Dockerfile,
-		OutputStream: ioutil.Discard,
+		OutputStream: io.Discard,
 		ContextDir:   buildOpts.ContextDir,
 		BuildArgs:    buildOpts.BuildArgs,
 	})


### PR DESCRIPTION
As of go1.16, the ioutil package's functionality is provided by packages
io and os. This commit changes to use those implementations, except for
the case of ioutil.ReadDir; the API of os.ReadDir is slightly different,
so that will be changed in a separate commit.