### PR TITLE
Replace time.Sleep calls with time.After and context check

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -118,7 +118,12 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 						})); err != nil {
 							return err
 						}
-						time.Sleep(timeToExpiry - thresholdTime)
+						select {
+						case <-time.After(timeToExpiry - thresholdTime):
+							// Nothing to do.
+						case <-egCtx.Done():
+							return egCtx.Err()
+						}
 					}
 				})
 				if err = eg.Wait(); err != nil {

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -671,8 +671,13 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 			lCmd := linkCmd(a)
 
 			for err := lCmd.RunE(cmd, args); err != nil; err = lCmd.RunE(cmd, args) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "retrying link: %s\n", err)
-				time.Sleep(1 * time.Second)
+				a.Log.Info("Error running link; retrying", zap.Error(err))
+				select {
+				case <-time.After(time.Second):
+					// Keep going.
+				case <-cmd.Context().Done():
+					return cmd.Context().Err()
+				}
 			}
 
 			sCmd := startCmd(a)

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -86,7 +86,12 @@ func (c *Chain) CreateOpenChannels(ctx context.Context, dst *Chain, maxRetries u
 		case !success:
 			failures++
 			c.log.Info("Retrying transaction...")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+				// Nothing to do.
+			case <-ctx.Done():
+				return modified, ctx.Err()
+			}
 
 			if failures > maxRetries {
 				return modified, fmt.Errorf("! Channel failed: [%s]chan{%s}port{%s} -> [%s]chan{%s}port{%s}",

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -71,7 +71,12 @@ func (c *Chain) CreateOpenConnections(ctx context.Context, dst *Chain, maxRetrie
 		case !success:
 			failed++
 			c.log.Info("Retrying transaction...")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+				// Nothing to do.
+			case <-ctx.Done():
+				return modified, ctx.Err()
+			}
 
 			if failed > maxRetries {
 				return modified, fmt.Errorf("! Connection failed: [%s]client{%s}conn{%s} -> [%s]client{%s}conn{%s}",

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1506,7 +1506,12 @@ func (cc *CosmosProvider) WaitForNBlocks(ctx context.Context, n int64) error {
 		if h.SyncInfo.LatestBlockHeight > initial+n {
 			return nil
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-time.After(10 * time.Millisecond):
+			// Nothing to do.
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 


### PR DESCRIPTION
This way, if a user sends SIGINT during a point when we were previously
sleeping, this should begin cancellation immediately instead of waiting
for the sleep to complete first.