### PR TITLE
fix block height timeout issue

### DIFF
--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -37,7 +37,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		timeoutHeight = h.GetHeight().GetRevisionHeight() + toHeightOffset
 		timeoutTimestamp = 0
 	case toTimeOffset > 0:
-		timeoutHeight = h.GetHeight().GetRevisionHeight() + 1000
+		timeoutHeight = 0
 		timeoutTimestamp = uint64(time.Now().Add(toTimeOffset).UnixNano())
 	case toHeightOffset == 0 && toTimeOffset == 0:
 		timeoutHeight = h.GetHeight().GetRevisionHeight() + 1000

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -830,24 +830,37 @@ func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcP
 	var (
 		acc string
 		err error
+		msg sdk.Msg
 	)
 	if acc, err = cc.Address(); err != nil {
 		return nil, err
 	}
 
-	version := clienttypes.ParseChainID(dstChainId)
+	// If the timeoutHeight is 0 then we don't need to explicitly set it on the MsgTransfer
+	if timeoutHeight == 0 {
+		msg = &transfertypes.MsgTransfer{
+			SourcePort:       srcPortId,
+			SourceChannel:    srcChanId,
+			Token:            amount,
+			Sender:           acc,
+			Receiver:         dstAddr,
+			TimeoutTimestamp: timeoutTimestamp,
+		}
+	} else {
+		version := clienttypes.ParseChainID(dstChainId)
 
-	msg := &transfertypes.MsgTransfer{
-		SourcePort:    srcPortId,
-		SourceChannel: srcChanId,
-		Token:         amount,
-		Sender:        acc,
-		Receiver:      dstAddr,
-		TimeoutHeight: clienttypes.Height{
-			RevisionNumber: version,
-			RevisionHeight: timeoutHeight,
-		},
-		TimeoutTimestamp: timeoutTimestamp,
+		msg = &transfertypes.MsgTransfer{
+			SourcePort:    srcPortId,
+			SourceChannel: srcChanId,
+			Token:         amount,
+			Sender:        acc,
+			Receiver:      dstAddr,
+			TimeoutHeight: clienttypes.Height{
+				RevisionNumber: version,
+				RevisionHeight: timeoutHeight,
+			},
+			TimeoutTimestamp: timeoutTimestamp,
+		}
 	}
 
 	return NewCosmosMessage(msg), nil


### PR DESCRIPTION
We shouldn't be setting both a height and timestamp based timeout in `SendTransferMsg()`.
Explicitly setting the `TimeoutHeight` on `MsgTransfer` even when passing in 0 seems to have also been causing a bug where the relayer tries to timeout packets that should be valid