### PR TITLE
Pass explicit logger to relayer package functions

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,7 +80,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 				relaydebug.StartDebugServer(cmd.Context(), log, ln)
 			}
 
-			rlyErrCh := relayer.StartRelayer(cmd.Context(), c[src], c[dst], filter, maxTxSize, maxMsgLength)
+			rlyErrCh := relayer.StartRelayer(cmd.Context(), a.Log, c[src], c[dst], filter, maxTxSize, maxMsgLength)
 
 			// NOTE: This block of code is useful for ensuring that the clients tracking each chain do not expire
 			// when there are no packets flowing across the channels. It is currently a source of errors that have been

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -730,7 +730,7 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 				return err
 			}
 
-			return relayer.RelayPacket(cmd.Context(), c[src], c[dst], sp, maxTxSize, maxMsgLength, uint64(seqNum), channel)
+			return relayer.RelayPacket(cmd.Context(), a.Log, c[src], c[dst], sp, maxTxSize, maxMsgLength, uint64(seqNum), channel)
 		},
 	}
 
@@ -774,7 +774,7 @@ $ %s tx relay-pkts demo-path channel-0`,
 				return err
 			}
 
-			if err = relayer.RelayPackets(cmd.Context(), c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
+			if err = relayer.RelayPackets(cmd.Context(), a.Log, c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
 				return err
 			}
 
@@ -824,7 +824,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 				return err
 			}
 
-			if err = relayer.RelayAcknowledgements(cmd.Context(), c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
+			if err = relayer.RelayAcknowledgements(cmd.Context(), a.Log, c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
 				return err
 			}
 
@@ -1001,7 +1001,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			}
 
-			return c[src].SendTransferMsg(cmd.Context(), c[dst], amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
+			return c[src].SendTransferMsg(cmd.Context(), a.Log, c[dst], amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
 		},
 	}
 

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -623,7 +623,7 @@ func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, 
 			break
 		}
 
-		if closeSteps.Send(ctx, c, dst); closeSteps.Success() && closeSteps.Last {
+		if closeSteps.Send(ctx, c.log, c, dst); closeSteps.Success() && closeSteps.Last {
 			srch, dsth, err := QueryLatestHeights(ctx, c, dst)
 			if err != nil {
 				return err

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -258,7 +258,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 
 	// Send msgs to both chains
 	if clients.Ready() {
-		if clients.Send(ctx, c, dst); clients.Success() {
+		if clients.Send(ctx, c.log, c, dst); clients.Success() {
 			c.log.Info(
 				"Clients updated",
 				zap.String("src_chain_id", c.ChainID()),

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -11,43 +11,50 @@ import (
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 )
 
-// LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
-func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
-	if c.debug {
-		fields := make([]zap.Field, 1+len(msgs), 2+len(msgs))
-		fields[0] = zap.String("src_chain_id", c.ChainID())
-		for i, msg := range msgs {
-			cm, ok := msg.(cosmos.CosmosMessage)
-			if ok {
-				fields[i+1] = zap.Object(
-					fmt.Sprintf("msg-%d", i),
-					cm,
-				)
-			} else {
-				// TODO: choose another encoding instead of skipping?
-				fields[i+1] = zap.Skip()
-			}
+func logFailedTx(log *zap.Logger, chainID string, res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+	fields := make([]zap.Field, 1+len(msgs), 2+len(msgs))
+	fields[0] = zap.String("chain_id", chainID)
+	for i, msg := range msgs {
+		cm, ok := msg.(cosmos.CosmosMessage)
+		if ok {
+			fields[i+1] = zap.Object(
+				fmt.Sprintf("msg-%d", i),
+				cm,
+			)
+		} else {
+			// TODO: choose another encoding instead of skipping?
+			fields[i+1] = zap.Skip()
 		}
-		if err != nil {
-			fields = append(fields, zap.Error(err))
-		}
-		c.log.Info("Failed sending transaction", fields...)
 	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	log.Info("Failed sending transaction", fields...)
 
 	if res != nil && res.Code != 0 && res.Data != "" {
-		c.log.Info(
+		msgTypes := make([]string, len(msgs))
+		for i, msg := range msgs {
+			msgTypes[i] = msg.Type()
+		}
+
+		log.Info(
 			"Sent transaction that resulted in error",
-			zap.String("src_chain_id", c.ChainID()),
+			zap.String("chain_id", chainID),
 			zap.Int64("height", res.Height),
-			zap.String("msg_types", getMsgTypes(msgs)),
+			zap.Strings("msg_types", msgTypes),
 			zap.Uint32("error_code", res.Code),
 			zap.String("error_data", res.Data),
 		)
 	}
 
 	if res != nil {
-		c.log.Debug("Transaction response", zap.Object("resp", res))
+		log.Debug("Transaction response", zap.Object("resp", res))
 	}
+}
+
+// LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
+func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+	logFailedTx(c.log, c.ChainID(), res, err, msgs)
 }
 
 func (c *Chain) logPacketsRelayed(dst *Chain, num int, srcChannel *chantypes.IdentifiedChannel) {

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -8,11 +8,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/provider"
+	"go.uber.org/zap"
 )
 
 //nolint:lll
 // SendTransferMsg initiates an ics20 transfer from src to dst with the specified args
-func (c *Chain) SendTransferMsg(ctx context.Context, dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
+func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
 	var (
 		timeoutHeight    uint64
 		timeoutTimestamp uint64
@@ -54,7 +55,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, dst *Chain, amount sdk.Coin
 		Dst: []provider.RelayerMessage{},
 	}
 
-	if txs.Send(ctx, c, dst); !txs.Success() {
+	if txs.Send(ctx, log, c, dst); !txs.Success() {
 		return fmt.Errorf("failed to send transfer message")
 	}
 	return nil

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -18,15 +18,15 @@ type ActiveChannel struct {
 }
 
 // StartRelayer starts the main relaying loop and returns a channel that will contain any control-flow related errors.
-func StartRelayer(ctx context.Context, src, dst *Chain, filter ChannelFilter, maxTxSize, maxMsgLength uint64) chan error {
+func StartRelayer(ctx context.Context, log *zap.Logger, src, dst *Chain, filter ChannelFilter, maxTxSize, maxMsgLength uint64) chan error {
 	errorChan := make(chan error, 1)
 
-	go relayerMainLoop(ctx, src, dst, filter, maxTxSize, maxMsgLength, errorChan)
+	go relayerMainLoop(ctx, log, src, dst, filter, maxTxSize, maxMsgLength, errorChan)
 	return errorChan
 }
 
 // relayerMainLoop is the main loop of the relayer.
-func relayerMainLoop(ctx context.Context, src, dst *Chain, filter ChannelFilter, maxTxSize, maxMsgLength uint64, errCh chan<- error) {
+func relayerMainLoop(ctx context.Context, log *zap.Logger, src, dst *Chain, filter ChannelFilter, maxTxSize, maxMsgLength uint64, errCh chan<- error) {
 	defer close(errCh)
 
 	channels := make(chan *ActiveChannel, 10)
@@ -55,7 +55,7 @@ func relayerMainLoop(ctx context.Context, src, dst *Chain, filter ChannelFilter,
 		for _, channel := range srcOpenChannels {
 			if !channel.active {
 				channel.active = true
-				go relayUnrelayedPacketsAndAcks(ctx, src, dst, maxTxSize, maxMsgLength, channel, channels)
+				go relayUnrelayedPacketsAndAcks(ctx, log, src, dst, maxTxSize, maxMsgLength, channel, channels)
 			}
 		}
 
@@ -161,17 +161,17 @@ func applyChannelFilterRule(filter ChannelFilter, channels []*types.IdentifiedCh
 }
 
 // relayUnrelayedPacketsAndAcks will relay all the pending packets and acknowledgements on both the src and dst chains.
-func relayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *ActiveChannel, channels chan<- *ActiveChannel) {
+func relayUnrelayedPacketsAndAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *ActiveChannel, channels chan<- *ActiveChannel) {
 	// make goroutine signal its death, whether it's a panic or a return
 	defer func() {
 		channels <- srcChannel
 	}()
 
 	for {
-		if ok := relayUnrelayedPackets(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); !ok {
+		if ok := relayUnrelayedPackets(ctx, log, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); !ok {
 			return
 		}
-		if ok := relayUnrelayedAcks(ctx, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); !ok {
+		if ok := relayUnrelayedAcks(ctx, log, src, dst, maxTxSize, maxMsgLength, srcChannel.channel); !ok {
 			return
 		}
 
@@ -188,7 +188,7 @@ func relayUnrelayedPacketsAndAcks(ctx context.Context, src, dst *Chain, maxTxSiz
 // relayUnrelayedPackets fetches unrelayed packet sequence numbers and attempts to relay the associated packets.
 // relayUnrelayedPackets returns true if packets were empty or were successfully relayed.
 // Otherwise, it logs the errors and returns false.
-func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
+func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
 	childCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 
@@ -236,11 +236,11 @@ func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxM
 		)
 	}
 
-	if err := RelayPackets(childCtx, src, dst, sp, maxTxSize, maxMsgLength, srcChannel); err != nil {
+	if err := RelayPackets(childCtx, log, src, dst, sp, maxTxSize, maxMsgLength, srcChannel); err != nil {
 		// If there was a context cancellation or deadline while attempting to relay packets,
 		// log that and indicate failure.
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			src.log.Warn(
+			log.Warn(
 				"Context finished while waiting for RelayPackets to complete",
 				zap.String("src_chain_id", src.ChainID()),
 				zap.String("src_channel_id", srcChannel.ChannelId),
@@ -252,7 +252,7 @@ func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxM
 		}
 
 		// Otherwise, not a context error, but an application-level error.
-		src.log.Warn(
+		log.Warn(
 			"Relay packets error",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -270,14 +270,14 @@ func relayUnrelayedPackets(ctx context.Context, src, dst *Chain, maxTxSize, maxM
 // relayUnrelayedAcks fetches unrelayed acknowledgements and attempts to relay them.
 // relayUnrelayedAcks returns true if acknowledgements were empty or were successfully relayed.
 // Otherwise, it logs the errors and returns false.
-func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
+func relayUnrelayedAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
 	childCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 
 	// Fetch any unrelayed acks depending on the channel order
 	ap, err := UnrelayedAcknowledgements(ctx, src, dst, srcChannel)
 	if err != nil {
-		src.log.Warn(
+		log.Warn(
 			"Error retrieving unrelayed acknowledgements",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -288,7 +288,7 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 
 	// If there are no unrelayed acks, stop early.
 	if ap.Empty() {
-		src.log.Info(
+		log.Info(
 			"No acknowledgements in queue",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -301,7 +301,7 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 	}
 
 	if len(ap.Src) > 0 {
-		src.log.Debug(
+		log.Debug(
 			"Unrelayed source acknowledgements",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -310,7 +310,7 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 	}
 
 	if len(ap.Dst) > 0 {
-		src.log.Debug(
+		log.Debug(
 			"Unrelayed destination acknowledgements",
 			zap.String("dst_chain_id", dst.ChainID()),
 			zap.String("dst_channel_id", srcChannel.Counterparty.ChannelId),
@@ -318,11 +318,11 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 		)
 	}
 
-	if err := RelayAcknowledgements(childCtx, src, dst, ap, maxTxSize, maxMsgLength, srcChannel); err != nil {
+	if err := RelayAcknowledgements(childCtx, log, src, dst, ap, maxTxSize, maxMsgLength, srcChannel); err != nil {
 		// If there was a context cancellation or deadline while attempting to relay acknowledgements,
 		// log that and indicate failure.
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			src.log.Warn(
+			log.Warn(
 				"Context finished while waiting for RelayAcknowledgements to complete",
 				zap.String("src_chain_id", src.ChainID()),
 				zap.String("src_channel_id", srcChannel.ChannelId),
@@ -334,7 +334,7 @@ func relayUnrelayedAcks(ctx context.Context, src, dst *Chain, maxTxSize, maxMsgL
 		}
 
 		// Otherwise, not a context error, but an application-level error.
-		src.log.Warn(
+		log.Warn(
 			"Relay acknowledgements error",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),


### PR DESCRIPTION
Instead of relying on the logger associated with a chain, accept a
logger specifically for use in the package-level function.

By convention, ctx is always the first parameter, and then log.

Passing the logger separately also allows more flexibility in the
parameter types to these functions, which will simplify adding new tests
shortly.