### PR TITLE
Extract appState struct to avoid global values in cmd package

### DIFF
--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/cosmos/relayer/relayer"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// appState is the modifiable state of the application.
+type appState struct {
+	Viper *viper.Viper
+
+	HomePath string
+	Debug    bool
+	Config   *Config
+}
+
+// AddPathFromFile modifies a.config.Paths to include the content stored in the given file.
+// If a non-nil error is returned, a.config.Paths is not modified.
+func (a *appState) AddPathFromFile(stderr io.Writer, file, name string) error {
+	if _, err := os.Stat(file); err != nil {
+		return err
+	}
+
+	byt, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	p := &relayer.Path{}
+	if err = json.Unmarshal(byt, &p); err != nil {
+		return err
+	}
+
+	if err = a.Config.ValidatePath(stderr, p); err != nil {
+		return err
+	}
+
+	return a.Config.Paths.Add(name, p)
+}
+
+// AddPathFromUserInput manually prompts the user to specify all the path details.
+// It returns any input or validation errors.
+// If the path was successfully added, it returns nil.
+func (a *appState) AddPathFromUserInput(stdin io.Reader, stderr io.Writer, src, dst, name string) error {
+	// TODO: confirm name is available before going through input.
+
+	var (
+		value string
+		err   error
+		path  = &relayer.Path{
+			Src: &relayer.PathEnd{
+				ChainID: src,
+			},
+			Dst: &relayer.PathEnd{
+				ChainID: dst,
+			},
+		}
+	)
+
+	fmt.Fprintf(stderr, "enter src(%s) client-id...\n", src)
+	if value, err = readLine(stdin); err != nil {
+		return err
+	}
+
+	path.Src.ClientID = value
+
+	if err = path.Src.Vclient(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stderr, "enter src(%s) connection-id...\n", src)
+	if value, err = readLine(stdin); err != nil {
+		return err
+	}
+
+	path.Src.ConnectionID = value
+
+	if err = path.Src.Vconn(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stderr, "enter dst(%s) client-id...\n", dst)
+	if value, err = readLine(stdin); err != nil {
+		return err
+	}
+
+	path.Dst.ClientID = value
+
+	if err = path.Dst.Vclient(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stderr, "enter dst(%s) connection-id...\n", dst)
+	if value, err = readLine(stdin); err != nil {
+		return err
+	}
+
+	path.Dst.ConnectionID = value
+
+	if err = path.Dst.Vconn(); err != nil {
+		return err
+	}
+
+	if err := a.Config.ValidatePath(stderr, path); err != nil {
+		return err
+	}
+
+	return a.Config.Paths.Add(name, path)
+}
+
+// OverwriteConfig overwrites the config files on disk with the serialization of cfg,
+// and it replaces a.Config with cfg.
+//
+// It is possible to use a brand new Config argument,
+// but typically the argument is a.Config.
+func (a *appState) OverwriteConfig(cfg *Config) error {
+	cfgPath := path.Join(a.HomePath, "config", "config.yaml")
+	if _, err := os.Stat(cfgPath); err != nil {
+		return fmt.Errorf("failed to check existence of config file at %s: %w", cfgPath, err)
+	}
+
+	a.Viper.SetConfigFile(cfgPath)
+	if err := a.Viper.ReadInConfig(); err != nil {
+		// TODO: if we failed to read in the new config, should we restore the old config?
+		return fmt.Errorf("failed to read config file at %s: %w", cfgPath, err)
+	}
+
+	// ensure validateConfig runs properly
+	if err := validateConfig(cfg); err != nil {
+		return fmt.Errorf("failed to validate config at %s: %w", cfgPath, err)
+	}
+
+	// marshal the new config
+	out, err := yaml.Marshal(ConfigToWrapper(cfg))
+	if err != nil {
+		return err
+	}
+
+	// Overwrite the config file.
+	if err := os.WriteFile(a.Viper.ConfigFileUsed(), out, 0600); err != nil {
+		return fmt.Errorf("failed to write config file at %s: %w", cfgPath, err)
+	}
+
+	// Write the config back into the app state.
+	a.Config = cfg
+	return nil
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -32,95 +32,95 @@ var (
 	flagVersion                 = "version"
 )
 
-func ibcDenomFlags(cmd *cobra.Command) *cobra.Command {
+func ibcDenomFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagIBCDenoms, "i", false, "Display IBC denominations for sending tokens back to other chains")
-	if err := viper.BindPFlag(flagIBCDenoms, cmd.Flags().Lookup(flagIBCDenoms)); err != nil {
+	if err := v.BindPFlag(flagIBCDenoms, cmd.Flags().Lookup(flagIBCDenoms)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func heightFlag(cmd *cobra.Command) *cobra.Command {
+func heightFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Int64(flags.FlagHeight, 0, "Height of headers to fetch")
-	if err := viper.BindPFlag(flags.FlagHeight, cmd.Flags().Lookup(flags.FlagHeight)); err != nil {
+	if err := v.BindPFlag(flags.FlagHeight, cmd.Flags().Lookup(flags.FlagHeight)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func paginationFlags(cmd *cobra.Command) *cobra.Command {
+func paginationFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Uint64P(flags.FlagOffset, "o", 0, "pagination offset for query")
 	cmd.Flags().Uint64P(flags.FlagLimit, "l", 10, "pagination limit for query")
-	if err := viper.BindPFlag(flags.FlagOffset, cmd.Flags().Lookup(flags.FlagOffset)); err != nil {
+	if err := v.BindPFlag(flags.FlagOffset, cmd.Flags().Lookup(flags.FlagOffset)); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag(flags.FlagLimit, cmd.Flags().Lookup(flags.FlagLimit)); err != nil {
+	if err := v.BindPFlag(flags.FlagLimit, cmd.Flags().Lookup(flags.FlagLimit)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func yamlFlag(cmd *cobra.Command) *cobra.Command {
+func yamlFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagYAML, "y", false, "output using yaml")
-	if err := viper.BindPFlag(flagYAML, cmd.Flags().Lookup(flagYAML)); err != nil {
+	if err := v.BindPFlag(flagYAML, cmd.Flags().Lookup(flagYAML)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func skipConfirm(cmd *cobra.Command) *cobra.Command {
+func skipConfirm(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagSkip, "y", false, "output using yaml")
-	if err := viper.BindPFlag(flagSkip, cmd.Flags().Lookup(flagSkip)); err != nil {
+	if err := v.BindPFlag(flagSkip, cmd.Flags().Lookup(flagSkip)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func chainsAddFlags(cmd *cobra.Command) *cobra.Command {
-	fileFlag(cmd)
-	urlFlag(cmd)
+func chainsAddFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	fileFlag(v, cmd)
+	urlFlag(v, cmd)
 	return cmd
 }
 
-func pathFlag(cmd *cobra.Command) *cobra.Command {
+func pathFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagPath, "p", "", "specify the path to relay over")
-	if err := viper.BindPFlag(flagPath, cmd.Flags().Lookup(flagPath)); err != nil {
+	if err := v.BindPFlag(flagPath, cmd.Flags().Lookup(flagPath)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func timeoutFlags(cmd *cobra.Command) *cobra.Command {
+func timeoutFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Uint64P(flagTimeoutHeightOffset, "y", 0, "set timeout height offset for ")
 	cmd.Flags().DurationP(flagTimeoutTimeOffset, "c", time.Duration(0), "specify the path to relay over")
-	if err := viper.BindPFlag(flagTimeoutHeightOffset, cmd.Flags().Lookup(flagTimeoutHeightOffset)); err != nil {
+	if err := v.BindPFlag(flagTimeoutHeightOffset, cmd.Flags().Lookup(flagTimeoutHeightOffset)); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag(flagTimeoutTimeOffset, cmd.Flags().Lookup(flagTimeoutTimeOffset)); err != nil {
+	if err := v.BindPFlag(flagTimeoutTimeOffset, cmd.Flags().Lookup(flagTimeoutTimeOffset)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func jsonFlag(cmd *cobra.Command) *cobra.Command {
+func jsonFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagJSON, "j", false, "returns the response in json format")
-	if err := viper.BindPFlag(flagJSON, cmd.Flags().Lookup(flagJSON)); err != nil {
+	if err := v.BindPFlag(flagJSON, cmd.Flags().Lookup(flagJSON)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func fileFlag(cmd *cobra.Command) *cobra.Command {
+func fileFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagFile, "f", "", "fetch json data from specified file")
-	if err := viper.BindPFlag(flagFile, cmd.Flags().Lookup(flagFile)); err != nil {
+	if err := v.BindPFlag(flagFile, cmd.Flags().Lookup(flagFile)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func timeoutFlag(cmd *cobra.Command) *cobra.Command {
+func timeoutFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagTimeout, "t", "10s", "timeout between relayer runs")
-	if err := viper.BindPFlag(flagTimeout, cmd.Flags().Lookup(flagTimeout)); err != nil {
+	if err := v.BindPFlag(flagTimeout, cmd.Flags().Lookup(flagTimeout)); err != nil {
 		panic(err)
 	}
 	return cmd
@@ -134,21 +134,21 @@ func getTimeout(cmd *cobra.Command) (time.Duration, error) {
 	return time.ParseDuration(to)
 }
 
-func urlFlag(cmd *cobra.Command) *cobra.Command {
+func urlFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagURL, "u", "", "url to fetch data from")
-	if err := viper.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL)); err != nil {
+	if err := v.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func strategyFlag(cmd *cobra.Command) *cobra.Command {
+func strategyFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagMaxTxSize, "s", "2", "strategy of path to generate of the messages in a relay transaction")
 	cmd.Flags().StringP(flagMaxMsgLength, "l", "5", "maximum number of messages in a relay transaction")
-	if err := viper.BindPFlag(flagMaxTxSize, cmd.Flags().Lookup(flagMaxTxSize)); err != nil {
+	if err := v.BindPFlag(flagMaxTxSize, cmd.Flags().Lookup(flagMaxTxSize)); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag(flagMaxMsgLength, cmd.Flags().Lookup(flagMaxMsgLength)); err != nil {
+	if err := v.BindPFlag(flagMaxMsgLength, cmd.Flags().Lookup(flagMaxMsgLength)); err != nil {
 		panic(err)
 	}
 	return cmd
@@ -172,75 +172,75 @@ func getAddInputs(cmd *cobra.Command) (file string, url string, err error) {
 	return
 }
 
-func retryFlag(cmd *cobra.Command) *cobra.Command {
+func retryFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Uint64P(flagMaxRetries, "r", 3, "maximum retries after failed message send")
-	if err := viper.BindPFlag(flagMaxRetries, cmd.Flags().Lookup(flagMaxRetries)); err != nil {
+	if err := v.BindPFlag(flagMaxRetries, cmd.Flags().Lookup(flagMaxRetries)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func updateTimeFlags(cmd *cobra.Command) *cobra.Command {
+func updateTimeFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Duration(flagThresholdTime, 6*time.Hour, "time before to expiry time to update client")
-	if err := viper.BindPFlag(flagThresholdTime, cmd.Flags().Lookup(flagThresholdTime)); err != nil {
+	if err := v.BindPFlag(flagThresholdTime, cmd.Flags().Lookup(flagThresholdTime)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func clientParameterFlags(cmd *cobra.Command) *cobra.Command {
+func clientParameterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagUpdateAfterExpiry, "e", true,
 		"allow governance to update the client if expiry occurs")
 	cmd.Flags().BoolP(flagUpdateAfterMisbehaviour, "m", true,
 		"allow governance to update the client if misbehaviour freezing occurs")
-	if err := viper.BindPFlag(flagUpdateAfterExpiry, cmd.Flags().Lookup(flagUpdateAfterExpiry)); err != nil {
+	if err := v.BindPFlag(flagUpdateAfterExpiry, cmd.Flags().Lookup(flagUpdateAfterExpiry)); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag(flagUpdateAfterMisbehaviour, cmd.Flags().Lookup(flagUpdateAfterMisbehaviour)); err != nil {
+	if err := v.BindPFlag(flagUpdateAfterMisbehaviour, cmd.Flags().Lookup(flagUpdateAfterMisbehaviour)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func channelParameterFlags(cmd *cobra.Command) *cobra.Command {
-	return srcPortFlag(dstPortFlag(versionFlag(orderFlag(cmd))))
+func channelParameterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	return srcPortFlag(v, dstPortFlag(v, versionFlag(v, orderFlag(v, cmd))))
 }
 
-func overrideFlag(cmd *cobra.Command) *cobra.Command {
+func overrideFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Bool(flagOverride, false, "option to not reuse existing client or channel")
-	if err := viper.BindPFlag(flagOverride, cmd.Flags().Lookup(flagOverride)); err != nil {
+	if err := v.BindPFlag(flagOverride, cmd.Flags().Lookup(flagOverride)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func orderFlag(cmd *cobra.Command) *cobra.Command {
+func orderFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagOrder, "o", "unordered", "order of channel to create (ordered or unordered)")
-	if err := viper.BindPFlag(flagOrder, cmd.Flags().Lookup(flagOrder)); err != nil {
+	if err := v.BindPFlag(flagOrder, cmd.Flags().Lookup(flagOrder)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func versionFlag(cmd *cobra.Command) *cobra.Command {
+func versionFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagVersion, "v", "ics20-1", "version of channel to create")
-	if err := viper.BindPFlag(flagVersion, cmd.Flags().Lookup(flagVersion)); err != nil {
+	if err := v.BindPFlag(flagVersion, cmd.Flags().Lookup(flagVersion)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func srcPortFlag(cmd *cobra.Command) *cobra.Command {
+func srcPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().String(flagSrcPort, "transfer", "port on src chain to use when generating path")
-	if err := viper.BindPFlag(flagSrcPort, cmd.Flags().Lookup(flagSrcPort)); err != nil {
+	if err := v.BindPFlag(flagSrcPort, cmd.Flags().Lookup(flagSrcPort)); err != nil {
 		panic(err)
 	}
 	return cmd
 }
 
-func dstPortFlag(cmd *cobra.Command) *cobra.Command {
+func dstPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().String(flagDstPort, "transfer", "port on dst chain to use when generating path")
-	if err := viper.BindPFlag(flagDstPort, cmd.Flags().Lookup(flagDstPort)); err != nil {
+	if err := v.BindPFlag(flagDstPort, cmd.Flags().Lookup(flagDstPort)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -33,25 +33,27 @@ const (
 )
 
 // keysCmd represents the keys command
-func keysCmd() *cobra.Command {
+func keysCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "keys",
 		Aliases: []string{"k"},
 		Short:   "Manage keys held by the relayer for each chain",
 	}
 
-	cmd.AddCommand(keysAddCmd())
-	cmd.AddCommand(keysRestoreCmd())
-	cmd.AddCommand(keysDeleteCmd())
-	cmd.AddCommand(keysListCmd())
-	cmd.AddCommand(keysShowCmd())
-	cmd.AddCommand(keysExportCmd())
+	cmd.AddCommand(
+		keysAddCmd(a),
+		keysRestoreCmd(a),
+		keysDeleteCmd(a),
+		keysListCmd(a),
+		keysShowCmd(a),
+		keysExportCmd(a),
+	)
 
 	return cmd
 }
 
 // keysAddCmd respresents the `keys add` command
-func keysAddCmd() *cobra.Command {
+func keysAddCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add [chain-id] [name]",
 		Aliases: []string{"a"},
@@ -62,7 +64,7 @@ $ %s keys add ibc-0
 $ %s keys add ibc-1 key2
 $ %s k a ibc-2 testkey`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -92,7 +94,7 @@ $ %s k a ibc-2 testkey`, appName, appName, appName)),
 }
 
 // keysRestoreCmd respresents the `keys add` command
-func keysRestoreCmd() *cobra.Command {
+func keysRestoreCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "restore [chain-id] [name] [mnemonic]",
 		Aliases: []string{"r"},
@@ -103,7 +105,7 @@ $ %s keys restore ibc-0 testkey "[mnemonic-words]"
 $ %s k r ibc-1 faucet-key "[mnemonic-words]"`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyName := args[1]
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -127,7 +129,7 @@ $ %s k r ibc-1 faucet-key "[mnemonic-words]"`, appName, appName)),
 }
 
 // keysDeleteCmd respresents the `keys delete` command
-func keysDeleteCmd() *cobra.Command {
+func keysDeleteCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [chain-id] [name]",
 		Aliases: []string{"d"},
@@ -138,7 +140,7 @@ $ %s keys delete ibc-0 -y
 $ %s keys delete ibc-1 key2 -y
 $ %s k d ibc-2 testkey`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -165,7 +167,7 @@ $ %s k d ibc-2 testkey`, appName, appName, appName)),
 		},
 	}
 
-	return skipConfirm(cmd)
+	return skipConfirm(a.Viper, cmd)
 }
 
 func askForConfirmation(stdin io.Reader, stderr io.Writer) bool {
@@ -188,7 +190,7 @@ func askForConfirmation(stdin io.Reader, stderr io.Writer) bool {
 }
 
 // keysListCmd respresents the `keys list` command
-func keysListCmd() *cobra.Command {
+func keysListCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list [chain-id]",
 		Aliases: []string{"l"},
@@ -198,7 +200,7 @@ func keysListCmd() *cobra.Command {
 $ %s keys list ibc-0
 $ %s k l ibc-1`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -220,7 +222,7 @@ $ %s k l ibc-1`, appName, appName)),
 }
 
 // keysShowCmd respresents the `keys show` command
-func keysShowCmd() *cobra.Command {
+func keysShowCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "show [chain-id] [[name]]",
 		Aliases: []string{"s"},
@@ -231,7 +233,7 @@ $ %s keys show ibc-0
 $ %s keys show ibc-1 key2
 $ %s k s ibc-2 testkey`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -252,7 +254,7 @@ $ %s k s ibc-2 testkey`, appName, appName, appName)),
 				return err
 			}
 
-			fmt.Println(address)
+			fmt.Fprintln(cmd.OutOrStdout(), address)
 			return nil
 		},
 	}
@@ -261,7 +263,7 @@ $ %s k s ibc-2 testkey`, appName, appName, appName)),
 }
 
 // keysExportCmd respresents the `keys export` command
-func keysExportCmd() *cobra.Command {
+func keysExportCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "export [chain-id] [name]",
 		Aliases: []string{"e"},
@@ -272,7 +274,7 @@ $ %s keys export ibc-0 testkey
 $ %s k e ibc-2 testkey`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyName := args[1]
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -21,7 +21,7 @@ const (
 	PATHSURL = "https://github.com/cosmos/relayer/tree/main/interchain"
 )
 
-func pathsCmd() *cobra.Command {
+func pathsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "paths",
 		Aliases: []string{"pth"},
@@ -32,18 +32,18 @@ This includes the client, connection, and channel ids from both the source and d
 	}
 
 	cmd.AddCommand(
-		pathsListCmd(),
-		pathsShowCmd(),
-		pathsAddCmd(),
-		pathsNewCmd(),
-		pathsFetchCmd(),
-		pathsDeleteCmd(),
+		pathsListCmd(a),
+		pathsShowCmd(a),
+		pathsAddCmd(a),
+		pathsNewCmd(a),
+		pathsFetchCmd(a),
+		pathsDeleteCmd(a),
 	)
 
 	return cmd
 }
 
-func pathsDeleteCmd() *cobra.Command {
+func pathsDeleteCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [index]",
 		Aliases: []string{"d"},
@@ -53,18 +53,17 @@ func pathsDeleteCmd() *cobra.Command {
 $ %s paths delete demo-path
 $ %s pth d path-name`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := config.Paths.Get(args[0]); err != nil {
+			if _, err := a.Config.Paths.Get(args[0]); err != nil {
 				return err
 			}
-			cfg := config
-			delete(cfg.Paths, args[0])
-			return overWriteConfig(cfg)
+			delete(a.Config.Paths, args[0])
+			return a.OverwriteConfig(a.Config)
 		},
 	}
 	return cmd
 }
 
-func pathsListCmd() *cobra.Command {
+func pathsListCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"l"},
@@ -80,14 +79,14 @@ $ %s pth l`, appName, appName, appName)),
 			case yml && jsn:
 				return fmt.Errorf("can't pass both --json and --yaml, must pick one")
 			case yml:
-				out, err := yaml.Marshal(config.Paths)
+				out, err := yaml.Marshal(a.Config.Paths)
 				if err != nil {
 					return err
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), string(out))
 				return nil
 			case jsn:
-				out, err := json.Marshal(config.Paths)
+				out, err := json.Marshal(a.Config.Paths)
 				if err != nil {
 					return err
 				}
@@ -95,8 +94,8 @@ $ %s pth l`, appName, appName, appName)),
 				return nil
 			default:
 				i := 0
-				for k, pth := range config.Paths {
-					chains, err := config.Chains.Gets(pth.Src.ChainID, pth.Dst.ChainID)
+				for k, pth := range a.Config.Paths {
+					chains, err := a.Config.Chains.Gets(pth.Src.ChainID, pth.Dst.ChainID)
 					if err != nil {
 						return err
 					}
@@ -111,7 +110,7 @@ $ %s pth l`, appName, appName, appName)),
 			}
 		},
 	}
-	return yamlFlag(jsonFlag(cmd))
+	return yamlFlag(a.Viper, jsonFlag(a.Viper, cmd))
 }
 
 func printPath(stdout io.Writer, i int, k string, pth *relayer.Path, chains, clients, connection string) {
@@ -126,7 +125,7 @@ func checkmark(status bool) string {
 	return xIcon
 }
 
-func pathsShowCmd() *cobra.Command {
+func pathsShowCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "show [path-name]",
 		Aliases: []string{"s"},
@@ -137,11 +136,11 @@ $ %s paths show demo-path --yaml
 $ %s paths show demo-path --json
 $ %s pth s path-name`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := config.Paths.Get(args[0])
+			p, err := a.Config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
-			chains, err := config.Chains.Gets(p.Src.ChainID, p.Dst.ChainID)
+			chains, err := a.Config.Chains.Gets(p.Src.ChainID, p.Dst.ChainID)
 			if err != nil {
 				return err
 			}
@@ -172,10 +171,10 @@ $ %s pth s path-name`, appName, appName, appName)),
 			return nil
 		},
 	}
-	return yamlFlag(jsonFlag(cmd))
+	return yamlFlag(a.Viper, jsonFlag(a.Viper, cmd))
 }
 
-func pathsAddCmd() *cobra.Command {
+func pathsAddCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add [src-chain-id] [dst-chain-id] [path-name]",
 		Aliases: []string{"a"},
@@ -187,34 +186,33 @@ $ %s paths add ibc-0 ibc-1 demo-path --file paths/demo.json
 $ %s pth a ibc-0 ibc-1 demo-path`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			_, err := config.Chains.Gets(src, dst)
+			_, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
 			}
 
-			var out *Config
 			file, err := cmd.Flags().GetString(flagFile)
 			if err != nil {
 				return err
 			}
 
 			if file != "" {
-				if out, err = fileInputPathAdd(cmd.ErrOrStderr(), file, args[2]); err != nil {
+				if err := a.AddPathFromFile(cmd.ErrOrStderr(), file, args[2]); err != nil {
 					return err
 				}
 			} else {
-				if out, err = userInputPathAdd(cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
+				if err := a.AddPathFromUserInput(cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
 					return err
 				}
 			}
 
-			return overWriteConfig(out)
+			return a.OverwriteConfig(a.Config)
 		},
 	}
-	return fileFlag(cmd)
+	return fileFlag(a.Viper, cmd)
 }
 
-func pathsNewCmd() *cobra.Command {
+func pathsNewCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "new [src-chain-id] [dst-chain-id] [path-name]",
 		Aliases: []string{"n"},
@@ -225,7 +223,7 @@ $ %s paths new ibc-0 ibc-1 demo-path
 $ %s pth n ibc-0 ibc-1 demo-path`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			_, err := config.Chains.Gets(src, dst)
+			_, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
 			}
@@ -236,18 +234,18 @@ $ %s pth n ibc-0 ibc-1 demo-path`, appName, appName)),
 			}
 
 			name := args[2]
-			if err = config.Paths.Add(name, p); err != nil {
+			if err = a.Config.Paths.Add(name, p); err != nil {
 				return err
 			}
 
-			return overWriteConfig(config)
+			return a.OverwriteConfig(a.Config)
 		},
 	}
-	return channelParameterFlags(cmd)
+	return channelParameterFlags(a.Viper, cmd)
 }
 
 // pathsFetchCmd attempts to fetch the json files containing the path metadata, for each configured chain, from GitHub
-func pathsFetchCmd() *cobra.Command {
+func pathsFetchCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "fetch",
 		Aliases: []string{"fch"},
@@ -271,8 +269,8 @@ $ %s pth fch`, appName, defaultHome, appName)),
 			}
 
 			// Try to fetch path info for each configured chain that has canonical chain/path info in the GH repo
-			for _, srcChain := range config.Chains {
-				for _, dstChain := range config.Chains {
+			for _, srcChain := range a.Config.Chains {
+				for _, dstChain := range a.Config.Chains {
 
 					// Add paths to rly config from {localRepo}/interchain/chaind-id/
 					localPathsDir := path.Join(localRepo, "interchain", srcChain.ChainID())
@@ -283,7 +281,6 @@ $ %s pth fch`, appName, defaultHome, appName)),
 						fmt.Fprintf(cmd.ErrOrStderr(), "path info does not exist for chain: %s. Consider adding its info to %s. Error: %v\n", srcChain.ChainID(), path.Join(PATHSURL, "interchain"), err)
 						break
 					}
-					cfg := config
 
 					// For each path file, check that the dst is also a configured chain in the relayers config
 					for _, f := range files {
@@ -308,7 +305,7 @@ $ %s pth fch`, appName, defaultHome, appName)),
 
 						if p.Dst.ChainID == dstChain.ChainID() {
 							pthName := strings.Split(f.Name(), ".")[0]
-							if err = cfg.AddPath(pthName, p); err != nil {
+							if err = a.Config.AddPath(pthName, p); err != nil {
 								return fmt.Errorf("failed to add path %s: %w", pth, err)
 							}
 
@@ -316,8 +313,7 @@ $ %s pth fch`, appName, defaultHome, appName)),
 						}
 					}
 
-					err = overWriteConfig(cfg)
-					if err != nil {
+					if err := a.OverwriteConfig(a.Config); err != nil {
 						return err
 					}
 				}
@@ -331,100 +327,4 @@ $ %s pth fch`, appName, defaultHome, appName)),
 
 func cleanupDir(dir string) {
 	_ = os.RemoveAll(dir)
-}
-
-func fileInputPathAdd(stderr io.Writer, file, name string) (cfg *Config, err error) {
-	// If the user passes in a file, attempt to read the chain config from that file
-	p := &relayer.Path{}
-	if _, err := os.Stat(file); err != nil {
-		return nil, err
-	}
-
-	byt, err := os.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = json.Unmarshal(byt, &p); err != nil {
-		return nil, err
-	}
-
-	if err = config.ValidatePath(stderr, p); err != nil {
-		return nil, err
-	}
-
-	if err = config.Paths.Add(name, p); err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
-func userInputPathAdd(stdin io.Reader, stderr io.Writer, src, dst, name string) (*Config, error) {
-	var (
-		value string
-		err   error
-		path  = &relayer.Path{
-			Src: &relayer.PathEnd{
-				ChainID: src,
-			},
-			Dst: &relayer.PathEnd{
-				ChainID: dst,
-			},
-		}
-	)
-
-	fmt.Fprintf(stderr, "enter src(%s) client-id...\n", src)
-	if value, err = readLine(stdin); err != nil {
-		return nil, err
-	}
-
-	path.Src.ClientID = value
-
-	if err = path.Src.Vclient(); err != nil {
-		return nil, err
-	}
-
-	fmt.Fprintf(stderr, "enter src(%s) connection-id...\n", src)
-	if value, err = readLine(stdin); err != nil {
-		return nil, err
-	}
-
-	path.Src.ConnectionID = value
-
-	if err = path.Src.Vconn(); err != nil {
-		return nil, err
-	}
-
-	fmt.Fprintf(stderr, "enter dst(%s) client-id...\n", dst)
-	if value, err = readLine(stdin); err != nil {
-		return nil, err
-	}
-
-	path.Dst.ClientID = value
-
-	if err = path.Dst.Vclient(); err != nil {
-		return nil, err
-	}
-
-	fmt.Fprintf(stderr, "enter dst(%s) connection-id...\n", dst)
-	if value, err = readLine(stdin); err != nil {
-		return nil, err
-	}
-
-	path.Dst.ConnectionID = value
-
-	if err = path.Dst.Vconn(); err != nil {
-		return nil, err
-	}
-
-	if err = config.ValidatePath(stderr, path); err != nil {
-		return nil, err
-	}
-
-	if err = config.Paths.Add(name, path); err != nil {
-		return nil, err
-	}
-
-	return config, nil
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -14,7 +14,7 @@ import (
 )
 
 // queryCmd represents the chain command
-func queryCmd() *cobra.Command {
+func queryCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "query",
 		Aliases: []string{"q"},
@@ -23,33 +23,33 @@ func queryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		queryUnrelayedPackets(),
-		queryUnrelayedAcknowledgements(),
+		queryUnrelayedPackets(a),
+		queryUnrelayedAcknowledgements(a),
 		flags.LineBreak,
 		//queryAccountCmd(),
-		queryBalanceCmd(),
-		queryHeaderCmd(),
-		queryNodeStateCmd(),
+		queryBalanceCmd(a),
+		queryHeaderCmd(a),
+		queryNodeStateCmd(a),
 		//queryValSetAtHeightCmd(),
-		queryTxs(),
-		queryTx(),
+		queryTxs(a),
+		queryTx(a),
 		flags.LineBreak,
-		queryClientCmd(),
-		queryClientsCmd(),
-		queryConnection(),
-		queryConnections(),
-		queryConnectionsUsingClient(),
-		queryChannel(),
-		queryChannels(),
-		queryConnectionChannels(),
-		queryPacketCommitment(),
-		queryIBCDenoms(),
+		queryClientCmd(a),
+		queryClientsCmd(a),
+		queryConnection(a),
+		queryConnections(a),
+		queryConnectionsUsingClient(a),
+		queryChannel(a),
+		queryChannels(a),
+		queryConnectionChannels(a),
+		queryPacketCommitment(a),
+		queryIBCDenoms(a),
 	)
 
 	return cmd
 }
 
-func queryIBCDenoms() *cobra.Command {
+func queryIBCDenoms(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ibc-denoms [chain-id]",
 		Short: "query denomination traces for a given network by chain ID",
@@ -60,7 +60,7 @@ $ %s q ibc-denoms ibc-0`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ $ %s q ibc-denoms ibc-0`,
 	return cmd
 }
 
-func queryTx() *cobra.Command {
+func queryTx(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx [chain-id] [tx-hash]",
 		Short: "query for a transaction on a given network by transaction hash and chain ID",
@@ -96,7 +96,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 	return cmd
 }
 
-func queryTxs() *cobra.Command {
+func queryTxs(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "txs [chain-id] [events]",
 		Short: "query for transactions on a given network by chain ID and a set of transaction events",
@@ -137,7 +137,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -168,7 +168,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 		},
 	}
 
-	return paginationFlags(cmd)
+	return paginationFlags(a.Viper, cmd)
 }
 
 //func queryAccountCmd() *cobra.Command {
@@ -224,7 +224,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 //	return cmd
 //}
 
-func queryBalanceCmd() *cobra.Command {
+func queryBalanceCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "balance [chain-id] [[key-name]]",
 		Aliases: []string{"bal"},
@@ -236,7 +236,7 @@ $ %s query balance ibc-0 testkey`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -270,10 +270,10 @@ $ %s query balance ibc-0 testkey`,
 		},
 	}
 
-	return ibcDenomFlags(cmd)
+	return ibcDenomFlags(a.Viper, cmd)
 }
 
-func queryHeaderCmd() *cobra.Command {
+func queryHeaderCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "header [chain-id] [[height]]",
 		Short: "query the header of a network by chain ID at a given height or the latest height",
@@ -284,7 +284,7 @@ $ %s query header ibc-0 1400`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -320,7 +320,7 @@ $ %s query header ibc-0 1400`,
 
 // GetCmdQueryConsensusState defines the command to query the consensus state of
 // the chain as defined in https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics#query
-func queryNodeStateCmd() *cobra.Command {
+func queryNodeStateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node-state [chain-id]",
 		Short: "query the consensus state of a network by chain ID",
@@ -331,7 +331,7 @@ $ %s q node-state ibc-1`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -355,7 +355,7 @@ $ %s q node-state ibc-1`,
 	return cmd
 }
 
-func queryClientCmd() *cobra.Command {
+func queryClientCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "client [chain-id] [client-id]",
 		Short: "query the state of a light client on a network by chain ID",
@@ -366,7 +366,7 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -403,10 +403,10 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 		},
 	}
 
-	return heightFlag(cmd)
+	return heightFlag(a.Viper, cmd)
 }
 
-func queryClientsCmd() *cobra.Command {
+func queryClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clients [chain-id]",
 		Aliases: []string{"clnts"},
@@ -418,7 +418,7 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -487,7 +487,7 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 //	return cmd
 //}
 
-func queryConnections() *cobra.Command {
+func queryConnections(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connections [chain-id]",
 		Aliases: []string{"conns"},
@@ -500,7 +500,7 @@ $ %s q conns ibc-1`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -534,7 +534,7 @@ $ %s q conns ibc-1`,
 	return cmd
 }
 
-func queryConnectionsUsingClient() *cobra.Command {
+func queryConnectionsUsingClient(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "client-connections [chain-id] [client-id]",
 		Short: "query for all connections for a given client on a network by chain ID",
@@ -545,7 +545,7 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -582,10 +582,10 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 		},
 	}
 
-	return heightFlag(cmd)
+	return heightFlag(a.Viper, cmd)
 }
 
-func queryConnection() *cobra.Command {
+func queryConnection(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connection [chain-id] [connection-id]",
 		Aliases: []string{"conn"},
@@ -597,7 +597,7 @@ $ %s q conn ibc-1 ibconeconn`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -630,7 +630,7 @@ $ %s q conn ibc-1 ibconeconn`,
 	return cmd
 }
 
-func queryConnectionChannels() *cobra.Command {
+func queryConnectionChannels(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connection-channels [chain-id] [connection-id]",
 		Short: "query all channels associated with a given connection on a network by chain ID",
@@ -641,7 +641,7 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -679,7 +679,7 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 	return cmd
 }
 
-func queryChannel() *cobra.Command {
+func queryChannel(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "channel [chain-id] [channel-id] [port-id]",
 		Short: "query a channel by channel and port ID on a network by chain ID",
@@ -690,7 +690,7 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -729,10 +729,10 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 		},
 	}
 
-	return heightFlag(cmd)
+	return heightFlag(a.Viper, cmd)
 }
 
-func queryChannels() *cobra.Command {
+func queryChannels(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "channels [chain-id]",
 		Short: "query for all channels on a network by chain ID",
@@ -743,7 +743,7 @@ $ %s query channels ibc-2 --offset 2 --limit 30`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -777,7 +777,7 @@ $ %s query channels ibc-2 --offset 2 --limit 30`,
 	return cmd
 }
 
-func queryPacketCommitment() *cobra.Command {
+func queryPacketCommitment(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "packet-commit [chain-id] [channel-id] [port-id] [seq]",
 		Short: "query for the packet commitment given a sequence and channel ID on a network by chain ID",
@@ -788,7 +788,7 @@ $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, err := config.Chains.Get(args[0])
+			chain, err := a.Config.Chains.Get(args[0])
 			if err != nil {
 				return err
 			}
@@ -820,7 +820,7 @@ $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
 	return cmd
 }
 
-func queryUnrelayedPackets() *cobra.Command {
+func queryUnrelayedPackets(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unrelayed-packets [path] [src-channel-id]",
 		Aliases: []string{"unrelayed-pkts"},
@@ -833,14 +833,14 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := config.Paths.Get(args[0])
+			path, err := a.Config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 
 			src, dst := path.Src.ChainID, path.Dst.ChainID
 
-			c, err := config.Chains.Gets(src, dst)
+			c, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
@@ -876,7 +876,7 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 	return cmd
 }
 
-func queryUnrelayedAcknowledgements() *cobra.Command {
+func queryUnrelayedAcknowledgements(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unrelayed-acknowledgements [path] [src-channel-id]",
 		Aliases: []string{"unrelayed-acks"},
@@ -889,13 +889,13 @@ $ %s query unrelayed-acks demo-path channel-0`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := config.Paths.Get(args[0])
+			path, err := a.Config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 			src, dst := path.Src.ChainID, path.Dst.ChainID
 
-			c, err := config.Chains.Gets(src, dst)
+			c, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -25,7 +25,7 @@ func queryCmd(a *appState) *cobra.Command {
 	cmd.AddCommand(
 		queryUnrelayedPackets(a),
 		queryUnrelayedAcknowledgements(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 		//queryAccountCmd(),
 		queryBalanceCmd(a),
 		queryHeaderCmd(a),
@@ -33,7 +33,7 @@ func queryCmd(a *appState) *cobra.Command {
 		//queryValSetAtHeightCmd(),
 		queryTxs(a),
 		queryTx(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 		queryClientCmd(a),
 		queryClientsCmd(a),
 		queryConnection(a),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,11 +88,11 @@ func NewRootCmd() *cobra.Command {
 		chainsCmd(a),
 		pathsCmd(a),
 		keysCmd(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 		transactionCmd(a),
 		queryCmd(a),
 		startCmd(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 		getVersionCmd(a),
 	)
 
@@ -116,4 +116,15 @@ func Execute() {
 func readLine(in io.Reader) (string, error) {
 	str, err := bufio.NewReader(in).ReadString('\n')
 	return strings.TrimSpace(str), err
+}
+
+// lineBreakCommand returns a new instance of a command to be used as a line break
+// in a command's help output.
+//
+// This is not a plain reference to flags.LineBreak,
+// because that is a global value that will be modified by concurrent tests,
+// causing a data race.
+func lineBreakCommand() *cobra.Command {
+	var cmd cobra.Command = *flags.LineBreak
+	return &cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -27,18 +28,14 @@ import (
 	"github.com/spf13/viper"
 )
 
-// MB is a megabyte
 const (
-	MB = 1048576 // in bytes
+	MB      = 1024 * 1024 // in bytes
+	appName = "rly"
 )
 
-var (
-	homePath    string
-	debug       bool
-	config      *Config
-	defaultHome = os.ExpandEnv("$HOME/.relayer")
-	appName     = "rly"
+var defaultHome = filepath.Join(os.Getenv("HOME"), ".relayer")
 
+const (
 	// Default identifiers for dummy usage
 	dcli = "defaultclientid"
 	dcon = "defaultconnectionid"
@@ -49,6 +46,12 @@ var (
 
 // NewRootCmd returns the root command for relayer.
 func NewRootCmd() *cobra.Command {
+	// Use a local app state instance scoped to the new root command,
+	// so that tests don't concurrently access the state.
+	a := &appState{
+		Viper: viper.New(),
+	}
+
 	// RootCmd represents the base command when called without any subcommands
 	var rootCmd = &cobra.Command{
 		Use:   appName,
@@ -63,34 +66,34 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
-		// reads `homeDir/config/config.yaml` into `var config *Config`
-		return initConfig(rootCmd)
+		// reads `homeDir/config/config.yaml` into `a.Config`
+		return initConfig(rootCmd, a)
 	}
 
 	// Register --home flag
-	rootCmd.PersistentFlags().StringVar(&homePath, flags.FlagHome, defaultHome, "set home directory")
-	if err := viper.BindPFlag(flags.FlagHome, rootCmd.PersistentFlags().Lookup(flags.FlagHome)); err != nil {
+	rootCmd.PersistentFlags().StringVar(&a.HomePath, flags.FlagHome, defaultHome, "set home directory")
+	if err := a.Viper.BindPFlag(flags.FlagHome, rootCmd.PersistentFlags().Lookup(flags.FlagHome)); err != nil {
 		panic(err)
 	}
 
 	// Register --debug flag
-	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug output")
-	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+	rootCmd.PersistentFlags().BoolVarP(&a.Debug, "debug", "d", false, "debug output")
+	if err := a.Viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		panic(err)
 	}
 
 	// Register subcommands
 	rootCmd.AddCommand(
-		configCmd(),
-		chainsCmd(),
-		pathsCmd(),
-		keysCmd(),
+		configCmd(a),
+		chainsCmd(a),
+		pathsCmd(a),
+		keysCmd(a),
 		flags.LineBreak,
-		transactionCmd(),
-		queryCmd(),
-		startCmd(),
+		transactionCmd(a),
+		queryCmd(a),
+		startCmd(a),
 		flags.LineBreak,
-		getVersionCmd(),
+		getVersionCmd(a),
 	)
 
 	return rootCmd

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -17,7 +17,7 @@ import (
 
 // transactionCmd returns a parent transaction command handler, where all child
 // commands can submit transactions on IBC-connected networks.
-func transactionCmd() *cobra.Command {
+func transactionCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "transact",
 		Aliases: []string{"tx"},
@@ -30,21 +30,21 @@ Most of these commands take a [path] argument. Make sure:
 	}
 
 	cmd.AddCommand(
-		linkCmd(),
-		linkThenStartCmd(),
-		relayMsgsCmd(),
-		relayMsgCmd(),
-		relayAcksCmd(),
-		xfersend(),
+		linkCmd(a),
+		linkThenStartCmd(a),
+		relayMsgsCmd(a),
+		relayMsgCmd(a),
+		relayAcksCmd(a),
+		xfersend(a),
 		flags.LineBreak,
-		createClientsCmd(),
-		createClientCmd(),
-		updateClientsCmd(),
-		upgradeClientsCmd(),
+		createClientsCmd(a),
+		createClientCmd(a),
+		updateClientsCmd(a),
+		upgradeClientsCmd(a),
 		//upgradeChainCmd(),
-		createConnectionCmd(),
-		createChannelCmd(),
-		closeChannelCmd(),
+		createConnectionCmd(a),
+		createChannelCmd(a),
+		closeChannelCmd(a),
 		flags.LineBreak,
 
 		//sendCmd(),
@@ -103,7 +103,7 @@ Most of these commands take a [path] argument. Make sure:
 //	return cmd
 //}
 
-func createClientsCmd() *cobra.Command {
+func createClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clients [path-name]",
 		Short: "create a clients between two configured chains with a configured path",
@@ -127,7 +127,7 @@ func createClientsCmd() *cobra.Command {
 				return err
 			}
 
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -142,7 +142,7 @@ func createClientsCmd() *cobra.Command {
 
 			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -151,10 +151,10 @@ func createClientsCmd() *cobra.Command {
 		},
 	}
 
-	return overrideFlag(clientParameterFlags(cmd))
+	return overrideFlag(a.Viper, clientParameterFlags(a.Viper, cmd))
 }
 
-func createClientCmd() *cobra.Command {
+func createClientCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "client [src-chain-id] [dst-chain-id] [path-name]",
 		Short: "create a client between two configured chains with a configured path",
@@ -180,13 +180,13 @@ func createClientCmd() *cobra.Command {
 
 			src := args[0]
 			dst := args[1]
-			c, err := config.Chains.Gets(src, dst)
+			c, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
 
 			pathName := args[2]
-			path, err := config.Paths.Get(pathName)
+			path, err := a.Config.Paths.Get(pathName)
 			if err != nil {
 				return err
 			}
@@ -231,7 +231,7 @@ func createClientCmd() *cobra.Command {
 
 			modified, err := relayer.CreateClient(c[src], c[dst], srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
-				if err = overWriteConfig(config); err != nil {
+				if err = a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -240,10 +240,10 @@ func createClientCmd() *cobra.Command {
 		},
 	}
 
-	return overrideFlag(clientParameterFlags(cmd))
+	return overrideFlag(a.Viper, clientParameterFlags(a.Viper, cmd))
 }
 
-func updateClientsCmd() *cobra.Command {
+func updateClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update-clients [path-name]",
 		Short: "update IBC clients between two configured chains with a configured path",
@@ -253,7 +253,7 @@ corresponding update-client messages.`,
 		Args:    cobra.ExactArgs(1),
 		Example: strings.TrimSpace(fmt.Sprintf(`$ %s transact update-clients demo-path`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -273,13 +273,13 @@ corresponding update-client messages.`,
 	return cmd
 }
 
-func upgradeClientsCmd() *cobra.Command {
+func upgradeClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade-clients [path-name] [chain-id]",
 		Short: "upgrades IBC clients between two configured chains with a configured path and chain-id",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -308,10 +308,10 @@ func upgradeClientsCmd() *cobra.Command {
 		},
 	}
 
-	return heightFlag(cmd)
+	return heightFlag(a.Viper, cmd)
 }
 
-func createConnectionCmd() *cobra.Command {
+func createConnectionCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connection [path-name]",
 		Aliases: []string{"conn"},
@@ -336,7 +336,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -367,7 +367,7 @@ $ %s tx conn demo-path --timeout 5s`,
 			// ensure that the clients exist
 			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -377,7 +377,7 @@ $ %s tx conn demo-path --timeout 5s`,
 
 			modified, err = c[src].CreateOpenConnections(c[dst], retries, to)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -386,10 +386,10 @@ $ %s tx conn demo-path --timeout 5s`,
 		},
 	}
 
-	return overrideFlag(clientParameterFlags(retryFlag(timeoutFlag(cmd))))
+	return overrideFlag(a.Viper, clientParameterFlags(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd))))
 }
 
-func createChannelCmd() *cobra.Command {
+func createChannelCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "channel [path-name]",
 		Aliases: []string{"chan"},
@@ -404,7 +404,7 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -459,7 +459,7 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 			}
 
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -468,10 +468,10 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 		},
 	}
 
-	return channelParameterFlags(overrideFlag(retryFlag(timeoutFlag(cmd))))
+	return channelParameterFlags(a.Viper, overrideFlag(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd))))
 }
 
-func closeChannelCmd() *cobra.Command {
+func closeChannelCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "channel-close [path-name] [src-channel-id] [src-port-id]",
 		Short: "close a channel between two configured chains with a configured path",
@@ -484,7 +484,7 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 			appName, appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -519,10 +519,10 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 		},
 	}
 
-	return timeoutFlag(cmd)
+	return timeoutFlag(a.Viper, cmd)
 }
 
-func linkCmd() *cobra.Command {
+func linkCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "link [path-name]",
 		Aliases: []string{"connect"},
@@ -548,13 +548,16 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return err
 			}
 
-			pth, err := config.Paths.Get(args[0])
+			pth, err := a.Config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 
 			src, dst := pth.Src.ChainID, pth.Dst.ChainID
-			c, err := config.Chains.Gets(src, dst)
+			c, err := a.Config.Chains.Gets(src, dst)
+			if err != nil {
+				return err
+			}
 
 			c[src].PathEnd = pth.Src
 			c[dst].PathEnd = pth.Dst
@@ -605,7 +608,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			// create clients if they aren't already created
 			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -616,7 +619,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			// create connection if it isn't already created
 			modified, err = c[src].CreateOpenConnections(c[dst], retries, to)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -627,7 +630,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			// create channel if it isn't already created
 			modified, err = c[src].CreateOpenChannels(c[dst], retries, to, srcPort, dstPort, order, version, override)
 			if modified {
-				if err := overWriteConfig(config); err != nil {
+				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
@@ -639,10 +642,10 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 		},
 	}
 
-	return overrideFlag(channelParameterFlags(clientParameterFlags(retryFlag(timeoutFlag(cmd)))))
+	return overrideFlag(a.Viper, channelParameterFlags(a.Viper, clientParameterFlags(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd)))))
 }
 
-func linkThenStartCmd() *cobra.Command {
+func linkThenStartCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "link-then-start [path-name]",
 		Aliases: []string{"connect-then-start"},
@@ -655,22 +658,22 @@ networks with a configured path and then start the relayer on that path.`,
 $ %s transact link-then-start demo-path
 $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lCmd := linkCmd()
+			lCmd := linkCmd(a)
 
 			for err := lCmd.RunE(cmd, args); err != nil; err = lCmd.RunE(cmd, args) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "retrying link: %s\n", err)
 				time.Sleep(1 * time.Second)
 			}
 
-			sCmd := startCmd()
+			sCmd := startCmd(a)
 			return sCmd.RunE(cmd, args)
 		},
 	}
 
-	return overrideFlag(clientParameterFlags(strategyFlag(retryFlag(timeoutFlag(cmd)))))
+	return overrideFlag(a.Viper, clientParameterFlags(a.Viper, strategyFlag(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd)))))
 }
 
-func relayMsgCmd() *cobra.Command {
+func relayMsgCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "relay-packet [path-name] [src-channel-id] [seq-num]",
 		Aliases: []string{"relay-pkt"},
@@ -682,7 +685,7 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -716,10 +719,10 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 		},
 	}
 
-	return strategyFlag(cmd)
+	return strategyFlag(a.Viper, cmd)
 }
 
-func relayMsgsCmd() *cobra.Command {
+func relayMsgsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "relay-packets [path-name] [src-channel-id]",
 		Aliases: []string{"relay-pkts"},
@@ -731,7 +734,7 @@ $ %s tx relay-pkts demo-path channel-0`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -764,10 +767,10 @@ $ %s tx relay-pkts demo-path channel-0`,
 		},
 	}
 
-	return strategyFlag(cmd)
+	return strategyFlag(a.Viper, cmd)
 }
 
-func relayAcksCmd() *cobra.Command {
+func relayAcksCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "relay-acknowledgements [path-name] [src-channel-id]",
 		Aliases: []string{"relay-acks"},
@@ -779,7 +782,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := config.ChainsFromPath(args[0])
+			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -814,7 +817,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 		},
 	}
 
-	return strategyFlag(cmd)
+	return strategyFlag(a.Viper, cmd)
 }
 
 // TODO still needs a revisit
@@ -882,7 +885,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 //	return cmd
 //}
 
-func xfersend() *cobra.Command {
+func xfersend(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transfer [src-chain-id] [dst-chain-id] [amount] [dst-addr] [src-channel-id]",
 		Short: "initiate a transfer from one network to another",
@@ -897,7 +900,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 `, appName, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			c, err := config.Chains.Gets(src, dst)
+			c, err := a.Config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
@@ -908,7 +911,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 			}
 
 			var path *relayer.Path
-			if path, err = setPathsFromArgs(c[src], c[dst], pathString); err != nil {
+			if path, err = setPathsFromArgs(a, c[src], c[dst], pathString); err != nil {
 				return err
 			}
 
@@ -987,12 +990,12 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 		},
 	}
 
-	return timeoutFlags(pathFlag(cmd))
+	return timeoutFlags(a.Viper, pathFlag(a.Viper, cmd))
 }
 
-func setPathsFromArgs(src, dst *relayer.Chain, name string) (*relayer.Path, error) {
+func setPathsFromArgs(a *appState, src, dst *relayer.Chain, name string) (*relayer.Path, error) {
 	// find any configured paths between the chains
-	paths, err := config.Paths.PathsFromChains(src.ChainID(), dst.ChainID())
+	paths, err := a.Config.Paths.PathsFromChains(src.ChainID(), dst.ChainID())
 	if err != nil {
 		return nil, err
 	}
@@ -1003,12 +1006,12 @@ func setPathsFromArgs(src, dst *relayer.Chain, name string) (*relayer.Path, erro
 	switch {
 	case name != "" && len(paths) > 1:
 		if path, err = paths.Get(name); err != nil {
-			return path, err
+			return nil, err
 		}
 
 	case name != "" && len(paths) == 1:
 		if path, err = paths.Get(name); err != nil {
-			return path, err
+			return nil, err
 		}
 
 	case name == "" && len(paths) > 1:
@@ -1020,11 +1023,11 @@ func setPathsFromArgs(src, dst *relayer.Chain, name string) (*relayer.Path, erro
 		}
 	}
 
-	if err = src.SetPath(path.End(src.ChainID())); err != nil {
+	if err := src.SetPath(path.End(src.ChainID())); err != nil {
 		return nil, err
 	}
 
-	if err = dst.SetPath(path.End(dst.ChainID())); err != nil {
+	if err := dst.SetPath(path.End(dst.ChainID())); err != nil {
 		return nil, err
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -36,7 +36,7 @@ Most of these commands take a [path] argument. Make sure:
 		relayMsgCmd(a),
 		relayAcksCmd(a),
 		xfersend(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 		createClientsCmd(a),
 		createClientCmd(a),
 		updateClientsCmd(a),
@@ -45,7 +45,7 @@ Most of these commands take a [path] argument. Make sure:
 		createConnectionCmd(a),
 		createChannelCmd(a),
 		closeChannelCmd(a),
-		flags.LineBreak,
+		lineBreakCommand(),
 
 		//sendCmd(),
 	)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,7 +26,7 @@ type versionInfo struct {
 	Go        string `json:"go" yaml:"go"`
 }
 
-func getVersionCmd() *cobra.Command {
+func getVersionCmd(a *appState) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:     "version",
 		Aliases: []string{"v"},
@@ -61,5 +61,5 @@ $ %s v`,
 		},
 	}
 
-	return jsonFlag(versionCmd)
+	return jsonFlag(a.Viper, versionCmd)
 }


### PR DESCRIPTION
This is a mechanical refactor to collect the package-level variables in `cmd` into a new `appState` struct. Essentially the same pattern applied as in https://github.com/strangelove-ventures/lens/pull/128.

This will enable the cmd package tests to use t.Parallel.