### PR TITLE
Adjust some debug-level logs to info level

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -96,8 +96,8 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 							timeToExpiry, err = UpdateClientsFromChains(egCtx, c[src], c[dst], thresholdTime)
 							return err
 						}, retry.Context(egCtx), retry.Attempts(5), retry.Delay(time.Millisecond*500), retry.LastErrorOnly(true), retry.OnRetry(func(n uint, err error) {
-							a.Log.Debug(
-								"Updating clients from chains",
+							a.Log.Info(
+								"Failed to update clients from chains",
 								zap.String("src_chain_id", c[src].ChainID()),
 								zap.String("dst_chain_id", c[dst].ChainID()),
 								zap.Uint("attempt", n+1),

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -220,11 +220,11 @@ func createClientCmd(a *appState) *cobra.Command {
 			if err = retry.Do(func() error {
 				srcUpdateHeader, dstUpdateHeader, err = relayer.GetLightSignedHeadersAtHeights(cmd.Context(), c[src], c[dst], srch, dsth)
 				if err != nil {
-					return fmt.Errorf("failed to query light signed headers: %w", err)
+					return err
 				}
-				return err
+				return nil
 			}, retry.Context(cmd.Context()), relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
-				a.Log.Debug(
+				a.Log.Info(
 					"Failed to get light signed header",
 					zap.String("src_chain_id", c[src].ChainID()),
 					zap.Int64("src_height", srch),

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -410,7 +410,6 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 		}
 
 		if !found || override {
-
 			if err = retry.Do(func() error {
 				dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
 				if err != nil || dsth == 0 {

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -36,12 +36,12 @@ func (c *Chain) CreateClients(ctx context.Context, dst *Chain, allowUpdateAfterE
 	if err = retry.Do(func() error {
 		srcUpdateHeader, dstUpdateHeader, err = GetLightSignedHeadersAtHeights(ctx, c, dst, srch, dsth)
 		if err != nil {
-			return fmt.Errorf("failed to query light signed headers: %w", err)
+			return err
 		}
-		return err
+		return nil
 	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		c.log.Debug(
-			"Failed to get light signed header",
+		c.log.Info(
+			"Failed to get light signed headers",
 			zap.String("src_chain_id", c.ChainID()),
 			zap.Int64("src_height", srch),
 			zap.String("dst_chain_id", dst.ChainID()),

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -121,7 +121,7 @@ func (c *Chain) errQueryUnrelayedPacketAcks() error {
 }
 
 func (c *Chain) LogRetryGetIBCUpdateHeader(n uint, err error) {
-	c.log.Debug(
+	c.log.Info(
 		"Failed to get IBC update headers",
 		zap.String("chain_id", c.ChainID()),
 		zap.Uint("attempt", n+1),

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -43,7 +43,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 				return nil
 			}
 		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			src.log.Debug(
+			src.log.Info(
 				"Failed to query packet commitments",
 				zap.String("channel_id", srcChannel.ChannelId),
 				zap.String("port_id", srcChannel.PortId),
@@ -77,7 +77,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 				return nil
 			}
 		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dst.log.Debug(
+			dst.log.Info(
 				"Failed to query packet commitments",
 				zap.String("channel_id", srcChannel.Counterparty.ChannelId),
 				zap.String("port_id", srcChannel.Counterparty.PortId),
@@ -107,7 +107,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 			rs.Src, err = dst.ChainProvider.QueryUnreceivedPackets(egCtx, uint64(dsth), srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcPacketSeq)
 			return err
 		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dst.log.Debug(
+			dst.log.Info(
 				"Failed to query unreceived packets",
 				zap.String("channel_id", srcChannel.Counterparty.ChannelId),
 				zap.String("port_id", srcChannel.Counterparty.PortId),
@@ -126,7 +126,7 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 			rs.Dst, err = src.ChainProvider.QueryUnreceivedPackets(egCtx, uint64(srch), srcChannel.ChannelId, srcChannel.PortId, dstPacketSeq)
 			return err
 		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			src.log.Debug(
+			src.log.Info(
 				"Failed to query unreceived packets",
 				zap.String("channel_id", srcChannel.Counterparty.ChannelId),
 				zap.String("port_id", srcChannel.Counterparty.PortId),
@@ -456,7 +456,7 @@ func AddMessagesForSequences(ctx context.Context, sequences []uint64, src, dst *
 				uint64(srch), uint64(dsth), seq, dstChanID, dstPortID, dst.ClientID(), srcChanID, srcPortID, src.ClientID())
 			return err
 		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			src.log.Debug(
+			src.log.Info(
 				"Failed to relay packet from sequence",
 				zap.String("src_chain_id", src.ChainID()),
 				zap.String("src_channel_id", srcChanID),

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -1333,15 +1333,18 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 	if err = retry.Do(func() error {
 		clientsResp, err = cc.QueryClients(ctx)
 		if err != nil {
-			cc.log.Debug(
-				"Failed to query clients",
-				zap.String("chain_id", cc.PCfg.ChainID),
-				zap.Error(err),
-			)
 			return err
 		}
-		return err
-	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
+		return nil
+	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
+		cc.log.Info(
+			"Failed to query clients",
+			zap.String("chain_id", cc.PCfg.ChainID),
+			zap.Uint("attempt", n+1),
+			zap.Uint("max_attempts", RtyAttNum),
+			zap.Error(err),
+		)
+	})); err != nil {
 		return "", false
 	}
 
@@ -1354,7 +1357,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 
 		tmClientState, ok := clientState.(*tmclient.ClientState)
 		if !ok {
-			cc.log.Debug(
+			cc.log.Info(
 				"Failed to convert value to *tmclient.ClientState",
 				zap.Stringer("client_state_type", reflect.TypeOf(clientState)),
 			)
@@ -1369,7 +1372,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 			// query the latest consensus state of the potential matching client
 			consensusStateResp, err := cc.QueryConsensusStateABCI(ctx, identifiedClientState.ClientId, existingClientState.GetLatestHeight())
 			if err != nil {
-				cc.log.Debug(
+				cc.log.Info(
 					"Failed to query latest consensus state for existing client on chain",
 					zap.String("chain_id", cc.PCfg.ChainID),
 					zap.Error(err),
@@ -1380,7 +1383,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 			//nolint:lll
 			header, err := counterparty.GetLightSignedHeaderAtHeight(ctx, int64(existingClientState.GetLatestHeight().GetRevisionHeight()))
 			if err != nil {
-				cc.log.Debug(
+				cc.log.Info(
 					"Failed to query header",
 					zap.String("chain_id", counterparty.ChainId()),
 					zap.Uint64("height", existingClientState.GetLatestHeight().GetRevisionHeight()),
@@ -1391,7 +1394,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 
 			exportedConsState, err := clienttypes.UnpackConsensusState(consensusStateResp.ConsensusState)
 			if err != nil {
-				cc.log.Debug(
+				cc.log.Info(
 					"Failed to unpack consensus state",
 					zap.String("chain", counterparty.ChainId()),
 					zap.Error(err),
@@ -1400,7 +1403,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 			}
 			existingConsensusState, ok := exportedConsState.(*tmclient.ConsensusState)
 			if !ok {
-				cc.log.Debug(
+				cc.log.Info(
 					"Cannot convert consensus state to *tmclient.ConsensusState",
 					zap.String("chain_id", counterparty.ChainId()),
 					zap.Stringer("consensus_state_type", reflect.TypeOf(exportedConsState)),
@@ -1414,7 +1417,7 @@ func (cc *CosmosProvider) FindMatchingClient(ctx context.Context, counterparty p
 
 			tmHeader, ok := header.(*tmclient.Header)
 			if !ok {
-				cc.log.Debug(
+				cc.log.Info(
 					"Failed to convert value to *tmclient.Header",
 					zap.Stringer("header_type", reflect.TypeOf(header)),
 				)

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -90,7 +90,7 @@ func QueryChannel(ctx context.Context, src *Chain, channelID string) (*chantypes
 		srcChannels, err = src.ChainProvider.QueryConnectionChannels(ctx, srch, src.ConnectionID())
 		return err
 	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		src.log.Debug(
+		src.log.Info(
 			"Failed to query connection channels",
 			zap.String("conn_id", src.ConnectionID()),
 			zap.Uint("attempt", n+1),

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -89,7 +89,7 @@ func queryChannelsOnConnection(ctx context.Context, src *Chain) ([]*types.Identi
 		srcChannels, err = src.ChainProvider.QueryConnectionChannels(ctx, srch, src.ConnectionID())
 		return err
 	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		src.log.Debug(
+		src.log.Info(
 			"Failed to query connection channels",
 			zap.String("conn_id", src.ConnectionID()),
 			zap.Uint("attempt", n+1),
@@ -106,7 +106,6 @@ func queryChannelsOnConnection(ctx context.Context, src *Chain) ([]*types.Identi
 // filterOpenChannels takes a slice of channels and adds all the channels with OPEN state to a new slice of channels.
 // NOTE: channels will not be added to the slice of open channels more than once.
 func filterOpenChannels(channels []*types.IdentifiedChannel, openChannels []*ActiveChannel) []*ActiveChannel {
-
 	// Filter for open channels
 	for _, channel := range channels {
 		if channel.State == types.OPEN {


### PR DESCRIPTION
Debug-level logs that were logging a failure detail have been promoted
to info level. An operator should be able to observe the default level
logs to see when particular operations are being retried due to failure.

Also make some of the OnRetry logging more consistent where I noticed it
was not following the usual pattern of logging only inside the retry.

There were existing debug-level messages that were just informational
about "going to do xyz" that seem appropriate to remain debug level.