### PR TITLE
Pass explicit context.Context through Provider interfaces

### DIFF
--- a/clib/main.go
+++ b/clib/main.go
@@ -15,6 +15,7 @@ package main
 // }
 import "C"
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -115,7 +116,7 @@ func SendToClib(port C.int, str C.Body) C.Body {
 			rm.Src = relayer.DecodeMsgs(src, action.SrcMsgs)
 			rm.Dst = relayer.DecodeMsgs(dst, action.DstMsgs)
 
-			rm.SendWithController(src, dst, false)
+			rm.SendWithController(context.Background(), src, dst, false) // TODO: should SendToClib accept a Context instead?
 			if !rm.Succeeded {
 				return C.CString("0")
 			}

--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,7 +24,7 @@ type appState struct {
 
 // AddPathFromFile modifies a.config.Paths to include the content stored in the given file.
 // If a non-nil error is returned, a.config.Paths is not modified.
-func (a *appState) AddPathFromFile(stderr io.Writer, file, name string) error {
+func (a *appState) AddPathFromFile(ctx context.Context, stderr io.Writer, file, name string) error {
 	if _, err := os.Stat(file); err != nil {
 		return err
 	}
@@ -38,7 +39,7 @@ func (a *appState) AddPathFromFile(stderr io.Writer, file, name string) error {
 		return err
 	}
 
-	if err = a.Config.ValidatePath(stderr, p); err != nil {
+	if err = a.Config.ValidatePath(ctx, stderr, p); err != nil {
 		return err
 	}
 
@@ -48,7 +49,7 @@ func (a *appState) AddPathFromFile(stderr io.Writer, file, name string) error {
 // AddPathFromUserInput manually prompts the user to specify all the path details.
 // It returns any input or validation errors.
 // If the path was successfully added, it returns nil.
-func (a *appState) AddPathFromUserInput(stdin io.Reader, stderr io.Writer, src, dst, name string) error {
+func (a *appState) AddPathFromUserInput(ctx context.Context, stdin io.Reader, stderr io.Writer, src, dst, name string) error {
 	// TODO: confirm name is available before going through input.
 
 	var (
@@ -108,7 +109,7 @@ func (a *appState) AddPathFromUserInput(stdin io.Reader, stderr io.Writer, src, 
 		return err
 	}
 
-	if err := a.Config.ValidatePath(stderr, path); err != nil {
+	if err := a.Config.ValidatePath(ctx, stderr, path); err != nil {
 		return err
 	}
 

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -237,7 +237,7 @@ $ %s ch l`, appName, appName)),
 						key = check
 					}
 
-					coins, err := c.ChainProvider.QueryBalance(c.ChainProvider.Key())
+					coins, err := c.ChainProvider.QueryBalance(cmd.Context(), c.ChainProvider.Key())
 					if err == nil && !coins.Empty() {
 						bal = check
 					}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -198,7 +199,7 @@ func configAddPathsCmd(a *appState) *cobra.Command {
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config add-paths configs/paths`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if err := addPathsFromDirectory(cmd.ErrOrStderr(), a, args[0]); err != nil {
+			if err := addPathsFromDirectory(cmd.Context(), cmd.ErrOrStderr(), a, args[0]); err != nil {
 				return err
 			}
 			return a.OverwriteConfig(a.Config)
@@ -261,7 +262,7 @@ func addChainsFromDirectory(stderr io.Writer, a *appState, dir string) error {
 //
 // addPathsFromDirectory returns the first error encountered,
 // which means a's paths may include a subset of the path files in dir.
-func addPathsFromDirectory(stderr io.Writer, a *appState, dir string) error {
+func addPathsFromDirectory(ctx context.Context, stderr io.Writer, a *appState, dir string) error {
 	dir = path.Clean(dir)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
@@ -285,7 +286,7 @@ func addPathsFromDirectory(stderr io.Writer, a *appState, dir string) error {
 		}
 
 		pthName := strings.Split(f.Name(), ".")[0]
-		if err := a.Config.ValidatePath(stderr, p); err != nil {
+		if err := a.Config.ValidatePath(ctx, stderr, p); err != nil {
 			return fmt.Errorf("failed to validate path %s: %w", pth, err)
 		}
 
@@ -616,18 +617,18 @@ func initConfig(cmd *cobra.Command, a *appState) error {
 }
 
 // ValidatePath checks that a path is valid
-func (c *Config) ValidatePath(stderr io.Writer, p *relayer.Path) (err error) {
-	if err = c.ValidatePathEnd(stderr, p.Src); err != nil {
+func (c *Config) ValidatePath(ctx context.Context, stderr io.Writer, p *relayer.Path) (err error) {
+	if err = c.ValidatePathEnd(ctx, stderr, p.Src); err != nil {
 		return sdkerrors.Wrapf(err, "chain %s failed path validation", p.Src.ChainID)
 	}
-	if err = c.ValidatePathEnd(stderr, p.Dst); err != nil {
+	if err = c.ValidatePathEnd(ctx, stderr, p.Dst); err != nil {
 		return sdkerrors.Wrapf(err, "chain %s failed path validation", p.Dst.ChainID)
 	}
 	return nil
 }
 
 // ValidatePathEnd validates provided pathend and returns error for invalid identifiers
-func (c *Config) ValidatePathEnd(stderr io.Writer, pe *relayer.PathEnd) error {
+func (c *Config) ValidatePathEnd(ctx context.Context, stderr io.Writer, pe *relayer.PathEnd) error {
 	chain, err := c.Chains.Get(pe.ChainID)
 	if err != nil {
 		fmt.Fprintf(stderr, "Chain %s is not currently configured.\n", pe.ChainID)
@@ -645,7 +646,7 @@ func (c *Config) ValidatePathEnd(stderr io.Writer, pe *relayer.PathEnd) error {
 		return err
 	}
 
-	height, err := chain.ChainProvider.QueryLatestHeight()
+	height, err := chain.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -99,7 +99,7 @@ $ %s pth l`, appName, appName, appName)),
 					if err != nil {
 						return err
 					}
-					stat := pth.QueryPathStatus(chains[pth.Src.ChainID], chains[pth.Dst.ChainID]).Status
+					stat := pth.QueryPathStatus(cmd.Context(), chains[pth.Src.ChainID], chains[pth.Dst.ChainID]).Status
 
 					printPath(cmd.OutOrStdout(), i, k, pth, checkmark(stat.Chains), checkmark(stat.Clients),
 						checkmark(stat.Connection))
@@ -146,7 +146,7 @@ $ %s pth s path-name`, appName, appName, appName)),
 			}
 			jsn, _ := cmd.Flags().GetBool(flagJSON)
 			yml, _ := cmd.Flags().GetBool(flagYAML)
-			pathWithStatus := p.QueryPathStatus(chains[p.Src.ChainID], chains[p.Dst.ChainID])
+			pathWithStatus := p.QueryPathStatus(cmd.Context(), chains[p.Src.ChainID], chains[p.Dst.ChainID])
 			switch {
 			case yml && jsn:
 				return fmt.Errorf("can't pass both --json and --yaml, must pick one")
@@ -197,11 +197,11 @@ $ %s pth a ibc-0 ibc-1 demo-path`, appName, appName, appName)),
 			}
 
 			if file != "" {
-				if err := a.AddPathFromFile(cmd.ErrOrStderr(), file, args[2]); err != nil {
+				if err := a.AddPathFromFile(cmd.Context(), cmd.ErrOrStderr(), file, args[2]); err != nil {
 					return err
 				}
 			} else {
-				if err := a.AddPathFromUserInput(cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
+				if err := a.AddPathFromUserInput(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
 					return err
 				}
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -912,7 +912,7 @@ $ %s query unrelayed-acks demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedAcknowledgements(c[src], c[dst], channel)
+			sp, err := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -510,7 +510,7 @@ $ %s q conns ibc-1`,
 			//	return err
 			//}
 
-			res, err := chain.ChainProvider.QueryConnections()
+			res, err := chain.ChainProvider.QueryConnections(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -565,7 +565,7 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 				}
 			}
 
-			res, err := chain.ChainProvider.QueryConnectionsUsingClient(height, chain.ClientID())
+			res, err := chain.ChainProvider.QueryConnectionsUsingClient(cmd.Context(), height, chain.ClientID())
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -291,7 +291,7 @@ $ %s query header ibc-0 1400`,
 			var header ibcexported.Header
 			switch len(args) {
 			case 1:
-				header, err = chain.ChainProvider.GetLightSignedHeaderAtHeight(0)
+				header, err = chain.ChainProvider.GetLightSignedHeaderAtHeight(cmd.Context(), 0)
 				if err != nil {
 					return err
 				}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -753,7 +753,7 @@ $ %s query channels ibc-2 --offset 2 --limit 30`,
 			//	return err
 			//}
 
-			res, err := chain.ChainProvider.QueryChannels()
+			res, err := chain.ChainProvider.QueryChannels(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -428,7 +428,7 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 			//	return err
 			//}
 
-			res, err := chain.ChainProvider.QueryClients()
+			res, err := chain.ChainProvider.QueryClients(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -101,7 +101,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 				return err
 			}
 
-			txs, err := chain.ChainProvider.QueryTx(args[1])
+			txs, err := chain.ChainProvider.QueryTx(cmd.Context(), args[1])
 			if err != nil {
 				return err
 			}
@@ -152,8 +152,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 				return err
 			}
 
-			txs, err := chain.ChainProvider.QueryTxs(int(offset), int(limit), []string{args[1]})
-			//txs, err := helpers.QueryTxs(chain, args[1], offset, limit)
+			txs, err := chain.ChainProvider.QueryTxs(cmd.Context(), int(offset), int(limit), []string{args[1]})
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -297,7 +297,7 @@ $ %s query header ibc-0 1400`,
 				}
 
 			case 2:
-				header, err = helpers.QueryHeader(chain, args[1])
+				header, err = helpers.QueryHeader(cmd.Context(), chain, args[1])
 				if err != nil {
 					return err
 				}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -655,7 +655,7 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 			//	return err
 			//}
 
-			chans, err := chain.ChainProvider.QueryConnectionChannels(0, args[1])
+			chans, err := chain.ChainProvider.QueryConnectionChannels(cmd.Context(), 0, args[1])
 			if err != nil {
 				return err
 			}
@@ -852,7 +852,7 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 			}
 
 			channelID := args[1]
-			channel, err := relayer.QueryChannel(c[src], channelID)
+			channel, err := relayer.QueryChannel(cmd.Context(), c[src], channelID)
 			if err != nil {
 				return err
 			}
@@ -907,7 +907,7 @@ $ %s query unrelayed-acks demo-path channel-0`,
 			}
 
 			channelID := args[1]
-			channel, err := relayer.QueryChannel(c[src], channelID)
+			channel, err := relayer.QueryChannel(cmd.Context(), c[src], channelID)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -70,7 +70,7 @@ $ %s q ibc-denoms ibc-0`,
 				return err
 			}
 
-			res, err := chain.ChainProvider.QueryDenomTraces(0, 100, h)
+			res, err := chain.ChainProvider.QueryDenomTraces(cmd.Context(), 0, 100, h)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -259,7 +259,7 @@ $ %s query balance ibc-0 testkey`,
 				return err
 			}
 
-			coins, err := helpers.QueryBalance(chain, addr, showDenoms)
+			coins, err := helpers.QueryBalance(cmd.Context(), chain, addr, showDenoms)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -857,7 +857,7 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(c[src], c[dst], channel)
+			sp, err := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -335,7 +335,7 @@ $ %s q node-state ibc-1`,
 				return err
 			}
 
-			csRes, _, err := chain.ChainProvider.QueryConsensusState(0)
+			csRes, _, err := chain.ChainProvider.QueryConsensusState(cmd.Context(), 0)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -65,7 +65,7 @@ $ %s q ibc-denoms ibc-0`,
 				return err
 			}
 
-			h, err := chain.ChainProvider.QueryLatestHeight()
+			h, err := chain.ChainProvider.QueryLatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -376,7 +376,7 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 			}
 
 			if height == 0 {
-				height, err = chain.ChainProvider.QueryLatestHeight()
+				height, err = chain.ChainProvider.QueryLatestHeight(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -559,7 +559,7 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 			}
 
 			if height == 0 {
-				height, err = chain.ChainProvider.QueryLatestHeight()
+				height, err = chain.ChainProvider.QueryLatestHeight(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -605,7 +605,7 @@ $ %s q conn ibc-1 ibconeconn`,
 				return err
 			}
 
-			height, err := chain.ChainProvider.QueryLatestHeight()
+			height, err := chain.ChainProvider.QueryLatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -706,7 +706,7 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 			}
 
 			if height == 0 {
-				height, err = chain.ChainProvider.QueryLatestHeight()
+				height, err = chain.ChainProvider.QueryLatestHeight(cmd.Context())
 				if err != nil {
 					return err
 				}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -92,7 +92,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 					for {
 						var timeToExpiry time.Duration
 						if err = retry.Do(func() error {
-							timeToExpiry, err = UpdateClientsFromChains(c[src], c[dst], thresholdTime)
+							timeToExpiry, err = UpdateClientsFromChains(ctx, c[src], c[dst], thresholdTime)
 							return err
 						}, retry.Attempts(5), retry.Delay(time.Millisecond*500), retry.LastErrorOnly(true), retry.OnRetry(func(n uint, err error) {
 							if a.Debug {
@@ -137,7 +137,7 @@ func trapSignal(ctx context.Context, stderr io.Writer, errorChan chan error, src
 }
 
 // UpdateClientsFromChains takes src, dst chains, threshold time and update clients based on expiry time
-func UpdateClientsFromChains(src, dst *relayer.Chain, thresholdTime time.Duration) (time.Duration, error) {
+func UpdateClientsFromChains(ctx context.Context, src, dst *relayer.Chain, thresholdTime time.Duration) (time.Duration, error) {
 	var (
 		srcTimeExpiry, dstTimeExpiry time.Duration
 		err                          error
@@ -146,12 +146,12 @@ func UpdateClientsFromChains(src, dst *relayer.Chain, thresholdTime time.Duratio
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
 		var err error
-		srcTimeExpiry, err = src.ChainProvider.AutoUpdateClient(dst.ChainProvider, thresholdTime, src.ClientID(), dst.ClientID())
+		srcTimeExpiry, err = src.ChainProvider.AutoUpdateClient(ctx, dst.ChainProvider, thresholdTime, src.ClientID(), dst.ClientID())
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstTimeExpiry, err = dst.ChainProvider.AutoUpdateClient(src.ChainProvider, thresholdTime, dst.ClientID(), src.ClientID())
+		dstTimeExpiry, err = dst.ChainProvider.AutoUpdateClient(ctx, src.ChainProvider, thresholdTime, dst.ClientID(), src.ClientID())
 		return err
 	})
 	if err = eg.Wait(); err != nil {

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -710,7 +710,7 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(c[src], c[dst], channel)
+			sp, err := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
 			if err != nil {
 				return err
 			}
@@ -754,7 +754,7 @@ $ %s tx relay-pkts demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(c[src], c[dst], channel)
+			sp, err := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -217,7 +217,7 @@ func createClientCmd(a *appState) *cobra.Command {
 			// Query the light signed headers for src & dst at the heights srch & dsth, retry if the query fails
 			var srcUpdateHeader, dstUpdateHeader exported.Header
 			if err = retry.Do(func() error {
-				srcUpdateHeader, dstUpdateHeader, err = relayer.GetLightSignedHeadersAtHeights(c[src], c[dst], srch, dsth)
+				srcUpdateHeader, dstUpdateHeader, err = relayer.GetLightSignedHeadersAtHeights(cmd.Context(), c[src], c[dst], srch, dsth)
 				if err != nil {
 					return fmt.Errorf("failed to query light signed headers: %w", err)
 				}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -205,7 +205,7 @@ func createClientCmd(a *appState) *cobra.Command {
 			// Query the latest heights on src and dst and retry if the query fails
 			var srch, dsth int64
 			if err = retry.Do(func() error {
-				srch, dsth, err = relayer.QueryLatestHeights(c[src], c[dst])
+				srch, dsth, err = relayer.QueryLatestHeights(cmd.Context(), c[src], c[dst])
 				if srch == 0 || dsth == 0 || err != nil {
 					return fmt.Errorf("failed to query latest heights: %w", err)
 				}
@@ -224,7 +224,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				return err
 			}, relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
 				c[src].LogRetryGetLightSignedHeader(n, err)
-				srch, dsth, _ = relayer.QueryLatestHeights(c[src], c[dst])
+				srch, dsth, _ = relayer.QueryLatestHeights(cmd.Context(), c[src], c[dst])
 			})); err != nil {
 				return err
 			}
@@ -266,7 +266,7 @@ corresponding update-client messages.`,
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			return c[src].UpdateClients(c[dst])
+			return c[src].UpdateClients(cmd.Context(), c[dst])
 		},
 	}
 
@@ -505,7 +505,7 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			srch, err := c[src].ChainProvider.QueryLatestHeight()
+			srch, err := c[src].ChainProvider.QueryLatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -515,7 +515,7 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 				return err
 			}
 
-			return c[src].CloseChannel(c[dst], to, channelID, portID, channel)
+			return c[src].CloseChannel(cmd.Context(), c[dst], to, channelID, portID, channel)
 		},
 	}
 
@@ -920,7 +920,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 				return err
 			}
 
-			srch, err := c[src].ChainProvider.QueryLatestHeight()
+			srch, err := c[src].ChainProvider.QueryLatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -986,7 +986,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			}
 
-			return c[src].SendTransferMsg(c[dst], amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
+			return c[src].SendTransferMsg(cmd.Context(), c[dst], amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
 		},
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -946,7 +946,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 					srcChannelID, c[src], path.Src.ConnectionID)
 			}
 
-			dts, err := c[src].ChainProvider.QueryDenomTraces(0, 100, srch)
+			dts, err := c[src].ChainProvider.QueryDenomTraces(cmd.Context(), 0, 100, srch)
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -453,7 +453,7 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 			}
 
 			// create channel if it isn't already created
-			modified, err := c[src].CreateOpenChannels(c[dst], retries, to, srcPort, dstPort, order, version, override)
+			modified, err := c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
 			if err != nil {
 				return fmt.Errorf("error creating channels: %w", err)
 			}
@@ -628,7 +628,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			}
 
 			// create channel if it isn't already created
-			modified, err = c[src].CreateOpenChannels(c[dst], retries, to, srcPort, dstPort, order, version, override)
+			modified, err = c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -804,7 +804,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 
 			// sp.Src contains all sequences acked on SRC but acknowledgement not processed on DST
 			// sp.Dst contains all sequences acked on DST but acknowledgement not processed on SRC
-			sp, err := relayer.UnrelayedAcknowledgements(c[src], c[dst], channel)
+			sp, err := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -705,7 +705,7 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 			}
 
 			channelID := args[1]
-			channel, err := relayer.QueryChannel(c[src], channelID)
+			channel, err := relayer.QueryChannel(cmd.Context(), c[src], channelID)
 			if err != nil {
 				return err
 			}
@@ -749,7 +749,7 @@ $ %s tx relay-pkts demo-path channel-0`,
 			}
 
 			channelID := args[1]
-			channel, err := relayer.QueryChannel(c[src], channelID)
+			channel, err := relayer.QueryChannel(cmd.Context(), c[src], channelID)
 			if err != nil {
 				return err
 			}
@@ -797,7 +797,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 			}
 
 			channelID := args[1]
-			channel, err := relayer.QueryChannel(c[src], channelID)
+			channel, err := relayer.QueryChannel(cmd.Context(), c[src], channelID)
 			if err != nil {
 				return err
 			}
@@ -927,7 +927,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			// Query all channels for the configured connection on the src chain
 			srcChannelID := args[4]
-			channels, err := c[src].ChainProvider.QueryConnectionChannels(srch, path.Src.ConnectionID)
+			channels, err := c[src].ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Src.ConnectionID)
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -715,7 +715,7 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 				return err
 			}
 
-			return relayer.RelayPacket(c[src], c[dst], sp, maxTxSize, maxMsgLength, uint64(seqNum), channel)
+			return relayer.RelayPacket(cmd.Context(), c[src], c[dst], sp, maxTxSize, maxMsgLength, uint64(seqNum), channel)
 		},
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -375,7 +375,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 
-			modified, err = c[src].CreateOpenConnections(c[dst], retries, to)
+			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
@@ -617,7 +617,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			}
 
 			// create connection if it isn't already created
-			modified, err = c[src].CreateOpenConnections(c[dst], retries, to)
+			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -140,7 +140,7 @@ func createClientsCmd(a *appState) *cobra.Command {
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
@@ -229,7 +229,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				return err
 			}
 
-			modified, err := relayer.CreateClient(c[src], c[dst], srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			modified, err := relayer.CreateClient(cmd.Context(), c[src], c[dst], srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
 				if err = a.OverwriteConfig(a.Config); err != nil {
 					return err
@@ -365,7 +365,7 @@ $ %s tx conn demo-path --timeout 5s`,
 			}
 
 			// ensure that the clients exist
-			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
@@ -606,7 +606,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			}
 
 			// create clients if they aren't already created
-			modified, err := c[src].CreateClients(c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -301,10 +301,10 @@ func upgradeClientsCmd(a *appState) *cobra.Command {
 
 			// send the upgrade message on the targetChainID
 			if src == targetChainID {
-				return c[src].UpgradeClients(c[dst], height)
+				return c[src].UpgradeClients(cmd.Context(), c[dst], height)
 			}
 
-			return c[dst].UpgradeClients(c[src], height)
+			return c[dst].UpgradeClients(cmd.Context(), c[src], height)
 		},
 	}
 

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -65,5 +65,5 @@ func QueryHeader(ctx context.Context, chain *relayer.Chain, opts ...string) (ibc
 		return chain.ChainProvider.QueryHeaderAtHeight(ctx, height)
 	}
 
-	return chain.ChainProvider.GetLightSignedHeaderAtHeight(0)
+	return chain.ChainProvider.GetLightSignedHeaderAtHeight(ctx, 0)
 }

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -20,7 +20,7 @@ func QueryBalance(ctx context.Context, chain *relayer.Chain, address string, sho
 		return coins, nil
 	}
 
-	h, err := chain.ChainProvider.QueryLatestHeight()
+	h, err := chain.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -25,7 +25,7 @@ func QueryBalance(ctx context.Context, chain *relayer.Chain, address string, sho
 		return nil, err
 	}
 
-	dts, err := chain.ChainProvider.QueryDenomTraces(0, 1000, h)
+	dts, err := chain.ChainProvider.QueryDenomTraces(ctx, 0, 1000, h)
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -9,8 +10,8 @@ import (
 )
 
 // QueryBalance is a helper function for query balance
-func QueryBalance(chain *relayer.Chain, address string, showDenoms bool) (sdk.Coins, error) {
-	coins, err := chain.ChainProvider.QueryBalanceWithAddress(address)
+func QueryBalance(ctx context.Context, chain *relayer.Chain, address string, showDenoms bool) (sdk.Coins, error) {
+	coins, err := chain.ChainProvider.QueryBalanceWithAddress(ctx, address)
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -55,14 +55,14 @@ func QueryBalance(ctx context.Context, chain *relayer.Chain, address string, sho
 }
 
 // QueryHeader is a helper function for query header
-func QueryHeader(chain *relayer.Chain, opts ...string) (ibcexported.Header, error) {
+func QueryHeader(ctx context.Context, chain *relayer.Chain, opts ...string) (ibcexported.Header, error) {
 	if len(opts) > 0 {
 		height, err := strconv.ParseInt(opts[0], 10, 64) //convert to int64
 		if err != nil {
 			return nil, err
 		}
 
-		return chain.ChainProvider.QueryHeaderAtHeight(height)
+		return chain.ChainProvider.QueryHeaderAtHeight(ctx, height)
 	}
 
 	return chain.ChainProvider.GetLightSignedHeaderAtHeight(0)

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -173,8 +174,8 @@ func (c *Chain) GetSelfVersion() uint64 {
 }
 
 // GetTrustingPeriod returns the trusting period for the chain
-func (c *Chain) GetTrustingPeriod() (time.Duration, error) {
-	return c.ChainProvider.TrustingPeriod()
+func (c *Chain) GetTrustingPeriod(ctx context.Context) (time.Duration, error) {
+	return c.ChainProvider.TrustingPeriod(ctx)
 }
 
 // Log takes a string and logs the data

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -52,7 +52,7 @@ func (c *Chain) CreateOpenChannels(ctx context.Context, dst *Chain, maxRetries u
 		case success && lastStep:
 
 			if c.debug {
-				srch, dsth, err := QueryLatestHeights(c, dst)
+				srch, dsth, err := QueryLatestHeights(ctx, c, dst)
 				if err != nil {
 					return modified, err
 				}
@@ -104,7 +104,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 	)
 
 	if err = retry.Do(func() error {
-		srch, dsth, err = QueryLatestHeights(src, dst)
+		srch, dsth, err = QueryLatestHeights(ctx, src, dst)
 		if err != nil || srch == 0 || dsth == 0 {
 			return fmt.Errorf("failed to query latest heights. Err: %w", err)
 		}
@@ -143,7 +143,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight()
+			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to query latest heights. Err: %w", err)
 			}
@@ -160,12 +160,12 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight()
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			return srcChanID, dstChanID, success, last, modified, err
 		}
 
-		msgs, err = src.ChainProvider.ChannelOpenTry(dst.ChainProvider, dstHeader, srcPortID, dstPortID,
+		msgs, err = src.ChainProvider.ChannelOpenTry(ctx, dst.ChainProvider, dstHeader, srcPortID, dstPortID,
 			srcChanID, dstChanID, version, src.ConnectionID(), src.ClientID())
 
 		if err != nil {
@@ -191,7 +191,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight()
+			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to query latest heights. Err: %w", err)
 			}
@@ -208,12 +208,12 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight()
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			return srcChanID, dstChanID, success, last, modified, err
 		}
 
-		msgs, err = src.ChainProvider.ChannelOpenAck(dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstChanID, dstPortID)
+		msgs, err = src.ChainProvider.ChannelOpenAck(ctx, dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstChanID, dstPortID)
 		if err != nil {
 			return srcChanID, dstChanID, false, false, false, err
 		}
@@ -235,7 +235,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			srch, err = src.ChainProvider.QueryLatestHeight()
+			srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil || srch == 0 {
 				return fmt.Errorf("failed to query latest heights. Err: %w", err)
 			}
@@ -252,12 +252,12 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.LogRetryGetIBCUpdateHeader(n, err)
-			srch, _ = src.ChainProvider.QueryLatestHeight()
+			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			return srcChanID, dstChanID, success, last, modified, err
 		}
 
-		msgs, err = dst.ChainProvider.ChannelOpenAck(src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcChanID, srcPortID)
+		msgs, err = dst.ChainProvider.ChannelOpenAck(ctx, src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcChanID, srcPortID)
 		if err != nil {
 			return srcChanID, dstChanID, false, false, false, err
 		}
@@ -277,7 +277,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight()
+			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to query latest heights. Err: %w", err)
 			}
@@ -294,12 +294,12 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight()
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			return srcChanID, dstChanID, success, last, modified, err
 		}
 
-		msgs, err = src.ChainProvider.ChannelOpenConfirm(dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstPortID, dstChanID)
+		msgs, err = src.ChainProvider.ChannelOpenConfirm(ctx, dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstPortID, dstChanID)
 		if err != nil {
 			return srcChanID, dstChanID, false, false, false, err
 		}
@@ -321,7 +321,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			srch, err = src.ChainProvider.QueryLatestHeight()
+			srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil || srch == 0 {
 				return fmt.Errorf("failed to query latest heights. Err: %w", err)
 			}
@@ -338,12 +338,12 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.LogRetryGetIBCUpdateHeader(n, err)
-			srch, _ = src.ChainProvider.QueryLatestHeight()
+			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			return srcChanID, dstChanID, success, last, modified, err
 		}
 
-		msgs, err = dst.ChainProvider.ChannelOpenConfirm(src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcPortID, srcChanID)
+		msgs, err = dst.ChainProvider.ChannelOpenConfirm(ctx, src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcPortID, srcChanID)
 		if err != nil {
 			return srcChanID, dstChanID, false, false, false, err
 		}
@@ -396,7 +396,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 		if !found || override {
 
 			if err = retry.Do(func() error {
-				dsth, err = dst.ChainProvider.QueryLatestHeight()
+				dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 				if err != nil || dsth == 0 {
 					return fmt.Errorf("failed to query latest heights. Err: %w", err)
 				}
@@ -413,7 +413,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return err
 			}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 				dst.LogRetryGetIBCUpdateHeader(n, err)
-				dsth, _ = dst.ChainProvider.QueryLatestHeight()
+				dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 			})); err != nil {
 				return srcChanID, dstChanID, false, false, err
 			}
@@ -456,7 +456,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 		if !found || override {
 
 			if err = retry.Do(func() error {
-				dsth, err = dst.ChainProvider.QueryLatestHeight()
+				dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 				if err != nil || dsth == 0 {
 					return fmt.Errorf("failed to query latest heights. Err: %w", err)
 				}
@@ -473,13 +473,13 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return err
 			}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 				dst.LogRetryGetIBCUpdateHeader(n, err)
-				dsth, _ = dst.ChainProvider.QueryLatestHeight()
+				dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 			})); err != nil {
 				return srcChanID, dstChanID, false, false, err
 			}
 
 			// open try on source chain
-			msgs, err = src.ChainProvider.ChannelOpenTry(dst.ChainProvider, dstHeader, srcPortID, dstPortID, srcChanID, dstChanID, version, src.ConnectionID(), src.ClientID())
+			msgs, err = src.ChainProvider.ChannelOpenTry(ctx, dst.ChainProvider, dstHeader, srcPortID, dstPortID, srcChanID, dstChanID, version, src.ConnectionID(), src.ClientID())
 			if err != nil {
 				return srcChanID, dstChanID, false, false, err
 			}
@@ -517,7 +517,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 		if !found || override {
 
 			if err = retry.Do(func() error {
-				srch, err = src.ChainProvider.QueryLatestHeight()
+				srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 				if err != nil || srch == 0 {
 					return fmt.Errorf("failed to query latest heights. Err: %w", err)
 				}
@@ -534,13 +534,13 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return err
 			}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 				src.LogRetryGetIBCUpdateHeader(n, err)
-				srch, _ = src.ChainProvider.QueryLatestHeight()
+				srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
 			})); err != nil {
 				return srcChanID, dstChanID, false, false, err
 			}
 
 			// open try on destination chain
-			msgs, err = dst.ChainProvider.ChannelOpenTry(src.ChainProvider, srcHeader, dstPortID, srcPortID, dstChanID, srcChanID, version, dst.ConnectionID(), dst.ClientID())
+			msgs, err = dst.ChainProvider.ChannelOpenTry(ctx, src.ChainProvider, srcHeader, dstPortID, srcPortID, dstChanID, srcChanID, version, dst.ConnectionID(), dst.ClientID())
 			if err != nil {
 				return srcChanID, dstChanID, false, false, err
 			}
@@ -571,7 +571,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 
 // CloseChannel runs the channel closing messages on timeout until they pass.
 // TODO: add max retries or something to this function
-func (c *Chain) CloseChannel(dst *Chain, to time.Duration, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) error {
+func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) error {
 	ticker := time.NewTicker(to)
 	defer ticker.Stop()
 
@@ -579,7 +579,7 @@ func (c *Chain) CloseChannel(dst *Chain, to time.Duration, srcChanID, srcPortID 
 	dstPortID := srcChan.Channel.Counterparty.PortId
 
 	for ; true; <-ticker.C {
-		closeSteps, err := c.CloseChannelStep(dst, srcChanID, srcPortID, srcChan)
+		closeSteps, err := c.CloseChannelStep(ctx, dst, srcChanID, srcPortID, srcChan)
 		if err != nil {
 			return err
 		}
@@ -589,7 +589,7 @@ func (c *Chain) CloseChannel(dst *Chain, to time.Duration, srcChanID, srcPortID 
 		}
 
 		if closeSteps.Send(c, dst); closeSteps.Success() && closeSteps.Last {
-			srch, dsth, err := QueryLatestHeights(c, dst)
+			srch, dsth, err := QueryLatestHeights(ctx, c, dst)
 			if err != nil {
 				return err
 			}
@@ -614,8 +614,8 @@ func (c *Chain) CloseChannel(dst *Chain, to time.Duration, srcChanID, srcPortID 
 // CloseChannelStep returns the next set of messages for closing a channel with given
 // identifiers between chains src and dst. If the closing handshake hasn't started, then CloseChannelStep
 // will begin the handshake on the src chain.
-func (c *Chain) CloseChannelStep(dst *Chain, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) (*RelayMsgs, error) {
-	dsth, err := dst.ChainProvider.QueryLatestHeight()
+func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) (*RelayMsgs, error) {
+	dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +664,7 @@ func (c *Chain) CloseChannelStep(dst *Chain, srcChanID, srcPortID string, srcCha
 				logChannelStates(dst, c, dstChan, srcChan)
 			}
 
-			srch, err := c.ChainProvider.QueryLatestHeight()
+			srch, err := c.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -693,7 +693,7 @@ func (c *Chain) CloseChannelStep(dst *Chain, srcChanID, srcPortID string, srcCha
 				logChannelStates(dst, c, dstChan, srcChan)
 			}
 
-			srch, err := c.ChainProvider.QueryLatestHeight()
+			srch, err := c.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -727,7 +727,7 @@ func (c *Chain) CloseChannelStep(dst *Chain, srcChanID, srcPortID string, srcCha
 				logChannelStates(c, dst, srcChan, dstChan)
 			}
 
-			dsth, err := dst.ChainProvider.QueryLatestHeight()
+			dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -153,7 +153,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 			}
@@ -201,7 +201,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 			}
@@ -245,7 +245,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 			if err != nil || srch == 0 {
 				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 			}
@@ -287,7 +287,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 			if err != nil || dsth == 0 {
 				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 			}
@@ -331,7 +331,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 		}
 
 		if err = retry.Do(func() error {
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 			if err != nil || srch == 0 {
 				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 			}
@@ -406,7 +406,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 			}
 
 			if err = retry.Do(func() error {
-				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 				if err != nil || dsth == 0 {
 					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 				}
@@ -466,7 +466,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 			}
 
 			if err = retry.Do(func() error {
-				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 				if err != nil || dsth == 0 {
 					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 				}
@@ -527,7 +527,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 			}
 
 			if err = retry.Do(func() error {
-				srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+				srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 				if err != nil || srch == 0 {
 					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
 				}
@@ -644,7 +644,7 @@ func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, src
 				logChannelStates(c, dst, srcChan, dstChan)
 			}
 
-			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(dsth, c.ChainProvider, c.ClientID())
+			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, c.ChainProvider, c.ClientID())
 			if err != nil {
 				return nil, err
 			}
@@ -669,7 +669,7 @@ func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, src
 				return nil, err
 			}
 
-			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 			if err != nil {
 				return nil, err
 			}
@@ -698,7 +698,7 @@ func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, src
 				return nil, err
 			}
 
-			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 			if err != nil {
 				return nil, err
 			}
@@ -732,7 +732,7 @@ func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, src
 				return nil, err
 			}
 
-			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(dsth, c.ChainProvider, c.ClientID())
+			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, c.ChainProvider, c.ClientID())
 			if err != nil {
 				return nil, err
 			}

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -172,7 +172,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -218,7 +218,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -262,7 +262,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			dst.LogFailedTx(res, err, msgs)
 		}
@@ -306,7 +306,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 
 		last = true
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -348,7 +348,7 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			dst.LogFailedTx(res, err, msgs)
 		}
@@ -423,7 +423,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				src.LogFailedTx(res, err, msgs)
 			}
@@ -484,7 +484,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				src.LogFailedTx(res, err, msgs)
 			}
