### PR TITLE
add missing channel flags to the `link-then-start` cmd

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -670,7 +670,7 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 		},
 	}
 
-	return overrideFlag(a.Viper, clientParameterFlags(a.Viper, strategyFlag(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd)))))
+	return overrideFlag(a.Viper, channelParameterFlags(a.Viper, clientParameterFlags(a.Viper, strategyFlag(a.Viper, retryFlag(a.Viper, timeoutFlag(a.Viper, cmd))))))
 }
 
 func relayMsgCmd(a *appState) *cobra.Command {


### PR DESCRIPTION
Adding missing channel flags to the `rly tx link-then-start` cmd that were introduced in PR #585 
The command isn't used in our current Docker tests so it went unnoticed