### PR TITLE
Support explicit log format configuration

### DIFF
--- a/cmd/system_test.go
+++ b/cmd/system_test.go
@@ -51,7 +51,7 @@ func (s *System) Run(log *zap.Logger, args ...string) RunResult {
 // providing in as the command's standard input,
 // and returns a RunResult that has its Stdout and Stderr populated.
 func (s *System) RunWithInput(log *zap.Logger, in io.Reader, args ...string) RunResult {
-	rootCmd := cmd.NewRootCmd(log, zap.NewAtomicLevel())
+	rootCmd := cmd.NewRootCmd(log)
 	rootCmd.SetIn(in)
 	// cmd.Execute also sets SilenceUsage,
 	// so match that here for more correct assertions.


### PR DESCRIPTION
This maintains the existing behavior of "auto" formatting (console
formatting if connected to a terminal, logfmt otherwise), but allows
opting in to logfmt, json, or console encoding specifically if so
desired. This will give operators fine control over log formatting for
any postprocessing they may want, and it will allow us to easily add new
encodings should that need ever arise.