### PR TITLE
Embed cosmos SDK version info in binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT  := $(shell git log -1 --format='%H')
-SDKCOMMIT := $(shell go list -m -u -f '{{.Version}}' github.com/cosmos/cosmos-sdk)
 GAIA_VERSION := v6.0.0
 AKASH_VERSION := v0.12.1
 OSMOSIS_VERSION := v6.4.0
@@ -16,9 +15,7 @@ all: lint install
 ###############################################################################
 
 LD_FLAGS = -X github.com/cosmos/relayer/cmd.Version=$(VERSION) \
-	-X github.com/cosmos/relayer/cmd.Commit=$(COMMIT) \
-	-X github.com/cosmos/relayer/cmd.SDKCommit=$(SDKCOMMIT) \
-	-X github.com/cosmos/relayer/cmd.GaiaCommit=$(GAIACOMMIT)
+	-X github.com/cosmos/relayer/cmd.Commit=$(COMMIT)
 
 BUILD_FLAGS := -ldflags '$(LD_FLAGS)'
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -15,8 +16,6 @@ var (
 	Version = ""
 	// Commit defines the application commit hash (defined at compile time)
 	Commit = ""
-	// SDKCommit defines the CosmosSDK commit hash (defined at compile time)
-	SDKCommit = ""
 )
 
 type versionInfo struct {
@@ -42,10 +41,20 @@ $ %s v`,
 				return err
 			}
 
+			cosmosSDK := "(unable to determine)"
+			if bi, ok := debug.ReadBuildInfo(); ok {
+				for _, dep := range bi.Deps {
+					if dep.Path == "github.com/cosmos/cosmos-sdk" {
+						cosmosSDK = dep.Version
+						break
+					}
+				}
+			}
+
 			verInfo := versionInfo{
 				Version:   Version,
 				Commit:    Commit,
-				CosmosSDK: SDKCommit,
+				CosmosSDK: cosmosSDK,
 				Go:        fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 			}
 


### PR DESCRIPTION
This does not need to be a linker flag since it can be determined at
runtime.

Also stop attempting to link `GaiaCommit`, as there is no variable with
that name in the cmd package, and nothing sets `GAIACOMMIT` in the
Makefile either.