### PR TITLE
Use errgroup.WithContext where applicable

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -86,7 +86,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 			// hard to rectify, so we are just avoiding this code path for now
 			if false {
 				thresholdTime := a.Viper.GetDuration(flagThresholdTime)
-				eg := new(errgroup.Group)
+				eg, ctx := errgroup.WithContext(ctx)
 
 				eg.Go(func() error {
 					for {
@@ -143,15 +143,15 @@ func UpdateClientsFromChains(ctx context.Context, src, dst *relayer.Chain, thres
 		err                          error
 	)
 
-	eg := new(errgroup.Group)
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var err error
-		srcTimeExpiry, err = src.ChainProvider.AutoUpdateClient(ctx, dst.ChainProvider, thresholdTime, src.ClientID(), dst.ClientID())
+		srcTimeExpiry, err = src.ChainProvider.AutoUpdateClient(egCtx, dst.ChainProvider, thresholdTime, src.ClientID(), dst.ClientID())
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstTimeExpiry, err = dst.ChainProvider.AutoUpdateClient(ctx, src.ChainProvider, thresholdTime, dst.ClientID(), src.ClientID())
+		dstTimeExpiry, err = dst.ChainProvider.AutoUpdateClient(egCtx, src.ChainProvider, thresholdTime, dst.ClientID(), src.ClientID())
 		return err
 	})
 	if err = eg.Wait(); err != nil {

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -14,7 +14,6 @@ import (
 // UnrelayedSequences returns the unrelayed sequence numbers between two chains
 func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
 	var (
-		eg           = new(errgroup.Group)
 		srcPacketSeq = []uint64{}
 		dstPacketSeq = []uint64{}
 		rs           = &RelaySequences{Src: []uint64{}, Dst: []uint64{}}
@@ -25,6 +24,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		return nil, err
 	}
 
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var (
 			res *chantypes.QueryPacketCommitmentsResponse
@@ -32,7 +32,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		)
 		if err = retry.Do(func() error {
 			// Query the packet commitment
-			res, err = src.ChainProvider.QueryPacketCommitments(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
+			res, err = src.ChainProvider.QueryPacketCommitments(egCtx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -43,7 +43,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 			}
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.LogRetryQueryPacketCommitments(n, err, srcChannel.ChannelId, srcChannel.PortId)
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
+			srch, _ = src.ChainProvider.QueryLatestHeight(egCtx)
 		})); err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 			err error
 		)
 		if err = retry.Do(func() error {
-			res, err = dst.ChainProvider.QueryPacketCommitments(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+			res, err = dst.ChainProvider.QueryPacketCommitments(egCtx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -70,7 +70,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 			}
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryQueryPacketCommitments(n, err, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(egCtx)
 		})); err != nil {
 			return err
 		}
@@ -84,15 +84,16 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		return nil, err
 	}
 
+	eg, egCtx = errgroup.WithContext(ctx) // Re-set eg and egCtx after previous Wait.
 	eg.Go(func() error {
 		// Query all packets sent by src that have been received by dst
 		return retry.Do(func() error {
 			var err error
-			rs.Src, err = dst.ChainProvider.QueryUnreceivedPackets(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
+			rs.Src, err = dst.ChainProvider.QueryUnreceivedPackets(egCtx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			dst.LogRetryQueryUnreceivedPackets(n, err, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(egCtx)
 		}))
 	})
 
@@ -100,11 +101,11 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 		// Query all packets sent by dst that have been received by src
 		return retry.Do(func() error {
 			var err error
-			rs.Dst, err = src.ChainProvider.QueryUnreceivedPackets(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
+			rs.Dst, err = src.ChainProvider.QueryUnreceivedPackets(egCtx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.LogRetryQueryUnreceivedPackets(n, err, srcChannel.ChannelId, srcChannel.PortId)
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
+			srch, _ = src.ChainProvider.QueryLatestHeight(egCtx)
 		}))
 	})
 
@@ -118,7 +119,6 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 // UnrelayedAcknowledgements returns the unrelayed sequence numbers between two chains
 func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) (*RelaySequences, error) {
 	var (
-		eg           = new(errgroup.Group)
 		srcPacketSeq = []uint64{}
 		dstPacketSeq = []uint64{}
 		rs           = &RelaySequences{Src: []uint64{}, Dst: []uint64{}}
@@ -129,6 +129,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		return nil, err
 	}
 
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var (
 			res []*chantypes.PacketState
@@ -136,7 +137,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		)
 		if err = retry.Do(func() error {
 			// Query the packet commitment
-			res, err = src.ChainProvider.QueryPacketAcknowledgements(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
+			res, err = src.ChainProvider.QueryPacketAcknowledgements(egCtx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -146,7 +147,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 				return nil
 			}
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
+			srch, _ = src.ChainProvider.QueryLatestHeight(egCtx)
 		})); err != nil {
 			return err
 		}
@@ -162,7 +163,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 			err error
 		)
 		if err = retry.Do(func() error {
-			res, err = dst.ChainProvider.QueryPacketAcknowledgements(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+			res, err = dst.ChainProvider.QueryPacketAcknowledgements(egCtx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
 			switch {
 			case err != nil:
 				return err
@@ -172,7 +173,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 				return nil
 			}
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(egCtx)
 		})); err != nil {
 			return err
 		}
@@ -186,14 +187,15 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		return nil, err
 	}
 
+	eg, egCtx = errgroup.WithContext(ctx) // Re-set eg and egCtx after previous Wait.
 	eg.Go(func() error {
 		// Query all packets sent by src that have been received by dst
 		var err error
 		return retry.Do(func() error {
-			rs.Src, err = dst.ChainProvider.QueryUnreceivedAcknowledgements(ctx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
+			rs.Src, err = dst.ChainProvider.QueryUnreceivedAcknowledgements(egCtx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
 			return err
 		}, RtyErr, RtyAtt, RtyDel, retry.OnRetry(func(n uint, err error) {
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
+			dsth, _ = dst.ChainProvider.QueryLatestHeight(egCtx)
 		}))
 	})
 
@@ -201,10 +203,10 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 		// Query all packets sent by dst that have been received by src
 		var err error
 		return retry.Do(func() error {
-			rs.Dst, err = src.ChainProvider.QueryUnreceivedAcknowledgements(ctx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
+			rs.Dst, err = src.ChainProvider.QueryUnreceivedAcknowledgements(egCtx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
 			return err
 		}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
+			srch, _ = src.ChainProvider.QueryLatestHeight(egCtx)
 		}))
 	})
 
@@ -248,17 +250,17 @@ func RelayAcknowledgements(ctx context.Context, src, dst *Chain, sp *RelaySequen
 		}
 
 		var (
-			eg                   errgroup.Group
 			srcHeader, dstHeader ibcexported.Header
 		)
+		eg, egCtx := errgroup.WithContext(ctx)
 		eg.Go(func() error {
 			var err error
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
+			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(egCtx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
 			return err
 		})
 		eg.Go(func() error {
 			var err error
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.PathEnd.ClientID)
+			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(egCtx, dsth, src.ChainProvider, src.PathEnd.ClientID)
 			return err
 		})
 		if err := eg.Wait(); err != nil {
@@ -348,15 +350,15 @@ func RelayPackets(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxT
 			return err
 		}
 
-		eg := new(errgroup.Group)
+		eg, egCtx := errgroup.WithContext(ctx)
 		// add messages for sequences on src
 		eg.Go(func() error {
-			return AddMessagesForSequences(ctx, sp.Src, src, dst, srch, dsth, &msgs.Src, &msgs.Dst, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+			return AddMessagesForSequences(egCtx, sp.Src, src, dst, srch, dsth, &msgs.Src, &msgs.Dst, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
 		})
 
 		// add messages for sequences on dst
 		eg.Go(func() error {
-			return AddMessagesForSequences(ctx, sp.Dst, dst, src, dsth, srch, &msgs.Dst, &msgs.Src, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId)
+			return AddMessagesForSequences(egCtx, sp.Dst, dst, src, dsth, srch, &msgs.Dst, &msgs.Src, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId)
 		})
 
 		if err = eg.Wait(); err != nil {
@@ -371,12 +373,13 @@ func RelayPackets(ctx context.Context, src, dst *Chain, sp *RelaySequences, maxT
 
 		// Prepend non-empty msg lists with UpdateClient
 
+		eg, egCtx = errgroup.WithContext(ctx) // New errgroup because previous egCtx is canceled at this point.
 		eg.Go(func() error {
-			return PrependUpdateClientMsg(ctx, &msgs.Dst, src, dst, srch)
+			return PrependUpdateClientMsg(egCtx, &msgs.Dst, src, dst, srch)
 		})
 
 		eg.Go(func() error {
-			return PrependUpdateClientMsg(ctx, &msgs.Src, dst, src, dsth)
+			return PrependUpdateClientMsg(egCtx, &msgs.Src, dst, src, dsth)
 		})
 
 		if err = eg.Wait(); err != nil {

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -17,15 +17,15 @@ import (
 
 // QueryLatestHeights returns the heights of multiple chains at once
 func QueryLatestHeights(ctx context.Context, src, dst *Chain) (srch, dsth int64, err error) {
-	var eg = new(errgroup.Group)
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var err error
-		srch, err = src.ChainProvider.QueryLatestHeight(ctx)
+		srch, err = src.ChainProvider.QueryLatestHeight(egCtx)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
+		dsth, err = dst.ChainProvider.QueryLatestHeight(egCtx)
 		return err
 	})
 	err = eg.Wait()
@@ -107,15 +107,15 @@ func QueryChannel(ctx context.Context, src *Chain, channelID string) (*chantypes
 
 // GetIBCUpdateHeaders returns a pair of IBC update headers which can be used to update an on chain light client
 func GetIBCUpdateHeaders(ctx context.Context, srch, dsth int64, src, dst provider.ChainProvider, srcClientID, dstClientID string) (srcHeader, dstHeader ibcexported.Header, err error) {
-	var eg = new(errgroup.Group)
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var err error
-		srcHeader, err = src.GetIBCUpdateHeader(ctx, srch, dst, dstClientID)
+		srcHeader, err = src.GetIBCUpdateHeader(egCtx, srch, dst, dstClientID)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstHeader, err = dst.GetIBCUpdateHeader(ctx, dsth, src, srcClientID)
+		dstHeader, err = dst.GetIBCUpdateHeader(egCtx, dsth, src, srcClientID)
 		return err
 	})
 	if err = eg.Wait(); err != nil {
@@ -125,17 +125,15 @@ func GetIBCUpdateHeaders(ctx context.Context, srch, dsth int64, src, dst provide
 }
 
 func GetLightSignedHeadersAtHeights(ctx context.Context, src, dst *Chain, srch, dsth int64) (srcUpdateHeader, dstUpdateHeader ibcexported.Header, err error) {
-	var (
-		eg = new(errgroup.Group)
-	)
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var err error
-		srcUpdateHeader, err = src.ChainProvider.GetLightSignedHeaderAtHeight(ctx, srch)
+		srcUpdateHeader, err = src.ChainProvider.GetLightSignedHeaderAtHeight(egCtx, srch)
 		return err
 	})
 	eg.Go(func() error {
 		var err error
-		dstUpdateHeader, err = dst.ChainProvider.GetLightSignedHeaderAtHeight(ctx, dsth)
+		dstUpdateHeader, err = dst.ChainProvider.GetLightSignedHeaderAtHeight(egCtx, dsth)
 		return err
 	})
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
errgroup.WithContext returns a context that is canceled once the first
callback returns an error. This means, for example, if querying one
chain fails for whatever reason, the context passed to the other method
will be canceled, so the overall method will no longer block waiting for
success on one method when the whole group will fail.

We have some places where we are using an errgroup multiple times in one
scope, so I have named the derived context egCtx to hopefully clarify
the valid life of the context.

If we make a mistake using this pattern in the future, it ought to fail
in an obvious manner when a later call immediately fails with a canceled
context.

This change should merge cleanly with #611 and should not require any
new changes, as retry.Context should continue to use the outer context,
not the inner errgroup context.