### PR TITLE
Use narrower parameters to (*RelayMsgs).Send()

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -623,7 +623,7 @@ func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, 
 			break
 		}
 
-		if closeSteps.Send(ctx, c.log, c, dst); closeSteps.Success() && closeSteps.Last {
+		if closeSteps.Send(ctx, c.log, AsRelayMsgSender(c), AsRelayMsgSender(dst)); closeSteps.Success() && closeSteps.Last {
 			srch, dsth, err := QueryLatestHeights(ctx, c, dst)
 			if err != nil {
 				return err

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -258,7 +258,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 
 	// Send msgs to both chains
 	if clients.Ready() {
-		if clients.Send(ctx, c.log, c, dst); clients.Success() {
+		if clients.Send(ctx, c.log, AsRelayMsgSender(c), AsRelayMsgSender(dst)); clients.Success() {
 			c.log.Info(
 				"Clients updated",
 				zap.String("src_chain_id", c.ChainID()),

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -352,7 +352,7 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 		}
 
 		// send messages to their respective chains
-		if msgs.Send(ctx, log, src, dst); msgs.Success() {
+		if msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst)); msgs.Success() {
 			if len(msgs.Dst) > 1 {
 				dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 			}
@@ -427,7 +427,7 @@ func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *Rel
 		}
 
 		// send messages to their respective chains
-		if msgs.Send(ctx, log, src, dst); msgs.Success() {
+		if msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst)); msgs.Success() {
 			if len(msgs.Dst) > 1 {
 				dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 			}
@@ -642,7 +642,7 @@ func RelayPacket(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *Rela
 	}
 
 	// send messages to their respective chains
-	if msgs.Send(ctx, log, src, dst); msgs.Success() {
+	if msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst)); msgs.Success() {
 		if len(msgs.Dst) > 1 {
 			dst.logPacketsRelayed(src, len(msgs.Dst)-1, srcChannel)
 		}

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -55,7 +55,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		Dst: []provider.RelayerMessage{},
 	}
 
-	if txs.Send(ctx, log, c, dst); !txs.Success() {
+	if txs.Send(ctx, log, AsRelayMsgSender(c), AsRelayMsgSender(dst)); !txs.Success() {
 		return fmt.Errorf("failed to send transfer message")
 	}
 	return nil

--- a/relayer/relaymsgs_test.go
+++ b/relayer/relaymsgs_test.go
@@ -1,0 +1,133 @@
+package relayer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cosmos/relayer/v2/relayer"
+	"github.com/cosmos/relayer/v2/relayer/provider"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestRelayMsgs_IsMaxTx(t *testing.T) {
+	rm := relayer.RelayMsgs{
+		MaxTxSize:    10,
+		MaxMsgLength: 10,
+	}
+	require.True(t, rm.IsMaxTx(1, 11), "only exceeded tx size")
+	require.True(t, rm.IsMaxTx(11, 1), "only exceeded message length")
+	require.False(t, rm.IsMaxTx(4, 5), "neither exceeded")
+
+	rm = relayer.RelayMsgs{
+		MaxTxSize:    0,
+		MaxMsgLength: 10,
+	}
+	require.True(t, rm.IsMaxTx(11, 1), "exceeded set max message length")
+	require.False(t, rm.IsMaxTx(5, 100), "did not exceed set max message length")
+
+	rm = relayer.RelayMsgs{
+		MaxTxSize:    10,
+		MaxMsgLength: 0,
+	}
+	require.True(t, rm.IsMaxTx(1, 11), "exceeded set max tx size")
+	require.False(t, rm.IsMaxTx(100, 5), "did not exceed set max tx size")
+
+	rm = relayer.RelayMsgs{
+		MaxTxSize:    0,
+		MaxMsgLength: 0,
+	}
+	require.False(t, rm.IsMaxTx(9999999, 99999999), "no limits to exceed")
+}
+
+// fakeRelayerMessage is a dummy implementation of provider.RelayerMessage.
+type fakeRelayerMessage struct {
+	t, b string
+}
+
+var _ provider.RelayerMessage = fakeRelayerMessage{}
+
+func (m fakeRelayerMessage) Type() string {
+	return m.t
+}
+
+func (m fakeRelayerMessage) MsgBytes() ([]byte, error) {
+	return []byte(m.b), nil
+}
+
+func TestRelayMsgs_Send(t *testing.T) {
+	// Fixtures for test.
+	// src appends to srcSent and dst appends to dstSent.
+	var srcSent []provider.RelayerMessage
+	src := relayer.RelayMsgSender{
+		ChainID: "src",
+		SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			srcSent = append(srcSent, msgs...)
+			return nil, false, nil
+		},
+	}
+
+	var dstSent []provider.RelayerMessage
+	dst := relayer.RelayMsgSender{
+		ChainID: "dst",
+		SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			dstSent = append(dstSent, msgs...)
+			return nil, false, nil
+		},
+	}
+
+	srcMsg := fakeRelayerMessage{t: "srctype", b: "srcdata"}
+	dstMsg := fakeRelayerMessage{t: "dsttype", b: "dstdata"}
+
+	t.Run("sends in a single batch when there are no limits", func(t *testing.T) {
+		// Clear state (in case this test is ever reordered).
+		srcSent = nil
+		dstSent = nil
+
+		rm := relayer.RelayMsgs{
+			Src: []provider.RelayerMessage{srcMsg},
+			Dst: []provider.RelayerMessage{dstMsg},
+		}
+
+		rm.Send(context.Background(), zaptest.NewLogger(t), src, dst)
+
+		require.Equal(t, []provider.RelayerMessage{srcMsg}, srcSent)
+		require.Equal(t, []provider.RelayerMessage{dstMsg}, dstSent)
+	})
+
+	t.Run("sends all messages when max message length exceeded", func(t *testing.T) {
+		// Clear state from previous test.
+		srcSent = nil
+		dstSent = nil
+
+		rm := relayer.RelayMsgs{
+			Src: []provider.RelayerMessage{srcMsg, srcMsg, srcMsg},
+			Dst: []provider.RelayerMessage{dstMsg, dstMsg, dstMsg},
+
+			MaxMsgLength: 2,
+		}
+
+		rm.Send(context.Background(), zaptest.NewLogger(t), src, dst)
+
+		require.Equal(t, []provider.RelayerMessage{srcMsg, srcMsg, srcMsg}, srcSent)
+		require.Equal(t, []provider.RelayerMessage{dstMsg, dstMsg, dstMsg}, dstSent)
+	})
+
+	t.Run("sends all messages when max tx size exceeded", func(t *testing.T) {
+		// Clear state from previous test.
+		srcSent = nil
+		dstSent = nil
+
+		rm := relayer.RelayMsgs{
+			Src: []provider.RelayerMessage{srcMsg, srcMsg, srcMsg},
+			Dst: []provider.RelayerMessage{dstMsg, dstMsg, dstMsg},
+
+			MaxMsgLength: 2,
+		}
+
+		rm.Send(context.Background(), zaptest.NewLogger(t), src, dst)
+
+		require.Equal(t, []provider.RelayerMessage{srcMsg, srcMsg, srcMsg}, srcSent)
+		require.Equal(t, []provider.RelayerMessage{dstMsg, dstMsg, dstMsg}, dstSent)
+	})
+}


### PR DESCRIPTION
And backfill some basic tests for that method.

The new, narrower RelayMsgSender struct is much simpler to mock in test
than the wide interface matching Chain. And having some basic tests in
place will make it easier to continue refactoring Send.