### PR TITLE
Only validate client and connection identifiers if they are set already.

### DIFF
--- a/relayer/ics24.go
+++ b/relayer/ics24.go
@@ -35,7 +35,7 @@ func PathsSet(chains ...*Chain) bool {
 	return true
 }
 
-// SetPath sets the path and validates the identifiers
+// SetPath sets the path and validates the identifiers if they are initialized.
 func (c *Chain) SetPath(p *PathEnd) error {
 	err := p.ValidateFull()
 	if err != nil {
@@ -45,12 +45,14 @@ func (c *Chain) SetPath(p *PathEnd) error {
 	return nil
 }
 
-// AddPath takes the elements of a path and validates then, setting that path to the chain
+// AddPath takes the client and connection identifiers for a Path,
+// and if they are initialized, validates them before setting the PathEnd on the Chain.
+// NOTE: if the Path is blank (i.e. the identifiers are not set) validation is skipped.
 func (c *Chain) AddPath(clientID, connectionID string) error {
 	return c.SetPath(&PathEnd{ChainID: c.ChainID(), ClientID: clientID, ConnectionID: connectionID})
 }
 
-// ValidateFull returns errors about invalid identifiers as well as unset path variables for the appropriate type
+// ValidateFull returns errors about invalid client and connection identifiers.
 func (pe *PathEnd) ValidateFull() error {
 	if pe.ClientID != "" {
 		if err := pe.Vclient(); err != nil {

--- a/relayer/ics24.go
+++ b/relayer/ics24.go
@@ -52,11 +52,16 @@ func (c *Chain) AddPath(clientID, connectionID string) error {
 
 // ValidateFull returns errors about invalid identifiers as well as unset path variables for the appropriate type
 func (pe *PathEnd) ValidateFull() error {
-	if err := pe.Vclient(); err != nil {
-		return err
+	if pe.ClientID != "" {
+		if err := pe.Vclient(); err != nil {
+			return err
+		}
 	}
-	if err := pe.Vconn(); err != nil {
-		return err
+
+	if pe.ConnectionID != "" {
+		if err := pe.Vconn(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
`Path` identifiers are attempting to be validated on newly created Paths which don't have clients or connections initialized yet. If this is a blank `Path` we don't want to attempt to validate the identifiers

Closes #623 