### PR TITLE
Report relayer commit using debug.BuildInfo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,6 @@ builds:
     main: ./main.go
     ldflags:
       - -X github.com/cosmos/relayer/v2/cmd.Version={{ .Tag }}
-      - -X github.com/cosmos/relayer/v2/cmd.Commit={{ .FullCommit }}
     goos:
       - darwin
       - linux

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ all: lint install
 # Build / Install
 ###############################################################################
 
-LD_FLAGS = -X github.com/cosmos/relayer/v2/cmd.Version=$(VERSION) \
-	-X github.com/cosmos/relayer/v2/cmd.Commit=$(COMMIT)
+LD_FLAGS = -X github.com/cosmos/relayer/v2/cmd.Version=$(VERSION)
 
 BUILD_FLAGS := -ldflags '$(LD_FLAGS)'
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/cosmos/relayer/v2/internal/relaydebug"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -14,8 +15,6 @@ import (
 var (
 	// Version defines the application version (defined at compile time)
 	Version = ""
-	// Commit defines the application commit hash (defined at compile time)
-	Commit = ""
 )
 
 type versionInfo struct {
@@ -53,7 +52,7 @@ $ %s v`,
 
 			verInfo := versionInfo{
 				Version:   Version,
-				Commit:    Commit,
+				Commit:    relaydebug.BuildCommit(),
 				CosmosSDK: cosmosSDK,
 				Go:        fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 			}

--- a/internal/relaydebug/version_go117.go
+++ b/internal/relaydebug/version_go117.go
@@ -1,0 +1,14 @@
+//go:build !go1.18
+
+package relaydebug
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// BuildCommit reports an unknown commit,
+// due to building with a version of Go older than 1.18.
+func BuildCommit() string {
+	return fmt.Sprintf("unknown (built with %s)", runtime.Version())
+}

--- a/internal/relaydebug/version_go118.go
+++ b/internal/relaydebug/version_go118.go
@@ -1,0 +1,39 @@
+//go:build go1.18
+
+package relaydebug
+
+import (
+	"runtime/debug"
+	"strconv"
+)
+
+// BuildCommit reports the stamped vcs.revision according to debug.ReadBuildInfo,
+// including a suffix indicating whether the working tree had uncommitted changes.
+//
+// Note that this will report "unknown" if using "go run".
+// Use "go build" to compile to a binary to see the proper commit reported.
+func BuildCommit() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown (built without module support?)"
+	}
+
+	rev := "unknown"
+	dirty := false
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			if d, err := strconv.ParseBool(s.Value); err == nil {
+				dirty = d
+			}
+		}
+	}
+
+	if dirty {
+		return rev + " (dirty)"
+	}
+
+	return rev
+}


### PR DESCRIPTION
Now that CI is building with go1.18, we can use the embedded
vcs.revision field on BuildInfo instead of including it in ldflags.
Because this is a new API in go1.18, and we are not yet ready to
officially stop builds on go1.17, include a fallback to just report
"unknown" for the commit from go1.17 builds.