### PR TITLE
Add debug server

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
+const (
 	flagURL                     = "url"
 	flagSkip                    = "skip"
 	flagTimeout                 = "timeout"
@@ -30,6 +30,13 @@ var (
 	flagDstPort                 = "dst-port"
 	flagOrder                   = "order"
 	flagVersion                 = "version"
+	flagDebugAddr               = "debug-addr"
+)
+
+const (
+	// 7597 is "RLYR" on a telephone keypad.
+	// It also happens to be unassigned in the IANA port list.
+	defaultDebugAddr = "localhost:7597"
 )
 
 func ibcDenomFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
@@ -241,6 +248,14 @@ func srcPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 func dstPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().String(flagDstPort, "transfer", "port on dst chain to use when generating path")
 	if err := v.BindPFlag(flagDstPort, cmd.Flags().Lookup(flagDstPort)); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().String(flagDebugAddr, defaultDebugAddr, "address to use for debug server. Set empty to disable debug server.")
+	if err := v.BindPFlag(flagDebugAddr, cmd.Flags().Lookup(flagDebugAddr)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,7 +45,14 @@ If:
 ```
 Your client is the culprit here. Your client may be invalid or expired.
 
-
 ---
 
-[<-- Create Path Across Chanes](create-path-across-chain.md) - [Features -->](./features.md)
+**Inspect Go runtime debug data**
+
+If you started `rly` with the default `--debug-addr` argument,
+you can open `http://localhost:7597` in your browser to explore details from the Go runtime.
+
+If you need active assistance from the Relayer development team regarding an unresponsive Relayer instance,
+it will be helpful to provide the output from `http://localhost:7597/debug/pprof/goroutine?debug=2` at a minimum.
+
+[<-- Create Path Across Chains](create-path-across-chain.md) - [Features -->](./features.md)

--- a/internal/relaydebug/debugserver.go
+++ b/internal/relaydebug/debugserver.go
@@ -1,0 +1,48 @@
+package relaydebug
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/pprof"
+
+	"go.uber.org/zap"
+)
+
+// StartDebugServer starts a debug server in a background goroutine,
+// accepting connections on the given listener.
+// Any HTTP logging will be written at info level to the given logger.
+// The server will be forcefully shut down when ctx finishes.
+func StartDebugServer(ctx context.Context, log *zap.Logger, ln net.Listener) {
+	// Although we could just import net/http/pprof and rely on the default global server,
+	// we may want many instances of this in test,
+	// and we will probably want more endpoints as time goes on,
+	// so use a dedicated http.Server instance here.
+
+	// Set up new mux identical to the default mux configuration in net/http/pprof.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// And redirect the browser to the /debug/pprof root,
+	// so operators don't see a mysterious 404 page.
+	mux.Handle("/", http.RedirectHandler("/debug/pprof", http.StatusSeeOther))
+
+	srv := &http.Server{
+		Handler:  mux,
+		ErrorLog: zap.NewStdLog(log),
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	go srv.Serve(ln)
+
+	go func() {
+		<-ctx.Done()
+		srv.Close()
+	}()
+}


### PR DESCRIPTION
By default, it will listen on localhost:7597 as part of 'rly start'.
Currently, we only expose Go runtime data on that server. I anticipate
that we will eventually expose application-level data there as well.