### PR TITLE
Add channel filter to `Path` config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -574,6 +574,13 @@ func initConfig(cmd *cobra.Command) error {
 				return err
 			}
 
+			// verify that the channel filter rule is valid for every path in the config
+			for _, p := range cfgWrapper.Paths {
+				if err := p.ValidateChannelFilterRule(); err != nil {
+					return err
+				}
+			}
+
 			// build the config struct
 			var chains relayer.Chains
 			for _, pcfg := range cfgWrapper.ProviderConfigs {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -577,7 +577,7 @@ func initConfig(cmd *cobra.Command) error {
 			// verify that the channel filter rule is valid for every path in the config
 			for _, p := range cfgWrapper.Paths {
 				if err := p.ValidateChannelFilterRule(); err != nil {
-					return err
+					return fmt.Errorf("error initializing the relayer config for path %s: %w", p.String(), err)
 				}
 			}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,7 +48,8 @@ func startCmd() *cobra.Command {
 $ %s start demo-path --max-msgs 3
 $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			pathName := args[0]
+			c, src, dst, err := config.ChainsFromPath(pathName)
 			if err != nil {
 				return err
 			}
@@ -57,11 +58,13 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 				return err
 			}
 
-			path := config.Paths.MustGet(args[0])
+			path := config.Paths.MustGet(pathName)
 			maxTxSize, maxMsgLength, err := GetStartOptions(cmd)
 			if err != nil {
 				return err
 			}
+
+			filter := path.Filter
 
 			if relayer.SendToController != nil {
 				action := relayer.PathAction{
@@ -77,7 +80,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
-			errorChan := relayer.StartRelayer(ctx, c[src], c[dst], maxTxSize, maxMsgLength)
+			errorChan := relayer.StartRelayer(ctx, c[src], c[dst], filter, maxTxSize, maxMsgLength)
 
 			// NOTE: This block of code is useful for ensuring that the clients tracking each chain do not expire
 			// when there are no packets flowing across the channels. It is currently a source of errors that have been

--- a/configs/demo/paths/demo.json
+++ b/configs/demo/paths/demo.json
@@ -4,5 +4,9 @@
   },
   "dst": {
     "chain-id": "ibc-1"
+  },
+  "src-channel-filter": {
+    "rule": null,
+    "channel-list": []
   }
 }

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -13,8 +13,8 @@ import (
 const (
 	check     = "✔"
 	xIcon     = "✘"
-	allowList = "allowList"
-	denyList  = "denyList"
+	allowList = "allowlist"
+	denyList  = "denylist"
 )
 
 // Paths represent connection paths between chains
@@ -105,9 +105,19 @@ type ChannelFilter struct {
 func (p *Path) ValidateChannelFilterRule() error {
 	if p.Filter.Rule != allowList && p.Filter.Rule != denyList && p.Filter.Rule != "" {
 		return fmt.Errorf("%s is not a valid channel filter rule, please "+
-			"ensure your channel filter rule is `allowlist` or 'denylist'", p.Filter.Rule)
+			"ensure your channel filter rule is `%s` or '%s'", p.Filter.Rule, allowList, denyList)
 	}
 	return nil
+}
+
+// InChannelList returns true if the channelID argument is in the ChannelFilter's ChannelList or false otherwise.
+func (cf *ChannelFilter) InChannelList(channelID string) bool {
+	for _, channel := range cf.ChannelList {
+		if channel == channelID {
+			return true
+		}
+	}
+	return false
 }
 
 // End returns the proper end given a chainID.

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -13,8 +13,8 @@ import (
 const (
 	check     = "✔"
 	xIcon     = "✘"
-	whiteList = "whitelist"
-	blackList = "blacklist"
+	allowList = "allowList"
+	denyList  = "denyList"
 )
 
 // Paths represent connection paths between chains
@@ -94,18 +94,18 @@ type Path struct {
 	Filter *ChannelFilter `yaml:"src-channel-filter" json:"src-channel-filter"`
 }
 
-// ChannelFilter provides the means for either creating a whitelist or a blacklist of channels on the src chain
+// ChannelFilter provides the means for either creating an allowlist or a denylist of channels on the src chain
 // which will be used to narrow down the list of channels a user wants to relay on.
 type ChannelFilter struct {
 	Rule        string   `yaml:"rule" json:"rule"`
 	ChannelList []string `yaml:"channel-list" json:"channel-list"`
 }
 
-// ValidateChannelFilterRule verifies that the configured ChannelFilter rule is set to an appropriate value
+// ValidateChannelFilterRule verifies that the configured ChannelFilter rule is set to an appropriate value.
 func (p *Path) ValidateChannelFilterRule() error {
-	if p.Filter.Rule != whiteList && p.Filter.Rule != blackList && p.Filter.Rule != "" {
+	if p.Filter.Rule != allowList && p.Filter.Rule != denyList && p.Filter.Rule != "" {
 		return fmt.Errorf("error initializing the relayer config. %s is not a valid channel filter rule, please "+
-			"ensure your channel filter rule is `whitelist` or 'blacklist'", p.Filter.Rule)
+			"ensure your channel filter rule is `allowlist` or 'denylist'", p.Filter.Rule)
 	}
 	return nil
 }

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -104,7 +104,7 @@ type ChannelFilter struct {
 // ValidateChannelFilterRule verifies that the configured ChannelFilter rule is set to an appropriate value.
 func (p *Path) ValidateChannelFilterRule() error {
 	if p.Filter.Rule != allowList && p.Filter.Rule != denyList && p.Filter.Rule != "" {
-		return fmt.Errorf("error initializing the relayer config. %s is not a valid channel filter rule, please "+
+		return fmt.Errorf("%s is not a valid channel filter rule, please "+
 			"ensure your channel filter rule is `allowlist` or 'denylist'", p.Filter.Rule)
 	}
 	return nil
@@ -122,7 +122,7 @@ func (p *Path) End(chainID string) *PathEnd {
 }
 
 func (p *Path) String() string {
-	return fmt.Sprintf("[ ] %s ->\n %s", p.Src.String(), p.Dst.String())
+	return fmt.Sprintf("%s -> %s", p.Src.String(), p.Dst.String())
 }
 
 // GenPath generates a path with unspecified client, connection and channel identifiers

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -41,9 +41,9 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 				srcOpenChannels = FilterOpenChannels(srcChannels, srcOpenChannels)
 
 				switch filter.Rule {
-				case whiteList:
+				case allowList:
 					//do stuff
-				case blackList:
+				case denyList:
 					//do stuff
 				default:
 					// handle all channels on connection

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -29,7 +29,7 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 				return
 			default:
 				// Query the list of channels on the src connection
-				srcChannels, err := QueryChannelsOnConnection(src)
+				srcChannels, err := queryChannelsOnConnection(src)
 				if err != nil {
 					errorChan <- fmt.Errorf("error querying all channels on chain{%s}@connection{%s}: %v \n",
 						src.ChainID(), src.ConnectionID(), err)
@@ -37,16 +37,16 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 				}
 
 				// Apply the channel filter rule (i.e. build allowlist, denylist or relay on all channels available)
-				srcChannels = ApplyChannelFilterRule(filter, srcChannels)
+				srcChannels = applyChannelFilterRule(filter, srcChannels)
 
 				// Filter for open channels that are not already in our slice of open channels
-				srcOpenChannels = FilterOpenChannels(srcChannels, srcOpenChannels)
+				srcOpenChannels = filterOpenChannels(srcChannels, srcOpenChannels)
 
 				// Spin up a goroutine to relay packets & acks for each channel that isn't already being relayed against
 				for _, channel := range srcOpenChannels {
 					if !channel.active {
 						channel.active = true
-						go RelayUnrelayedPacketsAndAcks(ctx, src, dst, maxTxSize, maxMsgLength, channel, channels)
+						go relayUnrelayedPacketsAndAcks(ctx, src, dst, maxTxSize, maxMsgLength, channel, channels)
 					}
 				}
 
@@ -68,8 +68,8 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 	return errorChan
 }
 
-// QueryChannelsOnConnection queries all the channels associated with a connection on the src chain.
-func QueryChannelsOnConnection(src *Chain) ([]*types.IdentifiedChannel, error) {
+// queryChannelsOnConnection queries all the channels associated with a connection on the src chain.
+func queryChannelsOnConnection(src *Chain) ([]*types.IdentifiedChannel, error) {
 	// Query the latest heights on src & dst
 	srch, err := src.ChainProvider.QueryLatestHeight()
 	if err != nil {
@@ -91,9 +91,9 @@ func QueryChannelsOnConnection(src *Chain) ([]*types.IdentifiedChannel, error) {
 	return srcChannels, nil
 }
 
-// FilterOpenChannels takes a slice of channels and adds all the channels with OPEN state to a new slice of channels.
+// filterOpenChannels takes a slice of channels and adds all the channels with OPEN state to a new slice of channels.
 // NOTE: channels will not be added to the slice of open channels more than once.
-func FilterOpenChannels(channels []*types.IdentifiedChannel, openChannels []*ActiveChannel) []*ActiveChannel {
+func filterOpenChannels(channels []*types.IdentifiedChannel, openChannels []*ActiveChannel) []*ActiveChannel {
 
 	// Filter for open channels
 	for _, channel := range channels {
@@ -121,9 +121,9 @@ func FilterOpenChannels(channels []*types.IdentifiedChannel, openChannels []*Act
 	return openChannels
 }
 
-// ApplyChannelFilterRule will use the given ChannelFilter's rule and channel list to build the appropriate list of
+// applyChannelFilterRule will use the given ChannelFilter's rule and channel list to build the appropriate list of
 // channels to relay on.
-func ApplyChannelFilterRule(filter *ChannelFilter, channels []*types.IdentifiedChannel) []*types.IdentifiedChannel {
+func applyChannelFilterRule(filter *ChannelFilter, channels []*types.IdentifiedChannel) []*types.IdentifiedChannel {
 	switch filter.Rule {
 	case allowList:
 		var filteredChans []*types.IdentifiedChannel
@@ -148,8 +148,8 @@ func ApplyChannelFilterRule(filter *ChannelFilter, channels []*types.IdentifiedC
 	}
 }
 
-// RelayUnrelayedPacketsAndAcks will relay all the pending packets and acknowledgements on both the src and dst chains.
-func RelayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *ActiveChannel, channels chan<- *ActiveChannel) {
+// relayUnrelayedPacketsAndAcks will relay all the pending packets and acknowledgements on both the src and dst chains.
+func relayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *ActiveChannel, channels chan<- *ActiveChannel) {
 	// make goroutine signal its death, whether it's a panic or a return
 	defer func() {
 		channels <- srcChannel
@@ -160,10 +160,10 @@ func RelayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSiz
 		case <-ctx.Done():
 			return
 		default:
-			if err := RelayUnrelayedPackets(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); err != nil {
+			if err := relayUnrelayedPackets(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); err != nil {
 				return
 			}
-			if err := RelayUnrelayedAcks(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); err != nil {
+			if err := relayUnrelayedAcks(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); err != nil {
 				return
 			}
 
@@ -172,8 +172,8 @@ func RelayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSiz
 	}
 }
 
-// RelayUnrelayedPackets fetches unrelayed packet sequence numbers and attempts to relay the associated packets.
-func RelayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) error {
+// relayUnrelayedPackets fetches unrelayed packet sequence numbers and attempts to relay the associated packets.
+func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) error {
 	childCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 
@@ -216,8 +216,8 @@ func RelayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxM
 	return nil
 }
 
-// RelayUnrelayedAcks fetches unrelayed acknowledgements and attempts to relay them.
-func RelayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) error {
+// relayUnrelayedAcks fetches unrelayed acknowledgements and attempts to relay them.
+func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) error {
 	childCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -17,7 +17,7 @@ type ActiveChannel struct {
 }
 
 // StartRelayer starts the main relaying loop.
-func StartRelayer(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64) chan error {
+func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, maxTxSize, maxMsgLength uint64) chan error {
 	errorChan := make(chan error)
 	channels := make(chan *ActiveChannel, 10)
 	var srcOpenChannels []*ActiveChannel
@@ -39,6 +39,15 @@ func StartRelayer(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength 
 				// Filter for open channels that are not already in our slice of open channels
 				// TODO implement a filter list of channels we want to relay against or a list of channels to ignore
 				srcOpenChannels = FilterOpenChannels(srcChannels, srcOpenChannels)
+
+				switch filter.Rule {
+				case whiteList:
+					//do stuff
+				case blackList:
+					//do stuff
+				default:
+					// handle all channels on connection
+				}
 
 				// Spin up a goroutine to relay packets & acks for each channel that isn't already being relayed against
 				for _, channel := range srcOpenChannels {

--- a/relayer/strategies_test.go
+++ b/relayer/strategies_test.go
@@ -1,0 +1,100 @@
+package relayer
+
+import (
+	"testing"
+
+	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyChannelFilterAllowRule(t *testing.T) {
+	channels := []*chantypes.IdentifiedChannel{
+		{
+			ChannelId: "channel-0",
+		},
+		{
+			ChannelId: "channel-1",
+		},
+		{
+			ChannelId: "channel-2",
+		},
+	}
+
+	filter := &ChannelFilter{
+		Rule:        "allowlist",
+		ChannelList: []string{"channel-0", "channel-2"},
+	}
+
+	filteredChans := applyChannelFilterRule(filter, channels)
+
+	require.Equal(t, 2, len(filteredChans))
+}
+
+func TestApplyChannelFilterDenyRule(t *testing.T) {
+	channels := []*chantypes.IdentifiedChannel{
+		{
+			ChannelId: "channel-0",
+		},
+		{
+			ChannelId: "channel-1",
+		},
+		{
+			ChannelId: "channel-2",
+		},
+	}
+
+	filter := &ChannelFilter{
+		Rule:        "denylist",
+		ChannelList: []string{"channel-0", "channel-2"},
+	}
+
+	filteredChans := applyChannelFilterRule(filter, channels)
+
+	require.Equal(t, 1, len(filteredChans))
+}
+
+func TestApplyChannelFilterNoRule(t *testing.T) {
+	channels := []*chantypes.IdentifiedChannel{
+		{
+			ChannelId: "channel-0",
+		},
+		{
+			ChannelId: "channel-1",
+		},
+		{
+			ChannelId: "channel-2",
+		},
+	}
+
+	filter := &ChannelFilter{}
+
+	filteredChans := applyChannelFilterRule(filter, channels)
+
+	require.Equal(t, 3, len(filteredChans))
+}
+
+func TestValidateChannelFilterRule(t *testing.T) {
+	p := &Path{
+		Filter: &ChannelFilter{
+			Rule: "allowlist",
+		},
+	}
+	require.NoError(t, p.ValidateChannelFilterRule())
+
+	p = &Path{
+		Filter: &ChannelFilter{
+			Rule: "denylist",
+		},
+	}
+	require.NoError(t, p.ValidateChannelFilterRule())
+
+	p = &Path{Filter: &ChannelFilter{}}
+	require.NoError(t, p.ValidateChannelFilterRule())
+
+	p = &Path{
+		Filter: &ChannelFilter{
+			Rule: "invalid",
+		},
+	}
+	require.Error(t, p.ValidateChannelFilterRule())
+}

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -115,7 +115,11 @@ func chainTest(t *testing.T, tcs []testChain) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_ = relayer.StartRelayer(ctx, src, dst, 2*cmd.MB, 5)
+	filter := &relayer.ChannelFilter{
+		Rule:        "",
+		ChannelList: nil,
+	}
+	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains
@@ -263,7 +267,11 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_ = relayer.StartRelayer(ctx, src, dst, 2*cmd.MB, 5)
+	filter := &relayer.ChannelFilter{
+		Rule:        "",
+		ChannelList: nil,
+	}
+	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains
@@ -435,7 +443,11 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_ = relayer.StartRelayer(ctx, src, dst, 2*cmd.MB, 5)
+	filter := &relayer.ChannelFilter{
+		Rule:        "",
+		ChannelList: nil,
+	}
+	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -115,12 +115,8 @@ func chainTest(t *testing.T, tcs []testChain) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	filter := &relayer.ChannelFilter{
-		Rule:        "",
-		ChannelList: nil,
-	}
+	filter := &relayer.ChannelFilter{}
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
-	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(2))
@@ -267,12 +263,8 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	filter := &relayer.ChannelFilter{
-		Rule:        "",
-		ChannelList: nil,
-	}
+	filter := &relayer.ChannelFilter{}
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
-	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(1))
@@ -443,12 +435,8 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	filter := &relayer.ChannelFilter{
-		Rule:        "",
-		ChannelList: nil,
-	}
+	filter := &relayer.ChannelFilter{}
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
-	require.NoError(t, err)
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(1))


### PR DESCRIPTION
An example path config now would look something like the following:

```
hubosmo:
        src:
            chain-id: cosmoshub-4
            client-id: 07-tendermint-259
            connection-id: connection-257
        dst:
            chain-id: osmosis-1
            client-id: 07-tendermint-1
            connection-id: connection-1
        src-channel-filter:
                rule:
                channel-list: []  
```

Valid values for `rule` include:
- `allowlist`
- `denylist`
- empty value 

Where `allowlist` will indicate the user *only*  wants to relay on the list of channels in `channel-list`, `denylist` will indicate the user wants to relay every channel besides for the channels in `channel-list` and an empty value will indicate the user wants to relay on every available channel for that connection.

Closes #601               