### PR TITLE
Fix data race on cosmos provider config key

### DIFF
--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -64,10 +64,7 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 
 // QueryBalance returns the amount of coins in the relayer account
 func (cc *CosmosProvider) QueryBalance(ctx context.Context, keyName string) (sdk.Coins, error) {
-	if keyName != "" {
-		cc.PCfg.Key = keyName
-	}
-	addr, err := cc.Address()
+	addr, err := cc.ShowAddress(keyName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have been seeing intermittent data races when running the integration
tests with the race detector enabled. This seems to fix those races. I
don't think it would be valid to change the config's key name at runtime
anyway.