@@ -545,7 +545,7 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = dst.ChainProvider.SendMessages(msgs)
+			res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				dst.LogFailedTx(res, err, msgs)
 			}
@@ -588,7 +588,7 @@ func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, 
 			break
 		}
 
-		if closeSteps.Send(c, dst); closeSteps.Success() && closeSteps.Last {
+		if closeSteps.Send(ctx, c, dst); closeSteps.Success() && closeSteps.Last {
 			srch, dsth, err := QueryLatestHeights(ctx, c, dst)
 			if err != nil {
 				return err

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -263,7 +263,7 @@ func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) er
 		return err
 	}
 
-	consRes, err := dst.ChainProvider.QueryUpgradedConsState(height)
+	consRes, err := dst.ChainProvider.QueryUpgradedConsState(ctx, height)
 	if err != nil {
 		return err
 	}

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -111,7 +111,7 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 		// Will not reuse same client if override is true
 		if !override {
 			// Check if an identical light client already exists
-			clientID, found = src.ChainProvider.FindMatchingClient(dst.ChainProvider, clientState)
+			clientID, found = src.ChainProvider.FindMatchingClient(ctx, dst.ChainProvider, clientState)
 		}
 
 		if !found || override {

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -128,7 +128,7 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 
 			// if a matching client does not exist, create one
 			if err = retry.Do(func() error {
-				res, success, err = src.ChainProvider.SendMessages(msgs)
+				res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 				if err != nil {
 					src.LogFailedTx(res, err, msgs)
 					return fmt.Errorf("failed to send messages on chain{%s}: %w", src.ChainID(), err)
@@ -221,7 +221,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 
 	// Send msgs to both chains
 	if clients.Ready() {
-		if clients.Send(c, dst); clients.Success() {
+		if clients.Send(ctx, c, dst); clients.Success() {
 			c.Log(fmt.Sprintf("★ Clients updated: [%s]client(%s) {%d}->{%d} and [%s]client(%s) {%d}->{%d}",
 				c.ChainID(),
 				c.PathEnd.ClientID,
@@ -278,7 +278,7 @@ func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) er
 		upgradeMsg,
 	}
 
-	res, _, err := c.ChainProvider.SendMessages(msgs)
+	res, _, err := c.ChainProvider.SendMessages(ctx, msgs)
 	if err != nil {
 		c.LogFailedTx(res, err, msgs)
 		return err

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -78,7 +78,7 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 
 		// Query the trusting period for dst and retry if the query fails
 		if err = retry.Do(func() error {
-			tp, err = dst.GetTrustingPeriod()
+			tp, err = dst.GetTrustingPeriod(ctx)
 			if err != nil || tp.String() == "0s" {
 				return fmt.Errorf("failed to get trusting period for chain{%s}: %w", dst.ChainID(), err)
 			}

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -34,7 +34,7 @@ func (c *Chain) CreateClients(ctx context.Context, dst *Chain, allowUpdateAfterE
 
 	// Query the light signed headers for src & dst at the heights srch & dsth, retry if the query fails
 	if err = retry.Do(func() error {
-		srcUpdateHeader, dstUpdateHeader, err = GetLightSignedHeadersAtHeights(c, dst, srch, dsth)
+		srcUpdateHeader, dstUpdateHeader, err = GetLightSignedHeadersAtHeights(ctx, c, dst, srch, dsth)
 		if err != nil {
 			return fmt.Errorf("failed to query light signed headers: %w", err)
 		}
@@ -187,7 +187,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 	}
 
 	if err = retry.Do(func() error {
-		srcUpdateHeader, dstUpdateHeader, err = GetIBCUpdateHeaders(srch, dsth, c.ChainProvider, dst.ChainProvider, c.ClientID(), dst.ClientID())
+		srcUpdateHeader, dstUpdateHeader, err = GetIBCUpdateHeaders(ctx, srch, dsth, c.ChainProvider, dst.ChainProvider, c.ClientID(), dst.ClientID())
 		if err != nil {
 			c.Log(fmt.Sprintf("Failed to query light signed headers. Err: %v", err))
 			return err
@@ -239,7 +239,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 
 // UpgradeClients upgrades the client on src after dst chain has undergone an upgrade.
 func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) error {
-	dstHeader, err := dst.ChainProvider.GetLightSignedHeaderAtHeight(height)
+	dstHeader, err := dst.ChainProvider.GetLightSignedHeaderAtHeight(ctx, height)
 	if err != nil {
 		return err
 	}

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -238,7 +238,7 @@ func (c *Chain) UpdateClients(dst *Chain) (err error) {
 }
 
 // UpgradeClients upgrades the client on src after dst chain has undergone an upgrade.
-func (c *Chain) UpgradeClients(dst *Chain, height int64) error {
+func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) error {
 	dstHeader, err := dst.ChainProvider.GetLightSignedHeaderAtHeight(height)
 	if err != nil {
 		return err
@@ -258,7 +258,7 @@ func (c *Chain) UpgradeClients(dst *Chain, height int64) error {
 	}
 
 	// query proofs on counterparty
-	clientRes, err := dst.ChainProvider.QueryUpgradedClient(height)
+	clientRes, err := dst.ChainProvider.QueryUpgradedClient(ctx, height)
 	if err != nil {
 		return err
 	}

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -105,7 +105,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 	// is chosen or a new connection is created.
 	// This will perform either an OpenInit or OpenTry step and return
 	if err = retry.Do(func() error {
-		srcHeader, dstHeader, err = GetIBCUpdateHeaders(srch, dsth, src.ChainProvider, dst.ChainProvider, src.ClientID(), dst.ClientID())
+		srcHeader, dstHeader, err = GetIBCUpdateHeaders(ctx, srch, dsth, src.ChainProvider, dst.ChainProvider, src.ClientID(), dst.ClientID())
 		return err
 	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 		src.Log(fmt.Sprintf("failed to get IBC update headers, try(%d/%d). Err: %v", n+1, RtyAttNum, err))
@@ -270,7 +270,7 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 
 	// Get IBC Update Headers for src and dst which can be used to update an on chain light client on the counterparty
 	if err = retry.Do(func() error {
-		srcHeader, dstHeader, err = GetIBCUpdateHeaders(srch, dsth, src.ChainProvider, dst.ChainProvider, src.ClientID(), dst.ClientID())
+		srcHeader, dstHeader, err = GetIBCUpdateHeaders(ctx, srch, dsth, src.ChainProvider, dst.ChainProvider, src.ClientID(), dst.ClientID())
 		return err
 	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 		src.Log(fmt.Sprintf("failed to get IBC update headers, try(%d/%d). Err: %v", n+1, RtyAttNum, err))

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -144,7 +144,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -166,7 +166,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -187,7 +187,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			dst.LogFailedTx(res, err, msgs)
 		}
@@ -206,7 +206,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			src.LogFailedTx(res, err, msgs)
 		}
@@ -227,7 +227,7 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 		if err != nil {
 			dst.LogFailedTx(res, err, msgs)
 		}
@@ -296,7 +296,7 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				src.LogFailedTx(res, err, msgs)
 			}
@@ -332,7 +332,7 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				src.LogFailedTx(res, err, msgs)
 			}
@@ -368,7 +368,7 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = dst.ChainProvider.SendMessages(msgs)
+			res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
 			if err != nil {
 				dst.LogFailedTx(res, err, msgs)
 			}

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UnrelayedSequences returns the unrelayed sequence numbers between two chains
-func UnrelayedSequences(src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
+func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
 	var (
 		eg           = new(errgroup.Group)
 		srcPacketSeq = []uint64{}
@@ -32,7 +32,7 @@ func UnrelayedSequences(src, dst *Chain, srcChannel *chantypes.IdentifiedChannel
 		)
 		if err = retry.Do(func() error {
 			// Query the packet commitment
-			res, err = src.ChainProvider.QueryPacketCommitments(uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
+			res, err = src.ChainProvider.QueryPacketCommitments(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -59,7 +59,7 @@ func UnrelayedSequences(src, dst *Chain, srcChannel *chantypes.IdentifiedChannel
 			err error
 		)
 		if err = retry.Do(func() error {
-			res, err = dst.ChainProvider.QueryPacketCommitments(uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+			res, err = dst.ChainProvider.QueryPacketCommitments(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
 			switch {
 			case err != nil:
 				return err

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -88,7 +88,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		// Query all packets sent by src that have been received by dst
 		return retry.Do(func() error {
 			var err error
-			rs.Src, err = dst.ChainProvider.QueryUnreceivedPackets(uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
+			rs.Src, err = dst.ChainProvider.QueryUnreceivedPackets(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryQueryUnreceivedPackets(n, err, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
@@ -100,7 +100,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		// Query all packets sent by dst that have been received by src
 		return retry.Do(func() error {
 			var err error
-			rs.Dst, err = src.ChainProvider.QueryUnreceivedPackets(uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
+			rs.Dst, err = src.ChainProvider.QueryUnreceivedPackets(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.LogRetryQueryUnreceivedPackets(n, err, srcChannel.ChannelId, srcChannel.PortId)

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -316,7 +316,7 @@ func RelayAcknowledgements(ctx context.Context, src, dst *Chain, sp *RelaySequen
 		}
 
 		// send messages to their respective chains
-		if msgs.Send(src, dst); msgs.Success() {
+		if msgs.Send(ctx, src, dst); msgs.Success() {
 			if len(msgs.Dst) > 1 {
 				dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 			}
@@ -384,7 +384,7 @@ func RelayPackets(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxT
 		}
 
 		// send messages to their respective chains
-		if msgs.Send(src, dst); msgs.Success() {
+		if msgs.Send(ctx, src, dst); msgs.Success() {
 			if len(msgs.Dst) > 1 {
 				dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 			}
@@ -576,7 +576,7 @@ func RelayPacket(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxTx
 	}
 
 	// send messages to their respective chains
-	if msgs.Send(src, dst); msgs.Success() {
+	if msgs.Send(ctx, src, dst); msgs.Success() {
 		if len(msgs.Dst) > 1 {
 			dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 		}

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -253,12 +253,12 @@ func RelayAcknowledgements(ctx context.Context, src, dst *Chain, sp *RelaySequen
 		)
 		eg.Go(func() error {
 			var err error
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.PathEnd.ClientID)
+			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
 			return err
 		})
 		eg.Go(func() error {
 			var err error
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.PathEnd.ClientID)
+			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.PathEnd.ClientID)
 			return err
 		})
 		if err := eg.Wait(); err != nil {
@@ -442,7 +442,7 @@ func PrependUpdateClientMsg(ctx context.Context, msgs *[]provider.RelayerMessage
 
 		// Query IBC Update Header
 		if err = retry.Do(func() error {
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.PathEnd.ClientID)
+			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			srch, _, _ = QueryLatestHeights(ctx, src, dst)
@@ -550,7 +550,7 @@ func RelayPacket(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxTx
 
 	// Prepend non-empty msg lists with UpdateClient
 	if len(msgs.Dst) != 0 {
-		srcHeader, err := src.ChainProvider.GetIBCUpdateHeader(srch, dst.ChainProvider, dst.ClientID())
+		srcHeader, err := src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
 		if err != nil {
 			return err
 		}
@@ -563,7 +563,7 @@ func RelayPacket(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxTx
 	}
 
 	if len(msgs.Src) != 0 {
-		dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(dsth, src.ChainProvider, src.ClientID())
+		dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
 		if err != nil {
 			return err
 		}

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -190,7 +190,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		// Query all packets sent by src that have been received by dst
 		var err error
 		return retry.Do(func() error {
-			rs.Src, err = dst.ChainProvider.QueryUnreceivedAcknowledgements(uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
+			rs.Src, err = dst.ChainProvider.QueryUnreceivedAcknowledgements(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
 			return err
 		}, RtyErr, RtyAtt, RtyDel, retry.OnRetry(func(n uint, err error) {
 			dsth, _ = dst.ChainProvider.QueryLatestHeight()
@@ -201,7 +201,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		// Query all packets sent by dst that have been received by src
 		var err error
 		return retry.Do(func() error {
-			rs.Dst, err = src.ChainProvider.QueryUnreceivedAcknowledgements(uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
+			rs.Dst, err = src.ChainProvider.QueryUnreceivedAcknowledgements(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			srch, _ = src.ChainProvider.QueryLatestHeight()

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -116,7 +116,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 }
 
 // UnrelayedAcknowledgements returns the unrelayed sequence numbers between two chains
-func UnrelayedAcknowledgements(src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
+func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
 	var (
 		eg           = new(errgroup.Group)
 		srcPacketSeq = []uint64{}
@@ -136,7 +136,7 @@ func UnrelayedAcknowledgements(src, dst *Chain, srcChannel *chantypes.Identified
 		)
 		if err = retry.Do(func() error {
 			// Query the packet commitment
-			res, err = src.ChainProvider.QueryPacketAcknowledgements(uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
+			res, err = src.ChainProvider.QueryPacketAcknowledgements(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -162,7 +162,7 @@ func UnrelayedAcknowledgements(src, dst *Chain, srcChannel *chantypes.Identified
 			err error
 		)
 		if err = retry.Do(func() error {
-			res, err = dst.ChainProvider.QueryPacketAcknowledgements(uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+			res, err = dst.ChainProvider.QueryPacketAcknowledgements(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
 			switch {
 			case err != nil:
 				return err

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -54,7 +54,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, dst *Chain, amount sdk.Coin
 		Dst: []provider.RelayerMessage{},
 	}
 
-	if txs.Send(c, dst); !txs.Success() {
+	if txs.Send(ctx, c, dst); !txs.Success() {
 		return fmt.Errorf("failed to send transfer message")
 	}
 	return nil

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -11,14 +12,14 @@ import (
 
 //nolint:lll
 // SendTransferMsg initiates an ics20 transfer from src to dst with the specified args
-func (c *Chain) SendTransferMsg(dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
+func (c *Chain) SendTransferMsg(ctx context.Context, dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
 	var (
 		timeoutHeight    uint64
 		timeoutTimestamp uint64
 	)
 
 	// get header representing dst to check timeouts
-	dsth, err := dst.ChainProvider.QueryLatestHeight()
+	dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return err
 	}

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -23,7 +23,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, dst *Chain, amount sdk.Coin
 	if err != nil {
 		return err
 	}
-	h, err := dst.ChainProvider.GetIBCUpdateHeader(dsth, c.ChainProvider, c.PathEnd.ClientID)
+	h, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, c.ChainProvider, c.PathEnd.ClientID)
 	if err != nil {
 		return err
 	}

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"context"
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
@@ -167,7 +168,7 @@ type PathWithStatus struct {
 
 // QueryPathStatus returns an instance of the path struct with some attached data about
 // the current status of the path
-func (p *Path) QueryPathStatus(src, dst *Chain) *PathWithStatus {
+func (p *Path) QueryPathStatus(ctx context.Context, src, dst *Chain) *PathWithStatus {
 	var (
 		err              error
 		eg               errgroup.Group
@@ -178,11 +179,11 @@ func (p *Path) QueryPathStatus(src, dst *Chain) *PathWithStatus {
 		out = &PathWithStatus{Path: p, Status: PathStatus{false, false, false}}
 	)
 	eg.Go(func() error {
-		srch, err = src.ChainProvider.QueryLatestHeight()
+		srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 		return err
 	})
 	eg.Go(func() error {
-		dsth, err = dst.ChainProvider.QueryLatestHeight()
+		dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 		return err
 	})
 	if err = eg.Wait(); err != nil {

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -3,22 +3,21 @@ package cosmos
 import (
 	"context"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/types/module"
 	"math"
 	"os"
 	"reflect"
 	"strconv"
 	"time"
 
+	"github.com/avast/retry-go"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-
-	"github.com/avast/retry-go"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/module"
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
@@ -893,8 +892,8 @@ func (cc *CosmosProvider) MsgRelayRecvPacket(dst provider.ChainProvider, dsth in
 }
 
 // RelayPacketFromSequence relays a packet with a given seq on src and returns recvPacket msgs, timeoutPacketmsgs and error
-func (cc *CosmosProvider) RelayPacketFromSequence(src, dst provider.ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (provider.RelayerMessage, provider.RelayerMessage, error) {
-	txs, err := cc.QueryTxs(1, 1000, rcvPacketQuery(srcChanId, int(seq)))
+func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst provider.ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (provider.RelayerMessage, provider.RelayerMessage, error) {
+	txs, err := cc.QueryTxs(ctx, 1, 1000, rcvPacketQuery(srcChanId, int(seq)))
 	switch {
 	case err != nil:
 		return nil, nil, err
@@ -945,8 +944,8 @@ func (cc *CosmosProvider) RelayPacketFromSequence(src, dst provider.ChainProvide
 }
 
 // AcknowledgementFromSequence relays an acknowledgement with a given seq on src, source is the sending chain, destination is the receiving chain
-func (cc *CosmosProvider) AcknowledgementFromSequence(dst provider.ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
-	txs, err := dst.QueryTxs(1, 1000, ackPacketQuery(dstChanId, int(seq)))
+func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst provider.ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+	txs, err := dst.QueryTxs(ctx, 1, 1000, ackPacketQuery(dstChanId, int(seq)))
 	switch {
 	case err != nil:
 		return nil, err

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -319,7 +319,7 @@ func (cc *CosmosProvider) ConnectionOpenInit(srcClientId, dstClientId string, ds
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ConnectionOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ConnectionOpenTry(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -329,7 +329,7 @@ func (cc *CosmosProvider) ConnectionOpenTry(dstQueryProvider provider.QueryProvi
 		return nil, err
 	}
 
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (cc *CosmosProvider) ConnectionOpenTry(dstQueryProvider provider.QueryProvi
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ConnectionOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ConnectionOpenAck(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -386,7 +386,7 @@ func (cc *CosmosProvider) ConnectionOpenAck(dstQueryProvider provider.QueryProvi
 	if err != nil {
 		return nil, err
 	}
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (cc *CosmosProvider) ConnectionOpenAck(dstQueryProvider provider.QueryProvi
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ConnectionOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ConnectionOpenConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -435,7 +435,7 @@ func (cc *CosmosProvider) ConnectionOpenConfirm(dstQueryProvider provider.QueryP
 		return nil, err
 	}
 
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func (cc *CosmosProvider) ChannelOpenInit(srcClientId, srcConnId, srcPortId, src
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenTry(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -499,7 +499,7 @@ func (cc *CosmosProvider) ChannelOpenTry(dstQueryProvider provider.QueryProvider
 	if err != nil {
 		return nil, err
 	}
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +535,7 @@ func (cc *CosmosProvider) ChannelOpenTry(dstQueryProvider provider.QueryProvider
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenAck(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -545,7 +545,7 @@ func (cc *CosmosProvider) ChannelOpenAck(dstQueryProvider provider.QueryProvider
 		return nil, err
 	}
 
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func (cc *CosmosProvider) ChannelOpenAck(dstQueryProvider provider.QueryProvider
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenConfirm(dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChanId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChanId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -581,7 +581,7 @@ func (cc *CosmosProvider) ChannelOpenConfirm(dstQueryProvider provider.QueryProv
 	if err != nil {
 		return nil, err
 	}
-	cph, err := dstQueryProvider.QueryLatestHeight()
+	cph, err := dstQueryProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1153,12 +1153,12 @@ func (cc *CosmosProvider) MsgUpgradeClient(srcClientId string, consRes *clientty
 }
 
 // AutoUpdateClient update client automatically to prevent expiry
-func (cc *CosmosProvider) AutoUpdateClient(dst provider.ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error) {
-	srch, err := cc.QueryLatestHeight()
+func (cc *CosmosProvider) AutoUpdateClient(ctx context.Context, dst provider.ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error) {
+	srch, err := cc.QueryLatestHeight(ctx)
 	if err != nil {
 		return 0, err
 	}
-	dsth, err := dst.QueryLatestHeight()
+	dsth, err := dst.QueryLatestHeight(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -198,8 +198,8 @@ func (cc *CosmosProvider) Address() (string, error) {
 	return out, err
 }
 
-func (cc *CosmosProvider) TrustingPeriod() (time.Duration, error) {
-	res, err := cc.QueryStakingParams(context.Background())
+func (cc *CosmosProvider) TrustingPeriod(ctx context.Context) (time.Duration, error) {
+	res, err := cc.QueryStakingParams(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1229,7 +1229,7 @@ func (cc *CosmosProvider) AutoUpdateClient(ctx context.Context, dst provider.Cha
 
 	msgs := []provider.RelayerMessage{updateMsg}
 
-	res, success, err := cc.SendMessages(msgs)
+	res, success, err := cc.SendMessages(ctx, msgs)
 	if err != nil {
 		// cp.LogFailedTx(res, err, CosmosMsgs(msgs...))
 		return 0, err
@@ -1468,8 +1468,8 @@ func MustGetHeight(h ibcexported.Height) clienttypes.Height {
 
 // SendMessage attempts to sign, encode & send a RelayerMessage
 // This is used extensively in the relayer as an extension of the Provider interface
-func (cc *CosmosProvider) SendMessage(msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
-	return cc.SendMessages([]provider.RelayerMessage{msg})
+func (cc *CosmosProvider) SendMessage(ctx context.Context, msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+	return cc.SendMessages(ctx, []provider.RelayerMessage{msg})
 }
 
 // SendMessages attempts to sign, encode, & send a slice of RelayerMessages
@@ -1479,7 +1479,7 @@ func (cc *CosmosProvider) SendMessage(msg provider.RelayerMessage) (*provider.Re
 // transaction will not return an error. If a transaction is successfully sent, the result of the execution
 // of that transaction will be logged. A boolean indicating if a transaction was successfully
 // sent and executed successfully is returned.
-func (cc *CosmosProvider) SendMessages(msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+func (cc *CosmosProvider) SendMessages(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 	var (
 		txb     client.TxBuilder
 		txBytes []byte
@@ -1545,7 +1545,7 @@ func (cc *CosmosProvider) SendMessages(msgs []provider.RelayerMessage) (*provide
 		return nil, false, err
 	}
 
-	res, err = cc.BroadcastTx(context.Background(), txBytes)
+	res, err = cc.BroadcastTx(ctx, txBytes)
 	if err != nil || res == nil {
 		return nil, false, err
 	}

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1253,7 +1253,7 @@ func (cc *CosmosProvider) AutoUpdateClient(dst provider.ChainProvider, threshold
 // and check if any match the counterparty. The counterparty must have a matching consensus state
 // to the latest consensus state of a potential match. The provided client state is the client
 // state that will be created if there exist no matches.
-func (cc *CosmosProvider) FindMatchingClient(counterparty provider.ChainProvider, clientState ibcexported.ClientState) (string, bool) {
+func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty provider.ChainProvider, clientState ibcexported.ClientState) (string, bool) {
 	// TODO: add appropriate offset and limits
 	var (
 		clientsResp clienttypes.IdentifiedClientStates
@@ -1261,7 +1261,7 @@ func (cc *CosmosProvider) FindMatchingClient(counterparty provider.ChainProvider
 	)
 
 	if err = retry.Do(func() error {
-		clientsResp, err = cc.QueryClients()
+		clientsResp, err = cc.QueryClients(ctx)
 		if err != nil {
 			if cc.PCfg.Debug {
 				cc.Log(fmt.Sprintf("Error: querying clients on %s failed: %v", cc.PCfg.ChainID, err))

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1435,9 +1435,9 @@ func castClientStateToTMType(cs *codectypes.Any) (*tmclient.ClientState, error) 
 }
 
 // WaitForNBlocks blocks until the next block on a given chain
-func (cc *CosmosProvider) WaitForNBlocks(n int64) error {
+func (cc *CosmosProvider) WaitForNBlocks(ctx context.Context, n int64) error {
 	var initial int64
-	h, err := cc.RPCClient.Status(context.Background())
+	h, err := cc.RPCClient.Status(ctx)
 	if err != nil {
 		return err
 	}
@@ -1446,7 +1446,7 @@ func (cc *CosmosProvider) WaitForNBlocks(n int64) error {
 	}
 	initial = h.SyncInfo.LatestBlockHeight
 	for {
-		h, err = cc.RPCClient.Status(context.Background())
+		h, err = cc.RPCClient.Status(ctx)
 		if err != nil {
 			return err
 		}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -444,9 +444,9 @@ func (cc *CosmosProvider) queryConnectionABCI(height int64, connectionID string)
 
 // QueryConnections gets any connections on a chain
 // TODO add pagination support
-func (cc *CosmosProvider) QueryConnections() (conns []*conntypes.IdentifiedConnection, err error) {
+func (cc *CosmosProvider) QueryConnections(ctx context.Context) (conns []*conntypes.IdentifiedConnection, err error) {
 	qc := conntypes.NewQueryClient(cc)
-	res, err := qc.Connections(context.Background(), &conntypes.QueryConnectionsRequest{
+	res, err := qc.Connections(ctx, &conntypes.QueryConnectionsRequest{
 		Pagination: DefaultPageRequest(),
 	})
 	if err != nil || res == nil {
@@ -457,9 +457,9 @@ func (cc *CosmosProvider) QueryConnections() (conns []*conntypes.IdentifiedConne
 
 // QueryConnectionsUsingClient gets any connections that exist between chain and counterparty
 // TODO add pagination support
-func (cc *CosmosProvider) QueryConnectionsUsingClient(height int64, clientid string) (*conntypes.QueryConnectionsResponse, error) {
+func (cc *CosmosProvider) QueryConnectionsUsingClient(ctx context.Context, height int64, clientid string) (*conntypes.QueryConnectionsResponse, error) {
 	qc := conntypes.NewQueryClient(cc)
-	res, err := qc.Connections(context.Background(), &conntypes.QueryConnectionsRequest{
+	res, err := qc.Connections(ctx, &conntypes.QueryConnectionsRequest{
 		Pagination: DefaultPageRequest(),
 	})
 	return res, err

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -92,11 +92,11 @@ func (cc *CosmosProvider) QueryBalanceWithAddress(ctx context.Context, address s
 }
 
 // QueryUnbondingPeriod returns the unbonding period of the chain
-func (cc *CosmosProvider) QueryUnbondingPeriod() (time.Duration, error) {
+func (cc *CosmosProvider) QueryUnbondingPeriod(ctx context.Context) (time.Duration, error) {
 	req := stakingtypes.QueryParamsRequest{}
 	queryClient := stakingtypes.NewQueryClient(cc)
 
-	res, err := queryClient.Params(context.Background(), &req)
+	res, err := queryClient.Params(ctx, &req)
 	if err != nil {
 		return 0, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -629,9 +629,9 @@ func (cc *CosmosProvider) QueryPacketAcknowledgements(ctx context.Context, heigh
 }
 
 // QueryUnreceivedPackets returns a list of unrelayed packet commitments
-func (cc *CosmosProvider) QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
+func (cc *CosmosProvider) QueryUnreceivedPackets(ctx context.Context, height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
 	qc := chantypes.NewQueryClient(cc)
-	res, err := qc.UnreceivedPackets(context.Background(), &chantypes.QueryUnreceivedPacketsRequest{
+	res, err := qc.UnreceivedPackets(ctx, &chantypes.QueryUnreceivedPacketsRequest{
 		PortId:                    portid,
 		ChannelId:                 channelid,
 		PacketCommitmentSequences: seqs,

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -643,9 +643,9 @@ func (cc *CosmosProvider) QueryUnreceivedPackets(ctx context.Context, height uin
 }
 
 // QueryUnreceivedAcknowledgements returns a list of unrelayed packet acks
-func (cc *CosmosProvider) QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
+func (cc *CosmosProvider) QueryUnreceivedAcknowledgements(ctx context.Context, height uint64, channelid, portid string, seqs []uint64) ([]uint64, error) {
 	qc := chantypes.NewQueryClient(cc)
-	res, err := qc.UnreceivedAcks(context.Background(), &chantypes.QueryUnreceivedAcksRequest{
+	res, err := qc.UnreceivedAcks(ctx, &chantypes.QueryUnreceivedAcksRequest{
 		PortId:             portid,
 		ChannelId:          channelid,
 		PacketAckSequences: seqs,

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -600,9 +600,9 @@ func (cc *CosmosProvider) QueryChannels(ctx context.Context) ([]*chantypes.Ident
 
 // QueryPacketCommitments returns an array of packet commitments
 // TODO add pagination support
-func (cc *CosmosProvider) QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error) {
+func (cc *CosmosProvider) QueryPacketCommitments(ctx context.Context, height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error) {
 	qc := chantypes.NewQueryClient(cc)
-	c, err := qc.PacketCommitments(context.Background(), &chantypes.QueryPacketCommitmentsRequest{
+	c, err := qc.PacketCommitments(ctx, &chantypes.QueryPacketCommitmentsRequest{
 		PortId:     portid,
 		ChannelId:  channelid,
 		Pagination: DefaultPageRequest(),

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -298,12 +298,12 @@ func (cc *CosmosProvider) QueryUpgradeProof(key []byte, height uint64) ([]byte, 
 }
 
 // QueryUpgradedClient returns upgraded client info
-func (cc *CosmosProvider) QueryUpgradedClient(height int64) (*clienttypes.QueryClientStateResponse, error) {
+func (cc *CosmosProvider) QueryUpgradedClient(ctx context.Context, height int64) (*clienttypes.QueryClientStateResponse, error) {
 	req := clienttypes.QueryUpgradedClientStateRequest{}
 
 	queryClient := clienttypes.NewQueryClient(cc)
 
-	res, err := queryClient.UpgradedClientState(context.Background(), &req)
+	res, err := queryClient.UpgradedClientState(ctx, &req)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -587,15 +587,15 @@ func (cc *CosmosProvider) QueryConnectionChannels(ctx context.Context, height in
 
 // QueryChannels returns all the channels that are registered on a chain
 // TODO add pagination support
-func (cc *CosmosProvider) QueryChannels() ([]*chantypes.IdentifiedChannel, error) {
+func (cc *CosmosProvider) QueryChannels(ctx context.Context) ([]*chantypes.IdentifiedChannel, error) {
 	qc := chantypes.NewQueryClient(cc)
-	res, err := qc.Channels(context.Background(), &chantypes.QueryChannelsRequest{
+	res, err := qc.Channels(ctx, &chantypes.QueryChannelsRequest{
 		Pagination: DefaultPageRequest(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.Channels, err
+	return res.Channels, nil
 }
 
 // QueryPacketCommitments returns an array of packet commitments

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -573,9 +573,9 @@ func (cc *CosmosProvider) QueryChannelClient(ctx context.Context, height int64, 
 }
 
 // QueryConnectionChannels queries the channels associated with a connection
-func (cc *CosmosProvider) QueryConnectionChannels(height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error) {
+func (cc *CosmosProvider) QueryConnectionChannels(ctx context.Context, height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error) {
 	qc := chantypes.NewQueryClient(cc)
-	chans, err := qc.ConnectionChannels(context.Background(), &chantypes.QueryConnectionChannelsRequest{
+	chans, err := qc.ConnectionChannels(ctx, &chantypes.QueryConnectionChannelsRequest{
 		Connection: connectionid,
 		Pagination: DefaultPageRequest(),
 	})

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -65,31 +65,25 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 }
 
 // QueryBalance returns the amount of coins in the relayer account
-func (cc *CosmosProvider) QueryBalance(keyName string) (sdk.Coins, error) {
-	var (
-		addr string
-		err  error
-	)
-	if keyName == "" {
-		addr, err = cc.Address()
-	} else {
+func (cc *CosmosProvider) QueryBalance(ctx context.Context, keyName string) (sdk.Coins, error) {
+	if keyName != "" {
 		cc.PCfg.Key = keyName
-		addr, err = cc.Address()
 	}
-
+	addr, err := cc.Address()
 	if err != nil {
 		return nil, err
 	}
-	return cc.QueryBalanceWithAddress(addr)
+
+	return cc.QueryBalanceWithAddress(ctx, addr)
 }
 
 // QueryBalanceWithAddress returns the amount of coins in the relayer account with address as input
 // TODO add pagination support
-func (cc *CosmosProvider) QueryBalanceWithAddress(address string) (sdk.Coins, error) {
+func (cc *CosmosProvider) QueryBalanceWithAddress(ctx context.Context, address string) (sdk.Coins, error) {
 	p := &bankTypes.QueryAllBalancesRequest{Address: address, Pagination: DefaultPageRequest()}
 	queryClient := bankTypes.NewQueryClient(cc)
 
-	res, err := queryClient.AllBalances(context.Background(), p)
+	res, err := queryClient.AllBalances(ctx, p)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -780,8 +780,8 @@ func (cc *CosmosProvider) QueryHeaderAtHeight(ctx context.Context, height int64)
 }
 
 // QueryDenomTrace takes a denom from IBC and queries the information about it
-func (cc *CosmosProvider) QueryDenomTrace(denom string) (*transfertypes.DenomTrace, error) {
-	transfers, err := transfertypes.NewQueryClient(cc).DenomTrace(context.Background(),
+func (cc *CosmosProvider) QueryDenomTrace(ctx context.Context, denom string) (*transfertypes.DenomTrace, error) {
+	transfers, err := transfertypes.NewQueryClient(cc).DenomTrace(ctx,
 		&transfertypes.QueryDenomTraceRequest{
 			Hash: denom,
 		})
@@ -793,8 +793,8 @@ func (cc *CosmosProvider) QueryDenomTrace(denom string) (*transfertypes.DenomTra
 
 // QueryDenomTraces returns all the denom traces from a given chain
 // TODO add pagination support
-func (cc *CosmosProvider) QueryDenomTraces(offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error) {
-	transfers, err := transfertypes.NewQueryClient(cc).DenomTraces(context.Background(),
+func (cc *CosmosProvider) QueryDenomTraces(ctx context.Context, offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error) {
+	transfers, err := transfertypes.NewQueryClient(cc).DenomTraces(ctx,
 		&transfertypes.QueryDenomTracesRequest{
 			Pagination: DefaultPageRequest(),
 		})

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -379,9 +379,9 @@ func (cc *CosmosProvider) QueryConsensusState(ctx context.Context, height int64)
 
 // QueryClients queries all the clients!
 // TODO add pagination support
-func (cc *CosmosProvider) QueryClients() (clienttypes.IdentifiedClientStates, error) {
+func (cc *CosmosProvider) QueryClients(ctx context.Context) (clienttypes.IdentifiedClientStates, error) {
 	qc := clienttypes.NewQueryClient(cc)
-	state, err := qc.ClientStates(context.Background(), &clienttypes.QueryClientStatesRequest{
+	state, err := qc.ClientStates(ctx, &clienttypes.QueryClientStatesRequest{
 		Pagination: DefaultPageRequest(),
 	})
 	if err != nil {

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -736,8 +736,8 @@ func (cc *CosmosProvider) QueryPacketReceipt(height int64, channelid, portid str
 	}, nil
 }
 
-func (cc *CosmosProvider) QueryLatestHeight() (int64, error) {
-	stat, err := cc.RPCClient.Status(context.Background())
+func (cc *CosmosProvider) QueryLatestHeight(ctx context.Context) (int64, error) {
+	stat, err := cc.RPCClient.Status(ctx)
 	if err != nil {
 		return -1, err
 	} else if stat.SyncInfo.CatchingUp {

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -615,9 +615,9 @@ func (cc *CosmosProvider) QueryPacketCommitments(ctx context.Context, height uin
 
 // QueryPacketAcknowledgements returns an array of packet acks
 // TODO add pagination support
-func (cc *CosmosProvider) QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error) {
+func (cc *CosmosProvider) QueryPacketAcknowledgements(ctx context.Context, height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error) {
 	qc := chantypes.NewQueryClient(cc)
-	acks, err := qc.PacketAcknowledgements(context.Background(), &chantypes.QueryPacketAcknowledgementsRequest{
+	acks, err := qc.PacketAcknowledgements(ctx, &chantypes.QueryPacketAcknowledgementsRequest{
 		PortId:     portid,
 		ChannelId:  channelid,
 		Pagination: DefaultPageRequest(),

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -353,8 +353,8 @@ func (cc *CosmosProvider) QueryUpgradedConsState(ctx context.Context, height int
 
 // QueryConsensusState returns a consensus state for a given chain to be used as a
 // client in another chain, fetches latest height when passed 0 as arg
-func (cc *CosmosProvider) QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error) {
-	commit, err := cc.RPCClient.Commit(context.Background(), &height)
+func (cc *CosmosProvider) QueryConsensusState(ctx context.Context, height int64) (ibcexported.ConsensusState, int64, error) {
+	commit, err := cc.RPCClient.Commit(ctx, &height)
 	if err != nil {
 		return &ibctmtypes.ConsensusState{}, 0, err
 	}
@@ -363,7 +363,7 @@ func (cc *CosmosProvider) QueryConsensusState(height int64) (ibcexported.Consens
 	count := 10_000
 
 	nextHeight := height + 1
-	nextVals, err := cc.RPCClient.Validators(context.Background(), &nextHeight, &page, &count)
+	nextVals, err := cc.RPCClient.Validators(ctx, &nextHeight, &page, &count)
 	if err != nil {
 		return &ibctmtypes.ConsensusState{}, 0, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -325,12 +325,12 @@ func (cc *CosmosProvider) QueryUpgradedClient(ctx context.Context, height int64)
 }
 
 // QueryUpgradedConsState returns upgraded consensus state and height of client
-func (cc *CosmosProvider) QueryUpgradedConsState(height int64) (*clienttypes.QueryConsensusStateResponse, error) {
+func (cc *CosmosProvider) QueryUpgradedConsState(ctx context.Context, height int64) (*clienttypes.QueryConsensusStateResponse, error) {
 	req := clienttypes.QueryUpgradedConsensusStateRequest{}
 
 	queryClient := clienttypes.NewQueryClient(cc)
 
-	res, err := queryClient.UpgradedConsensusState(context.Background(), &req)
+	res, err := queryClient.UpgradedConsensusState(ctx, &req)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -560,9 +560,9 @@ func (cc *CosmosProvider) queryChannelABCI(height int64, portID, channelID strin
 }
 
 // QueryChannelClient returns the client state of the client supporting a given channel
-func (cc *CosmosProvider) QueryChannelClient(height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error) {
+func (cc *CosmosProvider) QueryChannelClient(ctx context.Context, height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error) {
 	qc := chantypes.NewQueryClient(cc)
-	cState, err := qc.ChannelClientState(context.Background(), &chantypes.QueryChannelClientStateRequest{
+	cState, err := qc.ChannelClientState(ctx, &chantypes.QueryChannelClientStateRequest{
 		PortId:    portid,
 		ChannelId: channelid,
 	})

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -34,17 +34,17 @@ import (
 )
 
 // QueryTx takes a transaction hash and returns the transaction
-func (cc *CosmosProvider) QueryTx(hashHex string) (*ctypes.ResultTx, error) {
+func (cc *CosmosProvider) QueryTx(ctx context.Context, hashHex string) (*ctypes.ResultTx, error) {
 	hash, err := hex.DecodeString(hashHex)
 	if err != nil {
-		return &ctypes.ResultTx{}, err
+		return nil, err
 	}
 
-	return cc.RPCClient.Tx(context.Background(), hash, true)
+	return cc.RPCClient.Tx(ctx, hash, true)
 }
 
 // QueryTxs returns an array of transactions given a tag
-func (cc *CosmosProvider) QueryTxs(page, limit int, events []string) ([]*ctypes.ResultTx, error) {
+func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error) {
 	if len(events) == 0 {
 		return nil, errors.New("must declare at least one event to search")
 	}
@@ -57,7 +57,7 @@ func (cc *CosmosProvider) QueryTxs(page, limit int, events []string) ([]*ctypes.
 		return nil, errors.New("limit must greater than 0")
 	}
 
-	res, err := cc.RPCClient.TxSearch(context.Background(), strings.Join(events, " AND "), true, &page, &limit, "")
+	res, err := cc.RPCClient.TxSearch(ctx, strings.Join(events, " AND "), true, &page, &limit, "")
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -747,7 +747,7 @@ func (cc *CosmosProvider) QueryLatestHeight(ctx context.Context) (int64, error) 
 }
 
 // QueryHeaderAtHeight returns the header at a given height
-func (cc *CosmosProvider) QueryHeaderAtHeight(height int64) (ibcexported.Header, error) {
+func (cc *CosmosProvider) QueryHeaderAtHeight(ctx context.Context, height int64) (ibcexported.Header, error) {
 	var (
 		page    = 1
 		perPage = 100000
@@ -756,12 +756,12 @@ func (cc *CosmosProvider) QueryHeaderAtHeight(height int64) (ibcexported.Header,
 		return nil, fmt.Errorf("must pass in valid height, %d not valid", height)
 	}
 
-	res, err := cc.RPCClient.Commit(context.Background(), &height)
+	res, err := cc.RPCClient.Commit(ctx, &height)
 	if err != nil {
 		return nil, err
 	}
 
-	val, err := cc.RPCClient.Validators(context.Background(), &height, &page, &perPage)
+	val, err := cc.RPCClient.Validators(ctx, &height, &page, &perPage)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -106,7 +106,7 @@ type QueryProvider interface {
 	QueryClientStateResponse(height int64, srcClientId string) (*clienttypes.QueryClientStateResponse, error)
 	QueryClientConsensusState(chainHeight int64, clientid string, clientHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryUpgradedClient(ctx context.Context, height int64) (*clienttypes.QueryClientStateResponse, error)
-	QueryUpgradedConsState(height int64) (*clienttypes.QueryConsensusStateResponse, error)
+	QueryUpgradedConsState(ctx context.Context, height int64) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error)
 	QueryClients() (clienttypes.IdentifiedClientStates, error)
 	AutoUpdateClient(dst ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -128,7 +128,7 @@ type QueryProvider interface {
 	QueryChannels(ctx context.Context) ([]*chantypes.IdentifiedChannel, error)
 	QueryPacketCommitments(ctx context.Context, height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
 	QueryPacketAcknowledgements(ctx context.Context, height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
-	QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
+	QueryUnreceivedPackets(ctx context.Context, height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryNextSeqRecv(height int64, channelid, portid string) (recvRes *chantypes.QueryNextSequenceReceiveResponse, err error)
 	QueryPacketCommitment(height int64, channelid, portid string, seq uint64) (comRes *chantypes.QueryPacketCommitmentResponse, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -114,8 +114,8 @@ type QueryProvider interface {
 
 	// ics 03 - connection
 	QueryConnection(height int64, connectionid string) (*conntypes.QueryConnectionResponse, error)
-	QueryConnections() (conns []*conntypes.IdentifiedConnection, err error)
-	QueryConnectionsUsingClient(height int64, clientid string) (*conntypes.QueryConnectionsResponse, error)
+	QueryConnections(ctx context.Context) (conns []*conntypes.IdentifiedConnection, err error)
+	QueryConnectionsUsingClient(ctx context.Context, height int64, clientid string) (*conntypes.QueryConnectionsResponse, error)
 	GenerateConnHandshakeProof(height int64, clientId, connId string) (clientState ibcexported.ClientState,
 		clientStateProof []byte, consensusProof []byte, connectionProof []byte,
 		connectionProofHeight ibcexported.Height, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -66,8 +67,8 @@ type ChainProvider interface {
 	MsgRelayTimeout(dst ChainProvider, dsth int64, packet RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
 	MsgRelayRecvPacket(dst ChainProvider, dsth int64, packet RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
 	MsgUpgradeClient(srcClientId string, consRes *clienttypes.QueryConsensusStateResponse, clientRes *clienttypes.QueryClientStateResponse) (RelayerMessage, error)
-	RelayPacketFromSequence(src, dst ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (RelayerMessage, RelayerMessage, error)
-	AcknowledgementFromSequence(dst ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
+	RelayPacketFromSequence(ctx context.Context, src, dst ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (RelayerMessage, RelayerMessage, error)
+	AcknowledgementFromSequence(ctx context.Context, dst ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
 
 	SendMessage(msg RelayerMessage) (*RelayerTxResponse, bool, error)
 	SendMessages(msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
@@ -88,8 +89,8 @@ type ChainProvider interface {
 // Do we need intermediate types? i.e. can we use the SDK types for both substrate and cosmos?
 type QueryProvider interface {
 	// chain
-	QueryTx(hashHex string) (*ctypes.ResultTx, error)
-	QueryTxs(page, limit int, events []string) ([]*ctypes.ResultTx, error)
+	QueryTx(ctx context.Context, hashHex string) (*ctypes.ResultTx, error)
+	QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error)
 	QueryLatestHeight() (int64, error)
 	QueryHeaderAtHeight(height int64) (ibcexported.Header, error)
 

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -123,7 +123,7 @@ type QueryProvider interface {
 
 	// ics 04 - channel
 	QueryChannel(height int64, channelid, portid string) (chanRes *chantypes.QueryChannelResponse, err error)
-	QueryChannelClient(height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
+	QueryChannelClient(ctx context.Context, height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
 	QueryConnectionChannels(height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
 	QueryChannels() ([]*chantypes.IdentifiedChannel, error)
 	QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -129,7 +129,7 @@ type QueryProvider interface {
 	QueryPacketCommitments(ctx context.Context, height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
 	QueryPacketAcknowledgements(ctx context.Context, height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
 	QueryUnreceivedPackets(ctx context.Context, height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
-	QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
+	QueryUnreceivedAcknowledgements(ctx context.Context, height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryNextSeqRecv(height int64, channelid, portid string) (recvRes *chantypes.QueryNextSequenceReceiveResponse, err error)
 	QueryPacketCommitment(height int64, channelid, portid string, seq uint64) (comRes *chantypes.QueryPacketCommitmentResponse, err error)
 	QueryPacketAcknowledgement(height int64, channelid, portid string, seq uint64) (ackRes *chantypes.QueryPacketAcknowledgementResponse, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -83,7 +83,7 @@ type ChainProvider interface {
 	Address() (string, error)
 	Timeout() string
 	TrustingPeriod(ctx context.Context) (time.Duration, error)
-	WaitForNBlocks(n int64) error
+	WaitForNBlocks(ctx context.Context, n int64) error
 }
 
 // Do we need intermediate types? i.e. can we use the SDK types for both substrate and cosmos?

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -136,8 +136,8 @@ type QueryProvider interface {
 	QueryPacketReceipt(height int64, channelid, portid string, seq uint64) (recRes *chantypes.QueryPacketReceiptResponse, err error)
 
 	// ics 20 - transfer
-	QueryDenomTrace(denom string) (*transfertypes.DenomTrace, error)
-	QueryDenomTraces(offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error)
+	QueryDenomTrace(ctx context.Context, denom string) (*transfertypes.DenomTrace, error)
+	QueryDenomTraces(ctx context.Context, offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error)
 }
 
 type RelayPacket interface {

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -52,13 +52,13 @@ type ChainProvider interface {
 	SubmitMisbehavior( /*TODO TBD*/ ) (RelayerMessage, error)
 	UpdateClient(srcClientId string, dstHeader ibcexported.Header) (RelayerMessage, error)
 	ConnectionOpenInit(srcClientId, dstClientId string, dstHeader ibcexported.Header) ([]RelayerMessage, error)
-	ConnectionOpenTry(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]RelayerMessage, error)
-	ConnectionOpenAck(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]RelayerMessage, error)
-	ConnectionOpenConfirm(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]RelayerMessage, error)
+	ConnectionOpenTry(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, dstClientId, srcConnId, dstConnId string) ([]RelayerMessage, error)
+	ConnectionOpenAck(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]RelayerMessage, error)
+	ConnectionOpenConfirm(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]RelayerMessage, error)
 	ChannelOpenInit(srcClientId, srcConnId, srcPortId, srcVersion, dstPortId string, order chantypes.Order, dstHeader ibcexported.Header) ([]RelayerMessage, error)
-	ChannelOpenTry(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]RelayerMessage, error)
-	ChannelOpenAck(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]RelayerMessage, error)
-	ChannelOpenConfirm(dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChannId string) ([]RelayerMessage, error)
+	ChannelOpenTry(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]RelayerMessage, error)
+	ChannelOpenAck(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]RelayerMessage, error)
+	ChannelOpenConfirm(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChannId string) ([]RelayerMessage, error)
 	ChannelCloseInit(srcPortId, srcChanId string) (RelayerMessage, error)
 	ChannelCloseConfirm(dstQueryProvider QueryProvider, dsth int64, dstChanId, dstPortId, srcPortId, srcChanId string) (RelayerMessage, error)
 
@@ -91,7 +91,7 @@ type QueryProvider interface {
 	// chain
 	QueryTx(ctx context.Context, hashHex string) (*ctypes.ResultTx, error)
 	QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error)
-	QueryLatestHeight() (int64, error)
+	QueryLatestHeight(ctx context.Context) (int64, error)
 	QueryHeaderAtHeight(height int64) (ibcexported.Header, error)
 
 	// bank
@@ -109,7 +109,7 @@ type QueryProvider interface {
 	QueryUpgradedConsState(ctx context.Context, height int64) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryConsensusState(ctx context.Context, height int64) (ibcexported.ConsensusState, int64, error)
 	QueryClients(ctx context.Context) (clienttypes.IdentifiedClientStates, error)
-	AutoUpdateClient(dst ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error)
+	AutoUpdateClient(ctx context.Context, dst ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error)
 	FindMatchingClient(ctx context.Context, counterparty ChainProvider, clientState ibcexported.ClientState) (string, bool)
 
 	// ics 03 - connection

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -92,7 +92,7 @@ type QueryProvider interface {
 	QueryTx(ctx context.Context, hashHex string) (*ctypes.ResultTx, error)
 	QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error)
 	QueryLatestHeight(ctx context.Context) (int64, error)
-	QueryHeaderAtHeight(height int64) (ibcexported.Header, error)
+	QueryHeaderAtHeight(ctx context.Context, height int64) (ibcexported.Header, error)
 
 	// bank
 	QueryBalance(ctx context.Context, keyName string) (sdk.Coins, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -127,7 +127,7 @@ type QueryProvider interface {
 	QueryConnectionChannels(ctx context.Context, height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
 	QueryChannels(ctx context.Context) ([]*chantypes.IdentifiedChannel, error)
 	QueryPacketCommitments(ctx context.Context, height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
-	QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
+	QueryPacketAcknowledgements(ctx context.Context, height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
 	QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryNextSeqRecv(height int64, channelid, portid string) (recvRes *chantypes.QueryNextSequenceReceiveResponse, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -125,7 +125,7 @@ type QueryProvider interface {
 	QueryChannel(height int64, channelid, portid string) (chanRes *chantypes.QueryChannelResponse, err error)
 	QueryChannelClient(ctx context.Context, height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
 	QueryConnectionChannels(ctx context.Context, height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
-	QueryChannels() ([]*chantypes.IdentifiedChannel, error)
+	QueryChannels(ctx context.Context) ([]*chantypes.IdentifiedChannel, error)
 	QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
 	QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
 	QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -108,9 +108,9 @@ type QueryProvider interface {
 	QueryUpgradedClient(ctx context.Context, height int64) (*clienttypes.QueryClientStateResponse, error)
 	QueryUpgradedConsState(ctx context.Context, height int64) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryConsensusState(ctx context.Context, height int64) (ibcexported.ConsensusState, int64, error)
-	QueryClients() (clienttypes.IdentifiedClientStates, error)
+	QueryClients(ctx context.Context) (clienttypes.IdentifiedClientStates, error)
 	AutoUpdateClient(dst ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error)
-	FindMatchingClient(counterparty ChainProvider, clientState ibcexported.ClientState) (string, bool)
+	FindMatchingClient(ctx context.Context, counterparty ChainProvider, clientState ibcexported.ClientState) (string, bool)
 
 	// ics 03 - connection
 	QueryConnection(height int64, connectionid string) (*conntypes.QueryConnectionResponse, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -105,7 +105,7 @@ type QueryProvider interface {
 	QueryClientState(height int64, clientid string) (ibcexported.ClientState, error)
 	QueryClientStateResponse(height int64, srcClientId string) (*clienttypes.QueryClientStateResponse, error)
 	QueryClientConsensusState(chainHeight int64, clientid string, clientHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error)
-	QueryUpgradedClient(height int64) (*clienttypes.QueryClientStateResponse, error)
+	QueryUpgradedClient(ctx context.Context, height int64) (*clienttypes.QueryClientStateResponse, error)
 	QueryUpgradedConsState(height int64) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error)
 	QueryClients() (clienttypes.IdentifiedClientStates, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -99,7 +99,7 @@ type QueryProvider interface {
 	QueryBalanceWithAddress(ctx context.Context, addr string) (sdk.Coins, error)
 
 	// staking
-	QueryUnbondingPeriod() (time.Duration, error)
+	QueryUnbondingPeriod(context.Context) (time.Duration, error)
 
 	// ics 02 - client
 	QueryClientState(height int64, clientid string) (ibcexported.ClientState, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -126,7 +126,7 @@ type QueryProvider interface {
 	QueryChannelClient(ctx context.Context, height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
 	QueryConnectionChannels(ctx context.Context, height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
 	QueryChannels(ctx context.Context) ([]*chantypes.IdentifiedChannel, error)
-	QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
+	QueryPacketCommitments(ctx context.Context, height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
 	QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
 	QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
 	QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -124,7 +124,7 @@ type QueryProvider interface {
 	// ics 04 - channel
 	QueryChannel(height int64, channelid, portid string) (chanRes *chantypes.QueryChannelResponse, err error)
 	QueryChannelClient(ctx context.Context, height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
-	QueryConnectionChannels(height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
+	QueryConnectionChannels(ctx context.Context, height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
 	QueryChannels() ([]*chantypes.IdentifiedChannel, error)
 	QueryPacketCommitments(height uint64, channelid, portid string) (commitments *chantypes.QueryPacketCommitmentsResponse, err error)
 	QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -95,8 +95,8 @@ type QueryProvider interface {
 	QueryHeaderAtHeight(height int64) (ibcexported.Header, error)
 
 	// bank
-	QueryBalance(keyName string) (sdk.Coins, error)
-	QueryBalanceWithAddress(addr string) (sdk.Coins, error)
+	QueryBalance(ctx context.Context, keyName string) (sdk.Coins, error)
+	QueryBalanceWithAddress(ctx context.Context, addr string) (sdk.Coins, error)
 
 	// staking
 	QueryUnbondingPeriod() (time.Duration, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -107,7 +107,7 @@ type QueryProvider interface {
 	QueryClientConsensusState(chainHeight int64, clientid string, clientHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error)
 	QueryUpgradedClient(ctx context.Context, height int64) (*clienttypes.QueryClientStateResponse, error)
 	QueryUpgradedConsState(ctx context.Context, height int64) (*clienttypes.QueryConsensusStateResponse, error)
-	QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error)
+	QueryConsensusState(ctx context.Context, height int64) (ibcexported.ConsensusState, int64, error)
 	QueryClients() (clienttypes.IdentifiedClientStates, error)
 	AutoUpdateClient(dst ChainProvider, thresholdTime time.Duration, srcClientId, dstClientId string) (time.Duration, error)
 	FindMatchingClient(counterparty ChainProvider, clientState ibcexported.ClientState) (string, bool)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -73,8 +73,8 @@ type ChainProvider interface {
 	SendMessage(msg RelayerMessage) (*RelayerTxResponse, bool, error)
 	SendMessages(msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
 
-	GetLightSignedHeaderAtHeight(h int64) (ibcexported.Header, error)
-	GetIBCUpdateHeader(srch int64, dst ChainProvider, dstClientId string) (ibcexported.Header, error)
+	GetLightSignedHeaderAtHeight(ctx context.Context, h int64) (ibcexported.Header, error)
+	GetIBCUpdateHeader(ctx context.Context, srch int64, dst ChainProvider, dstClientId string) (ibcexported.Header, error)
 
 	ChainId() string
 	Type() string

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -70,8 +70,8 @@ type ChainProvider interface {
 	RelayPacketFromSequence(ctx context.Context, src, dst ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId, srcClientId string) (RelayerMessage, RelayerMessage, error)
 	AcknowledgementFromSequence(ctx context.Context, dst ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
 
-	SendMessage(msg RelayerMessage) (*RelayerTxResponse, bool, error)
-	SendMessages(msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
+	SendMessage(ctx context.Context, msg RelayerMessage) (*RelayerTxResponse, bool, error)
+	SendMessages(ctx context.Context, msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
 
 	GetLightSignedHeaderAtHeight(ctx context.Context, h int64) (ibcexported.Header, error)
 	GetIBCUpdateHeader(ctx context.Context, srch int64, dst ChainProvider, dstClientId string) (ibcexported.Header, error)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -82,7 +82,7 @@ type ChainProvider interface {
 	Key() string
 	Address() (string, error)
 	Timeout() string
-	TrustingPeriod() (time.Duration, error)
+	TrustingPeriod(ctx context.Context) (time.Duration, error)
 	WaitForNBlocks(n int64) error
 }
 

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/avast/retry-go"
@@ -67,7 +68,7 @@ func QueryChannelPair(src, dst *Chain, srcH, dstH int64, srcChanID, dstChanID, s
 	return
 }
 
-func QueryChannel(src *Chain, channelID string) (*chantypes.IdentifiedChannel, error) {
+func QueryChannel(ctx context.Context, src *Chain, channelID string) (*chantypes.IdentifiedChannel, error) {
 	var (
 		srch        int64
 		err         error
@@ -85,7 +86,7 @@ func QueryChannel(src *Chain, channelID string) (*chantypes.IdentifiedChannel, e
 
 	// Query all channels for the given connection
 	if err = retry.Do(func() error {
-		srcChannels, err = src.ChainProvider.QueryConnectionChannels(srch, src.ConnectionID())
+		srcChannels, err = src.ChainProvider.QueryConnectionChannels(ctx, srch, src.ConnectionID())
 		return err
 	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 		src.LogRetryQueryConnectionChannels(n, err, src.ConnectionID())

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -16,16 +16,16 @@ import (
 )
 
 // QueryLatestHeights returns the heights of multiple chains at once
-func QueryLatestHeights(src, dst *Chain) (srch, dsth int64, err error) {
+func QueryLatestHeights(ctx context.Context, src, dst *Chain) (srch, dsth int64, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
 		var err error
-		srch, err = src.ChainProvider.QueryLatestHeight()
+		srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dsth, err = dst.ChainProvider.QueryLatestHeight()
+		dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 		return err
 	})
 	err = eg.Wait()
@@ -78,7 +78,7 @@ func QueryChannel(ctx context.Context, src *Chain, channelID string) (*chantypes
 	// Query the latest height
 	if err = retry.Do(func() error {
 		var err error
-		srch, err = src.ChainProvider.QueryLatestHeight()
+		srch, err = src.ChainProvider.QueryLatestHeight(ctx)
 		return err
 	}, RtyAtt, RtyDel, RtyErr); err != nil {
 		return nil, err

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -106,16 +106,16 @@ func QueryChannel(ctx context.Context, src *Chain, channelID string) (*chantypes
 }
 
 // GetIBCUpdateHeaders returns a pair of IBC update headers which can be used to update an on chain light client
-func GetIBCUpdateHeaders(srch, dsth int64, src, dst provider.ChainProvider, srcClientID, dstClientID string) (srcHeader, dstHeader ibcexported.Header, err error) {
+func GetIBCUpdateHeaders(ctx context.Context, srch, dsth int64, src, dst provider.ChainProvider, srcClientID, dstClientID string) (srcHeader, dstHeader ibcexported.Header, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
 		var err error
-		srcHeader, err = src.GetIBCUpdateHeader(srch, dst, dstClientID)
+		srcHeader, err = src.GetIBCUpdateHeader(ctx, srch, dst, dstClientID)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstHeader, err = dst.GetIBCUpdateHeader(dsth, src, srcClientID)
+		dstHeader, err = dst.GetIBCUpdateHeader(ctx, dsth, src, srcClientID)
 		return err
 	})
 	if err = eg.Wait(); err != nil {
@@ -124,18 +124,18 @@ func GetIBCUpdateHeaders(srch, dsth int64, src, dst provider.ChainProvider, srcC
 	return
 }
 
-func GetLightSignedHeadersAtHeights(src, dst *Chain, srch, dsth int64) (srcUpdateHeader, dstUpdateHeader ibcexported.Header, err error) {
+func GetLightSignedHeadersAtHeights(ctx context.Context, src, dst *Chain, srch, dsth int64) (srcUpdateHeader, dstUpdateHeader ibcexported.Header, err error) {
 	var (
 		eg = new(errgroup.Group)
 	)
 	eg.Go(func() error {
 		var err error
-		srcUpdateHeader, err = src.ChainProvider.GetLightSignedHeaderAtHeight(srch)
+		srcUpdateHeader, err = src.ChainProvider.GetLightSignedHeaderAtHeight(ctx, srch)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstUpdateHeader, err = dst.ChainProvider.GetLightSignedHeaderAtHeight(dsth)
+		dstUpdateHeader, err = dst.ChainProvider.GetLightSignedHeaderAtHeight(ctx, dsth)
 		return err
 	})
 	if err := eg.Wait(); err != nil {

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -29,7 +29,7 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 				return
 			default:
 				// Query the list of channels on the src connection
-				srcChannels, err := queryChannelsOnConnection(src)
+				srcChannels, err := queryChannelsOnConnection(ctx, src)
 				if err != nil {
 					errorChan <- fmt.Errorf("error querying all channels on chain{%s}@connection{%s}: %v \n",
 						src.ChainID(), src.ConnectionID(), err)
@@ -69,7 +69,7 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 }
 
 // queryChannelsOnConnection queries all the channels associated with a connection on the src chain.
-func queryChannelsOnConnection(src *Chain) ([]*types.IdentifiedChannel, error) {
+func queryChannelsOnConnection(ctx context.Context, src *Chain) ([]*types.IdentifiedChannel, error) {
 	// Query the latest heights on src & dst
 	srch, err := src.ChainProvider.QueryLatestHeight()
 	if err != nil {
@@ -80,7 +80,7 @@ func queryChannelsOnConnection(src *Chain) ([]*types.IdentifiedChannel, error) {
 	var srcChannels []*types.IdentifiedChannel
 
 	if err = retry.Do(func() error {
-		srcChannels, err = src.ChainProvider.QueryConnectionChannels(srch, src.ConnectionID())
+		srcChannels, err = src.ChainProvider.QueryConnectionChannels(ctx, srch, src.ConnectionID())
 		return err
 	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 		src.LogRetryQueryConnectionChannels(n, err, src.ConnectionID())

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -178,7 +178,7 @@ func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxM
 	defer cancel()
 
 	// Fetch any unrelayed sequences depending on the channel order
-	sp, err := UnrelayedSequences(src, dst, srcChannel)
+	sp, err := UnrelayedSequences(ctx, src, dst, srcChannel)
 	if err != nil {
 		src.Log(fmt.Sprintf("unrelayed sequences error: %s", err))
 		return err

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -222,7 +222,7 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 	defer cancel()
 
 	// Fetch any unrelayed acks depending on the channel order
-	ap, err := UnrelayedAcknowledgements(src, dst, srcChannel)
+	ap, err := UnrelayedAcknowledgements(ctx, src, dst, srcChannel)
 	if err != nil {
 		src.Log(fmt.Sprintf("unrelayed acks error: %s", err))
 		return err

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -71,7 +71,7 @@ func StartRelayer(ctx context.Context, src, dst *Chain, filter *ChannelFilter, m
 // queryChannelsOnConnection queries all the channels associated with a connection on the src chain.
 func queryChannelsOnConnection(ctx context.Context, src *Chain) ([]*types.IdentifiedChannel, error) {
 	// Query the latest heights on src & dst
-	srch, err := src.ChainProvider.QueryLatestHeight()
+	srch, err := src.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -101,12 +101,12 @@ func chainTest(t *testing.T, tcs []testChain) {
 	srcAddr, err := src.ChainProvider.Address()
 	require.NoError(t, err)
 
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channel))
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channel))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channel))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channel))
 
 	// send a couple of transfers to the queue on dst
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channel))
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channel))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channel))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channel))
 
 	// Wait for message inclusion in both chains
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
@@ -123,8 +123,8 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(2))
 
 	// send those tokens from dst back to dst and src back to src
-	require.NoError(t, src.SendTransferMsg(dst, twoTestCoin, dstAddr, 0, 0, channel))
-	require.NoError(t, dst.SendTransferMsg(src, twoTestCoin, srcAddr, 0, 0, channel))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, twoTestCoin, dstAddr, 0, 0, channel))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, twoTestCoin, srcAddr, 0, 0, channel))
 
 	// wait for packet processing
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(6))
@@ -270,7 +270,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(1))
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
 
-	latestHeight, err := dst.ChainProvider.QueryLatestHeight()
+	latestHeight, err := dst.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
 
 	header, err := dst.ChainProvider.QueryHeaderAtHeight(latestHeight)
@@ -413,20 +413,20 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	srcAddr, err := src.ChainProvider.Address()
 	require.NoError(t, err)
 
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channelOne))
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channelOne))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channelOne))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channelOne))
 
 	// send a couple of transfers to the queue on dst for first channel
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channelOne))
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channelOne))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channelOne))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channelOne))
 
 	// send a couple of transfers to the queue on src for second channel
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channelTwo))
-	require.NoError(t, src.SendTransferMsg(dst, testCoin, dstAddr, 0, 0, channelTwo))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channelTwo))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, testCoin, dstAddr, 0, 0, channelTwo))
 
 	// send a couple of transfers to the queue on dst for second channel
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channelTwo))
-	require.NoError(t, dst.SendTransferMsg(src, testCoin, srcAddr, 0, 0, channelTwo))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channelTwo))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channelTwo))
 
 	// Wait for message inclusion in both chains
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
@@ -443,12 +443,12 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
 
 	// send those tokens from dst back to dst and src back to src for first channel
-	require.NoError(t, src.SendTransferMsg(dst, twoTestCoin, dstAddr, 0, 0, channelOne))
-	require.NoError(t, dst.SendTransferMsg(src, twoTestCoin, srcAddr, 0, 0, channelOne))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, twoTestCoin, dstAddr, 0, 0, channelOne))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, twoTestCoin, srcAddr, 0, 0, channelOne))
 
 	// send those tokens from dst back to dst and src back to src for second channel
-	require.NoError(t, src.SendTransferMsg(dst, twoTestCoin, dstAddr, 0, 0, channelTwo))
-	require.NoError(t, dst.SendTransferMsg(src, twoTestCoin, srcAddr, 0, 0, channelTwo))
+	require.NoError(t, src.SendTransferMsg(context.Background(), dst, twoTestCoin, dstAddr, 0, 0, channelTwo))
+	require.NoError(t, dst.SendTransferMsg(context.Background(), src, twoTestCoin, srcAddr, 0, 0, channelTwo))
 
 	// wait for packet processing
 	require.NoError(t, dst.ChainProvider.WaitForNBlocks(6))

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -80,7 +80,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(dst, 3, timeout)
+	_, err = src.CreateOpenConnections(context.Background(), dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
@@ -167,7 +167,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(dst, 3, timeout)
+	_, err = src.CreateOpenConnections(context.Background(), dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
@@ -194,7 +194,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
-	_, err = src.CreateOpenConnections(dst, 3, timeout)
+	_, err = src.CreateOpenConnections(context.Background(), dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
@@ -245,7 +245,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(dst, 3, timeout)
+	_, err = src.CreateOpenConnections(context.Background(), dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
@@ -388,7 +388,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(dst, 3, timeout)
+	_, err = src.CreateOpenConnections(context.Background(), dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -73,7 +73,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, eg.Wait())
 
 	// create path
-	_, err = src.CreateClients(dst, true, true, false)
+	_, err = src.CreateClients(context.Background(), dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
@@ -160,7 +160,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 
 	// create path
-	_, err = src.CreateClients(dst, true, true, false)
+	_, err = src.CreateClients(context.Background(), dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
@@ -190,7 +190,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	dst.PathEnd.ClientID = ""
 	dst.PathEnd.ConnectionID = ""
 
-	_, err = src.CreateClients(dst, true, true, false)
+	_, err = src.CreateClients(context.Background(), dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
@@ -212,7 +212,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	src.PathEnd.ClientID = ""
 	dst.PathEnd.ClientID = ""
 
-	_, err = src.CreateClients(dst, true, true, true)
+	_, err = src.CreateClients(context.Background(), dst, true, true, true)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
@@ -238,7 +238,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.NoError(t, err)
 
 	// create path
-	_, err = src.CreateClients(dst, true, true, false)
+	_, err = src.CreateClients(context.Background(), dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 
@@ -381,7 +381,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// create path
-	_, err = src.CreateClients(dst, true, true, false)
+	_, err = src.CreateClients(context.Background(), dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(t, src, dst)
 

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -88,7 +88,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
-	channels, err := src.ChainProvider.QueryConnectionChannels(0, src.ConnectionID())
+	channels, err := src.ChainProvider.QueryConnectionChannels(context.Background(), 0, src.ConnectionID())
 	require.NoError(t, err)
 
 	channel := channels[0]
@@ -175,7 +175,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
-	channels, err := src.ChainProvider.QueryConnectionChannels(0, src.ConnectionID())
+	channels, err := src.ChainProvider.QueryConnectionChannels(context.Background(), 0, src.ConnectionID())
 	require.NoError(t, err)
 
 	channel := channels[0]
@@ -253,7 +253,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
-	channels, err := src.ChainProvider.QueryConnectionChannels(0, src.ConnectionID())
+	channels, err := src.ChainProvider.QueryConnectionChannels(context.Background(), 0, src.ConnectionID())
 	require.NoError(t, err)
 
 	channel := channels[0]
@@ -399,7 +399,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	// query open channels and ensure there are two
-	channels, err := src.ChainProvider.QueryConnectionChannels(0, src.ConnectionID())
+	channels, err := src.ChainProvider.QueryConnectionChannels(context.Background(), 0, src.ConnectionID())
 	require.NoError(t, err)
 	require.Equal(t, 2, len(channels))
 

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -273,7 +273,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	latestHeight, err := dst.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
 
-	header, err := dst.ChainProvider.QueryHeaderAtHeight(latestHeight)
+	header, err := dst.ChainProvider.QueryHeaderAtHeight(context.Background(), latestHeight)
 	require.NoError(t, err)
 
 	clientState, err := src.QueryTMClientState(latestHeight)

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -109,7 +109,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channel))
 
 	// Wait for message inclusion in both chains
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 1))
 
 	// start the relayer process in it's own goroutine
 	ctx, cancel := context.WithCancel(context.Background())
@@ -119,15 +119,15 @@ func chainTest(t *testing.T, tcs []testChain) {
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 
 	// Wait for relay message inclusion in both chains
-	require.NoError(t, src.ChainProvider.WaitForNBlocks(2))
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(2))
+	require.NoError(t, src.ChainProvider.WaitForNBlocks(context.Background(), 2))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 2))
 
 	// send those tokens from dst back to dst and src back to src
 	require.NoError(t, src.SendTransferMsg(context.Background(), dst, twoTestCoin, dstAddr, 0, 0, channel))
 	require.NoError(t, dst.SendTransferMsg(context.Background(), src, twoTestCoin, srcAddr, 0, 0, channel))
 
 	// wait for packet processing
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(6))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 6))
 
 	// kill relayer routine
 	cancel()
@@ -267,8 +267,8 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 
 	// Wait for relay message inclusion in both chains
-	require.NoError(t, src.ChainProvider.WaitForNBlocks(1))
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
+	require.NoError(t, src.ChainProvider.WaitForNBlocks(context.Background(), 1))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 1))
 
 	latestHeight, err := dst.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
@@ -314,7 +314,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.Equal(t, uint32(0), res.Code)
 
 	// wait for packet processing
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(6))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 6))
 
 	// kill relayer routine
 	cancel()
@@ -429,7 +429,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, dst.SendTransferMsg(context.Background(), src, testCoin, srcAddr, 0, 0, channelTwo))
 
 	// Wait for message inclusion in both chains
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 1))
 
 	// start the relayer process in it's own goroutine
 	ctx, cancel := context.WithCancel(context.Background())
@@ -439,8 +439,8 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	_ = relayer.StartRelayer(ctx, src, dst, filter, 2*cmd.MB, 5)
 
 	// Wait for relay message inclusion in both chains
-	require.NoError(t, src.ChainProvider.WaitForNBlocks(1))
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(1))
+	require.NoError(t, src.ChainProvider.WaitForNBlocks(context.Background(), 1))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 1))
 
 	// send those tokens from dst back to dst and src back to src for first channel
 	require.NoError(t, src.SendTransferMsg(context.Background(), dst, twoTestCoin, dstAddr, 0, 0, channelOne))
@@ -451,7 +451,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, dst.SendTransferMsg(context.Background(), src, twoTestCoin, srcAddr, 0, 0, channelTwo))
 
 	// wait for packet processing
-	require.NoError(t, dst.ChainProvider.WaitForNBlocks(6))
+	require.NoError(t, dst.ChainProvider.WaitForNBlocks(context.Background(), 6))
 
 	// kill relayer routine
 	cancel()

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -308,7 +308,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	updateMsg, err := src.ChainProvider.UpdateClient(src.PathEnd.ClientID, newHeader)
 	require.NoError(t, err)
 
-	res, success, err := src.ChainProvider.SendMessage(updateMsg)
+	res, success, err := src.ChainProvider.SendMessage(context.Background(), updateMsg)
 	require.NoError(t, err)
 	require.True(t, success)
 	require.Equal(t, uint32(0), res.Code)

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -53,7 +53,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			srcExpected, err = src.ChainProvider.QueryBalance(src.ChainProvider.Key())
+			srcExpected, err = src.ChainProvider.QueryBalance(context.Background(), src.ChainProvider.Key())
 			if srcExpected.IsZero() {
 				return fmt.Errorf("expected non-zero balance. Err: %w", err)
 			}
@@ -63,7 +63,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			dstExpected, err = dst.ChainProvider.QueryBalance(dst.ChainProvider.Key())
+			dstExpected, err = dst.ChainProvider.QueryBalance(context.Background(), dst.ChainProvider.Key())
 			if dstExpected.IsZero() {
 				return fmt.Errorf("expected non-zero balance. Err: %w", err)
 			}
@@ -133,12 +133,12 @@ func chainTest(t *testing.T, tcs []testChain) {
 	cancel()
 
 	// check balance on src against expected
-	srcGot, err := src.ChainProvider.QueryBalance(src.ChainProvider.Key())
+	srcGot, err := src.ChainProvider.QueryBalance(context.Background(), src.ChainProvider.Key())
 	require.NoError(t, err)
 	require.Equal(t, srcExpected.AmountOf(testDenom).Int64()-4000, srcGot.AmountOf(testDenom).Int64())
 
 	// check balance on dst against expected
-	dstGot, err := dst.ChainProvider.QueryBalance(dst.ChainProvider.Key())
+	dstGot, err := dst.ChainProvider.QueryBalance(context.Background(), dst.ChainProvider.Key())
 	require.NoError(t, err)
 	require.Equal(t, dstExpected.AmountOf(testDenom).Int64()-4000, dstGot.AmountOf(testDenom).Int64())
 }
@@ -351,7 +351,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			srcExpected, err = src.ChainProvider.QueryBalance(src.ChainProvider.Key())
+			srcExpected, err = src.ChainProvider.QueryBalance(context.Background(), src.ChainProvider.Key())
 			if err != nil {
 				return err
 			}
@@ -366,7 +366,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			dstExpected, err = dst.ChainProvider.QueryBalance(dst.ChainProvider.Key())
+			dstExpected, err = dst.ChainProvider.QueryBalance(context.Background(), dst.ChainProvider.Key())
 			if err != nil {
 				return err
 			}
@@ -457,12 +457,12 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	cancel()
 
 	// check balance on src against expected
-	srcGot, err := src.ChainProvider.QueryBalance(src.ChainProvider.Key())
+	srcGot, err := src.ChainProvider.QueryBalance(context.Background(), src.ChainProvider.Key())
 	require.NoError(t, err)
 	require.Equal(t, srcExpected.AmountOf(testDenom).Int64()-8000, srcGot.AmountOf(testDenom).Int64())
 
 	// check balance on dst against expected
-	dstGot, err := dst.ChainProvider.QueryBalance(dst.ChainProvider.Key())
+	dstGot, err := dst.ChainProvider.QueryBalance(context.Background(), dst.ChainProvider.Key())
 	require.NoError(t, err)
 	require.Equal(t, dstExpected.AmountOf(testDenom).Int64()-8000, dstGot.AmountOf(testDenom).Int64())
 }

--- a/test/relayer_chain_test.go
+++ b/test/relayer_chain_test.go
@@ -84,7 +84,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -171,7 +171,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -198,7 +198,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 	testChannelPair(t, src, dst, channel.ChannelId, channel.PortId)
 
@@ -249,7 +249,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -392,10 +392,10 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(t, src, dst)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenChannels(dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, true)
+	_, err = src.CreateOpenChannels(context.Background(), dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, true)
 	require.NoError(t, err)
 
 	// query open channels and ensure there are two

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -86,7 +86,7 @@ func testChannelPair(t *testing.T, src, dst *relayer.Chain, channelID, portID st
 func testChannel(t *testing.T, src, dst *relayer.Chain, channelID, portID string) {
 	t.Helper()
 
-	chans, err := src.ChainProvider.QueryChannels()
+	chans, err := src.ChainProvider.QueryChannels(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(chans))
 	require.Equal(t, chans[0].Ordering.String(), "ORDER_UNORDERED")

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -23,7 +23,7 @@ func testClientPair(t *testing.T, src, dst *relayer.Chain) {
 func testClient(t *testing.T, src *relayer.Chain) {
 	t.Helper()
 
-	srch, err := src.ChainProvider.QueryLatestHeight()
+	srch, err := src.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
 	var (
 		client *clientypes.QueryClientStateResponse
@@ -31,7 +31,7 @@ func testClient(t *testing.T, src *relayer.Chain) {
 	if err = retry.Do(func() error {
 		client, err = src.ChainProvider.QueryClientStateResponse(srch, src.ClientID())
 		if err != nil {
-			srch, _ = src.ChainProvider.QueryLatestHeight()
+			srch, _ = src.ChainProvider.QueryLatestHeight(context.Background())
 		}
 		return err
 	}); err != nil {
@@ -63,7 +63,7 @@ func testConnection(t *testing.T, src, dst *relayer.Chain) {
 	require.Equal(t, conns[0].Counterparty.GetConnectionID(), dst.PathEnd.ConnectionID)
 	require.Equal(t, conns[0].State.String(), "STATE_OPEN")
 
-	h, err := src.ChainProvider.QueryLatestHeight()
+	h, err := src.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
 
 	time.Sleep(time.Second * 5)
@@ -94,7 +94,7 @@ func testChannel(t *testing.T, src, dst *relayer.Chain, channelID, portID string
 	require.Equal(t, chans[0].Counterparty.ChannelId, channelID)
 	require.Equal(t, chans[0].Counterparty.GetPortID(), portID)
 
-	h, err := src.ChainProvider.QueryLatestHeight()
+	h, err := src.ChainProvider.QueryLatestHeight(context.Background())
 	require.NoError(t, err)
 
 	time.Sleep(time.Second * 5)

--- a/test/test_queries.go
+++ b/test/test_queries.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -54,7 +55,7 @@ func testConnectionPair(t *testing.T, src, dst *relayer.Chain) {
 func testConnection(t *testing.T, src, dst *relayer.Chain) {
 	t.Helper()
 
-	conns, err := src.ChainProvider.QueryConnections()
+	conns, err := src.ChainProvider.QueryConnections(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, len(conns), 1)
 	require.Equal(t, conns[0].ClientId, src.PathEnd.ClientID)


### PR DESCRIPTION
This is a purely mechanical refactor to use explicit context.Context argument values instead of  context.Background calls inline.

The change is split into many small commits in case that helps with reviewing.

Using explicit context.Context values will aid in enabling clean shutdowns on an interrupt signal.