### PR TITLE
Begin checking errors from SendMsgsResult

### DIFF
--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -304,14 +304,12 @@ func (cc *CosmosProvider) SubmitMisbehavior( /*TBD*/ ) (provider.RelayerMessage,
 }
 
 func (cc *CosmosProvider) UpdateClient(srcClientId string, dstHeader ibcexported.Header) (provider.RelayerMessage, error) {
-	var (
-		acc string
-		err error
-	)
 	if err := dstHeader.ValidateBasic(); err != nil {
 		return nil, err
 	}
-	if acc, err = cc.Address(); err != nil {
+
+	acc, err := cc.Address()
+	if err != nil {
 		return nil, err
 	}
 
@@ -326,9 +324,6 @@ func (cc *CosmosProvider) UpdateClient(srcClientId string, dstHeader ibcexported
 		Signer:   acc,
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	return NewCosmosMessage(msg), nil
 }
 


### PR DESCRIPTION
Instead of checking the `Success` method on `RelayMsgs`, inspect the `Error` method on the new `SendMsgsResult` type.

Add a new `PartiallySent` method on `SendMsgsResult` for use when logging details of a partially sent batch.

There are still a few other uses of `(*RelayMsgs).Send` which will get cleaned up in a followup PR.

This does not change any of the existing batching or ordering behavior in SendMsgs -- the questions in #667 are still outstanding.