### PR TITLE
Refactor cmd package to pass stdio

### DIFF
--- a/cmd/chains_test.go
+++ b/cmd/chains_test.go
@@ -1,0 +1,19 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainsList_Empty(t *testing.T) {
+	sys := NewSystem(t)
+
+	_ = sys.MustRun(t, "config", "init")
+
+	res := sys.MustRun(t, "chains", "list")
+
+	// Before adding any chains, attempting to list the chains gives a helpful message on stderr.
+	require.Empty(t, res.Stdout.String())
+	require.Contains(t, res.Stderr.String(), "no chains found")
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -76,7 +76,7 @@ $ %s q ibc-denoms ibc-0`,
 			}
 
 			for _, d := range res {
-				fmt.Println(d)
+				fmt.Fprintln(cmd.OutOrStdout(), d)
 			}
 			return nil
 		},
@@ -111,7 +111,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 				return err
 			}
 
-			fmt.Println(string(out))
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			return nil
 		},
 	}
@@ -163,7 +163,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 				return err
 			}
 
-			fmt.Println(string(out))
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			return nil
 		},
 	}
@@ -265,7 +265,7 @@ $ %s query balance ibc-0 testkey`,
 				return err
 			}
 
-			fmt.Printf("address {%s} balance {%s} \n", addr, coins)
+			fmt.Fprintf(cmd.OutOrStdout(), "address {%s} balance {%s} \n", addr, coins)
 			return nil
 		},
 	}
@@ -304,7 +304,14 @@ $ %s query header ibc-0 1400`,
 				}
 			}
 
-			return chain.Print(header, false, false)
+			s, err := chain.Sprint(header, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal header: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -334,7 +341,14 @@ $ %s q node-state ibc-1`,
 				return err
 			}
 
-			return chain.Print(csRes, false, false)
+			s, err := chain.Sprint(csRes, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal consensus state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -378,7 +392,14 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 				return err
 			}
 
-			return chain.Print(res, false, false)
+			s, err := chain.Sprint(res, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -414,14 +435,16 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 			}
 
 			for _, client := range res {
-				err = chain.Print(&client, false, false)
+				s, err := chain.Sprint(&client, false, false)
 				if err != nil {
-					return err
+					fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal state: %v\n", err)
+					continue
 				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), s)
 			}
 
 			return nil
-			//return chain.Print(res, false, false)
 		},
 	}
 
@@ -494,14 +517,16 @@ $ %s q conns ibc-1`,
 			}
 
 			for _, connection := range res {
-				err = chain.Print(connection, false, false)
+				s, err := chain.Sprint(connection, false, false)
 				if err != nil {
-					return err
+					fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal connection: %v\n", err)
+					continue
 				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), s)
 			}
 
 			return nil
-			//return chain.Print(res, false, false)
 		},
 	}
 
@@ -546,8 +571,14 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 				return err
 			}
 
-			return chain.Print(res, false, false)
-			//return chain.CLIContext(height).PrintProto(res)
+			s, err := chain.Sprint(res, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal client connection state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -585,8 +616,14 @@ $ %s q conn ibc-1 ibconeconn`,
 				return err
 			}
 
-			return chain.Print(res, false, false)
-			//return chain.CLIContext(height).PrintProto(res)
+			s, err := chain.Sprint(res, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal connection state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -625,14 +662,16 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 			}
 
 			for _, channel := range chans {
-				err = chain.Print(channel, false, false)
+				s, err := chain.Sprint(channel, false, false)
 				if err != nil {
-					return err
+					fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal channel: %v\n", err)
+					continue
 				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), s)
 			}
 
 			return nil
-			//return chain.Print(chans, false, false)
 		},
 	}
 
@@ -677,8 +716,14 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 				return err
 			}
 
-			return chain.Print(res, false, false)
-			//return chain.CLIContext(height).PrintProto(res)
+			s, err := chain.Sprint(res, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal channel state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -713,10 +758,13 @@ $ %s query channels ibc-2 --offset 2 --limit 30`,
 			}
 
 			for _, channel := range res {
-				err = chain.Print(channel, false, false)
+				s, err := chain.Sprint(channel, false, false)
 				if err != nil {
-					return err
+					fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal channel: %v\n", err)
+					continue
 				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), s)
 			}
 
 			return nil
@@ -757,7 +805,14 @@ $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
 				return err
 			}
 
-			return chain.Print(res, false, false)
+			s, err := chain.Sprint(res, false, false)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to marshal packet-commit state: %v\n", err)
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), s)
+			return nil
 		},
 	}
 
@@ -806,7 +861,7 @@ $ %s query unrelayed-pkts demo-path`,
 				return err
 			}
 
-			fmt.Println(string(out))
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			return nil
 		},
 	}
