### PR TITLE
remove unnecessary linker flag in `goreleaser.yaml`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,6 @@ builds:
     ldflags:
       - -X github.com/cosmos/relayer/cmd.Version={{ .Tag }}
       - -X github.com/cosmos/relayer/cmd.Commit={{ .FullCommit }}
-      - -X github.com/cosmos/relayer/cmd.SDKCommit={{ .Env.SDK_COMMIT }}
     goos:
       - darwin
       - linux


### PR DESCRIPTION
We no longer need the linker flag for the SDK version since we are retrieving that at runtime. I'm fairly certain this is causing the goreleaser job to fail 