### PR TITLE
Ensure StartRelayer goroutine indicates shutdown

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -129,6 +130,9 @@ func Execute() {
 		// This should result in cleaner output from non-interactive commands that stop quickly.
 		time.Sleep(250 * time.Millisecond)
 		fmt.Fprintf(os.Stderr, "Received signal %v. Attempting clean shutdown. Send interrupt again to force hard shutdown.\n", sig)
+
+		// Dump all goroutines on panic, not just the current one.
+		debug.SetTraceback("all")
 
 		// Block waiting for a second interrupt or a timeout.
 		// The main goroutine ought to finish before either case is reached.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -106,7 +107,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 			// The context being canceled will cause the relayer to stop,
 			// so we don't want to separately monitor the ctx.Done channel,
 			// because we would risk returning before the relayer cleans up.
-			if err := <-errorChan; err != nil {
+			if err := <-errorChan; err != nil && !errors.Is(err, context.Canceled) {
 				c[src].Log(fmt.Sprintf("relayer start error. Err: %v", err))
 				return err
 			}


### PR DESCRIPTION
Extract the anonymous function into a named function for a clearer stack
trace. Remove unnecessary select with one case and default from that
function; blocking calls in the main goroutine should respect the
context and should return promptly.

Defer closing the error channel so that the reader will always see a
clear signal that the goroutine has finished.