### PR TITLE
Fix more staticcheck errors

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
+	tmclient "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	ibctestingmock "github.com/cosmos/ibc-go/v3/testing/mock"
 	"github.com/cosmos/relayer/v2/cmd"
@@ -294,7 +294,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	pubKey, err := privVal.GetPubKey()
 	require.NoError(t, err)
 
-	tmHeader, ok := header.(*ibctmtypes.Header)
+	tmHeader, ok := header.(*tmclient.Header)
 	if !ok {
 		t.Fatalf("got data of type %T but wanted tmclient.Header \n", header)
 	}
@@ -468,7 +468,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 
 func createTMClientHeader(t *testing.T, chainID string, blockHeight int64, trustedHeight clienttypes.Height,
 	timestamp time.Time, tmValSet, tmTrustedVals *tmtypes.ValidatorSet, signers []tmtypes.PrivValidator,
-	oldHeader *ibctmtypes.Header) *ibctmtypes.Header {
+	oldHeader *tmclient.Header) *tmclient.Header {
 	var (
 		valSet      *tmproto.ValidatorSet
 		trustedVals *tmproto.ValidatorSet
@@ -521,7 +521,7 @@ func createTMClientHeader(t *testing.T, chainID string, blockHeight int64, trust
 
 	// The trusted fields may be nil. They may be filled before relaying messages to a client.
 	// The relayer is responsible for querying client and injecting appropriate trusted fields.
-	return &ibctmtypes.Header{
+	return &tmclient.Header{
 		SignedHeader:      signedHeader,
 		ValidatorSet:      valSet,
 		TrustedHeight:     trustedHeight,

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -98,24 +98,6 @@ func logConnectionStates(src, dst *Chain, srcConn, dstConn *conntypes.QueryConne
 	)
 }
 
-func (c *Chain) logTx(events map[string][]string) {
-	hashField := zap.Skip()
-	if e := events["tx.hash"]; len(e) > 0 {
-		hashField = zap.String("hash", e[0])
-	}
-	heightField := zap.Skip()
-	if e := events["tx.height"]; len(e) > 0 {
-		heightField = zap.String("height", e[0])
-	}
-	c.log.Info(
-		"Transaction",
-		zap.String("chain_id", c.ChainID()),
-		zap.Strings("actions", events["message.action"]),
-		heightField,
-		hashField,
-	)
-}
-
 func (c *Chain) errQueryUnrelayedPacketAcks() error {
 	return fmt.Errorf("no error on QueryPacketUnrelayedAcknowledgements for %s, however response is nil", c.ChainID())
 }

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -39,7 +39,7 @@ func relayerMainLoop(ctx context.Context, log *zap.Logger, src, dst *Chain, filt
 			if errors.Is(err, context.Canceled) {
 				errCh <- err
 			} else {
-				errCh <- fmt.Errorf("error querying all channels on chain{%s}@connection{%s}: %v\n",
+				errCh <- fmt.Errorf("error querying all channels on chain{%s}@connection{%s}: %w",
 					src.ChainID(), src.ConnectionID(), err)
 			}
 			return


### PR DESCRIPTION
- Avoid duplicate imports (and use more consistent import aliases)
- Remove unused, unexported method
- Use input error value before assigning over it
- Remove punctuation from end of error string