@@ -855,7 +910,7 @@ $ %s query unrelayed-acks demo-path`,
 				return err
 			}
 
-			fmt.Println(string(out))
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			return nil
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 
@@ -108,8 +109,8 @@ func Execute() {
 	}
 }
 
-// readLineFromBuf reads one line from stdin.
-func readStdin() (string, error) {
-	str, err := bufio.NewReader(os.Stdin).ReadString('\n')
+// readLine reads one line from the given reader.
+func readLine(in io.Reader) (string, error) {
+	str, err := bufio.NewReader(in).ReadString('\n')
 	return strings.TrimSpace(str), err
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"os/signal"
@@ -99,7 +100,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 				c[src].Log(fmt.Sprintf("update clients error. Err: %v", err))
 			}
 
-			trapSignal(done)
+			trapSignal(cmd.ErrOrStderr(), done)
 			return nil
 		},
 	}
@@ -107,14 +108,14 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 }
 
 // trap signal waits for a SIGINT or SIGTERM and then sends down the done channel
-func trapSignal(done func()) {
+func trapSignal(stderr io.Writer, done func()) {
 	sigCh := make(chan os.Signal, 1)
 
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	// wait for a signal
 	sig := <-sigCh
-	fmt.Println("Signal Received", sig.String())
+	fmt.Fprintln(stderr, "Signal Received", sig.String())
 	close(sigCh)
 
 	// call the cleanup func

--- a/cmd/system_test.go
+++ b/cmd/system_test.go
@@ -1,0 +1,87 @@
+package cmd_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/cosmos/relayer/cmd"
+)
+
+// System is a system under test.
+type System struct {
+	// Temporary directory to be injected as --home argument.
+	HomeDir string
+}
+
+// NewSystem creates a new system with a home dir associated with a temp dir belonging to t.
+//
+// The returned System does not store a reference to t;
+// some of its methods expect a *testing.T as an argument.
+// This allows creating one instance of System to be shared with subtests.
+func NewSystem(t *testing.T) *System {
+	t.Helper()
+
+	homeDir := t.TempDir()
+
+	return &System{
+		HomeDir: homeDir,
+	}
+}
+
+// RunResult is the stdout and stderr resulting from a call to (*System).Run,
+// and any error that was returned.
+type RunResult struct {
+	Stdout, Stderr bytes.Buffer
+
+	Err error
+}
+
+// Run calls s.RunWithInput with an empty stdin.
+func (s *System) Run(args ...string) RunResult {
+	return s.RunWithInput(bytes.NewReader(nil), args...)
+}
+
+// RunWithInput executes the root command with the given args,
+// providing in as the command's standard input,
+// and returns a RunResult that has its Stdout and Stderr populated.
+func (s *System) RunWithInput(in io.Reader, args ...string) RunResult {
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetIn(in)
+	// cmd.Execute also sets SilenceUsage,
+	// so match that here for more correct assertions.
+	rootCmd.SilenceUsage = true
+
+	var res RunResult
+	rootCmd.SetOutput(&res.Stdout)
+	rootCmd.SetErr(&res.Stderr)
+
+	// Prepend the system's home directory to any provided args.
+	args = append([]string{"--home", s.HomeDir}, args...)
+	rootCmd.SetArgs(args)
+
+	res.Err = rootCmd.Execute()
+	return res
+}
+
+// MustRun calls Run, but also calls t.Fatal if RunResult.Err is not nil.
+func (s *System) MustRun(t *testing.T, args ...string) RunResult {
+	t.Helper()
+
+	return s.MustRunWithInput(t, bytes.NewReader(nil), args...)
+}
+
+// MustRunWithInput calls RunWithInput, but also calls t.Fatal if RunResult.Err is not nil.
+func (s *System) MustRunWithInput(t *testing.T, in io.Reader, args ...string) RunResult {
+	t.Helper()
+
+	res := s.RunWithInput(in, args...)
+	if res.Err != nil {
+		t.Logf("Error executing %v: %v", args, res.Err)
+		t.Logf("Stdout: %q", res.Stdout.String())
+		t.Logf("Stderr: %q", res.Stderr.String())
+		t.FailNow()
+	}
+
+	return res
+}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -535,7 +535,7 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 			lCmd := linkCmd()
 
 			for err := lCmd.RunE(cmd, args); err != nil; err = lCmd.RunE(cmd, args) {
-				fmt.Printf("retrying link: %s\n", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "retrying link: %s\n", err)
 				time.Sleep(1 * time.Second)
 			}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -56,7 +56,7 @@ $ %s v`,
 				bz, err = yaml.Marshal(&verInfo)
 			}
 
-			fmt.Println(string(bz))
+			fmt.Fprintln(cmd.OutOrStdout(), string(bz))
 			return err
 		},
 	}

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -20,7 +20,13 @@ func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []p
 	if c.debug {
 		c.Log(fmt.Sprintf("- [%s] -> failed sending transaction:", c.ChainID()))
 		for _, msg := range msgs {
-			_ = c.Print(cosmos.CosmosMsg(msg), false, false)
+			s, err := c.Sprint(cosmos.CosmosMsg(msg), false, false)
+			if err != nil {
+				c.Log(fmt.Sprintf("Error formatting message: %v", err))
+			}
+			if s != "" {
+				c.Log("Failed value: " + s)
+			}
 		}
 	}
 

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -22,6 +22,7 @@ import (
 	sdked25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdkcryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	tmed25519 "github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/privval"
 )
 
@@ -133,7 +134,8 @@ func spinUpTestContainer(rchan chan<- *dockertest.Resource, pool *dockertest.Poo
 	}
 
 	// initialize the chain
-	c.Init(nil, debug)
+	// TODO: is there a better logger we can use for tests?
+	c.Init(log.NewTMLogger(log.NewSyncWriter(os.Stderr)), debug)
 
 	// create the test key
 	if err := c.CreateTestKey(); err != nil {


### PR DESCRIPTION
And add first "system test" for the cmd package, using the same patterns
recently added to strangelove/lens.

This switches from plain use of fmt.Print in the cmd package, to
fmt.Fprint variants passing the command's stdin/stdout/stderr as
appropriate. The rule of thumb is that stderr is used for diagnostic
output and stdout is used for "conventional" output that one would
perhaps pipe to another process.

This also replaces the relayer.Chain type's Print method with an Sprint
method, so that callers can decide how to directly the output.