### PR TITLE
Properly compose timeouts in `SendTransferMsg` and properly check timestamp in `relayPacketsFromResultTx`

### DIFF
--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -54,18 +54,14 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		// use local clock time as reference time if it is later than the
 		// consensus state timestamp of the counter party chain, otherwise
 		// still use consensus state timestamp as reference.
-		// see https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/client/cli/tx.go#L94-L110
-		now := time.Now().UnixNano()
+		// see https://github.com/cosmos/ibc-go/blob/ccc4cb804843f1a80acfb0d4dbf106d1ff2178bb/modules/apps/transfer/client/cli/tx.go#L94-L110
+		tmpNow := time.Now().UnixNano()
 		consensusTimestamp := consensusState.GetTimestamp()
-		if now > 0 {
-			now := uint64(now)
-			if now > consensusTimestamp {
-				timeoutTimestamp = now + uint64(toTimeOffset)
-			} else {
-				timeoutTimestamp = consensusTimestamp + uint64(toTimeOffset)
-			}
+		now := uint64(tmpNow)
+		if now > consensusTimestamp {
+			timeoutTimestamp = now + uint64(toTimeOffset)
 		} else {
-			return fmt.Errorf("local clock time is not greater than Jan 1st, 1970 12:00 AM")
+			timeoutTimestamp = consensusTimestamp + uint64(toTimeOffset)
 		}
 	}
 

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -2,10 +2,13 @@ package relayer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v3/modules/core/exported"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
 )
@@ -13,6 +16,11 @@ import (
 //nolint:lll
 // SendTransferMsg initiates an ics20 transfer from src to dst with the specified args
 func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
+	var (
+		timeoutHeight    uint64
+		timeoutTimestamp uint64
+	)
+
 	// get header representing dst to check timeouts
 	dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
 	if err != nil {
@@ -23,21 +31,52 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		return err
 	}
 
-	var (
-		timeoutHeight    uint64
-		timeoutTimestamp uint64
-	)
+	// if the timestamp offset is set we need to query the dst chains consensus state to get the current time
+	var consensusState ibcexported.ConsensusState
+	if toTimeOffset > 0 {
+		clientStateRes, err := dst.ChainProvider.QueryClientStateResponse(ctx, dsth, dst.ClientID())
+		if err != nil {
+			return fmt.Errorf("failed to query the client state response: %w", err)
+		}
+		clientState, err := clienttypes.UnpackClientState(clientStateRes.ClientState)
+		if err != nil {
+			return fmt.Errorf("failed to unpack client state: %w", err)
+		}
+		consensusStateRes, err := dst.ChainProvider.QueryClientConsensusState(ctx, dsth, dst.ClientID(), clientState.GetLatestHeight())
+		if err != nil {
+			return fmt.Errorf("failed to query client consensus state: %w", err)
+		}
+		consensusState, err = clienttypes.UnpackConsensusState(consensusStateRes.ConsensusState)
+		if err != nil {
+			return fmt.Errorf("failed to unpack consensus state: %w", err)
+		}
+
+		// use local clock time as reference time if it is later than the
+		// consensus state timestamp of the counter party chain, otherwise
+		// still use consensus state timestamp as reference.
+		// see https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/client/cli/tx.go#L94-L110
+		now := time.Now().UnixNano()
+		consensusTimestamp := consensusState.GetTimestamp()
+		if now > 0 {
+			now := uint64(now)
+			if now > consensusTimestamp {
+				timeoutTimestamp = now + uint64(toTimeOffset)
+			} else {
+				timeoutTimestamp = consensusTimestamp + uint64(toTimeOffset)
+			}
+		} else {
+			return fmt.Errorf("local clock time is not greater than Jan 1st, 1970 12:00 AM")
+		}
+	}
 
 	switch {
 	case toHeightOffset > 0 && toTimeOffset > 0:
 		timeoutHeight = h.GetHeight().GetRevisionHeight() + toHeightOffset
-		timeoutTimestamp = uint64(time.Now().Add(toTimeOffset).UnixNano())
 	case toHeightOffset > 0:
 		timeoutHeight = h.GetHeight().GetRevisionHeight() + toHeightOffset
 		timeoutTimestamp = 0
 	case toTimeOffset > 0:
 		timeoutHeight = 0
-		timeoutTimestamp = uint64(time.Now().Add(toTimeOffset).UnixNano())
 	case toHeightOffset == 0 && toTimeOffset == 0:
 		timeoutHeight = h.GetHeight().GetRevisionHeight() + 1000
 		timeoutTimestamp = 0

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -955,7 +955,7 @@ func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst 
 		return nil, nil, fmt.Errorf("more than one transaction returned with query")
 	}
 
-	rcvPackets, timeoutPackets, err := relayPacketsFromResultTx(ctx, src, dst, int64(dsth), txs[0], dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId)
+	rcvPackets, timeoutPackets, err := cc.relayPacketsFromResultTx(ctx, src, dst, int64(dsth), txs[0], dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId)
 	switch {
 	case err != nil:
 		return nil, nil, err
@@ -1041,7 +1041,7 @@ func ackPacketQuery(channelID string, seq int) []string {
 
 // relayPacketsFromResultTx looks through the events in a *ctypes.ResultTx
 // and returns relayPackets with the appropriate data
-func relayPacketsFromResultTx(ctx context.Context, src, dst provider.ChainProvider, dsth int64, res *ctypes.ResultTx, dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId string) ([]provider.RelayPacket, []provider.RelayPacket, error) {
+func (cc *CosmosProvider) relayPacketsFromResultTx(ctx context.Context, src, dst provider.ChainProvider, dsth int64, res *ctypes.ResultTx, dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId string) ([]provider.RelayPacket, []provider.RelayPacket, error) {
 	var (
 		rcvPackets     []provider.RelayPacket
 		timeoutPackets []provider.RelayPacket
@@ -1103,31 +1103,18 @@ func relayPacketsFromResultTx(ctx context.Context, src, dst provider.ChainProvid
 				return nil, nil, err
 			}
 
-			// TODO maybe there is a better way to get the timestamp from the chains consensus state?
-			// If the timestamp is set on the packet, we need to retrieve the current timestamp from dst's consensus state
-			var consensusState ibcexported.ConsensusState
+			// if the timestamp is set on the packet, we need to retrieve the current block time from dst
+			var b *ctypes.ResultBlock
 			if rp.timeoutStamp > 0 {
-				clientStateRes, err := dst.QueryClientStateResponse(ctx, dsth, dstClientId)
+				b, err = cc.RPCClient.Block(ctx, &dsth)
 				if err != nil {
-					return nil, nil, fmt.Errorf("failed to query the client state response: %w", err)
-				}
-				clientState, err := clienttypes.UnpackClientState(clientStateRes.ClientState)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to unpack client state: %w", err)
-				}
-				consensusStateRes, err := dst.QueryClientConsensusState(ctx, dsth, dstClientId, clientState.GetLatestHeight())
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to query client consensus state: %w", err)
-				}
-				consensusState, err = clienttypes.UnpackConsensusState(consensusStateRes.ConsensusState)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to unpack consesnsus state: %w", err)
+					return nil, nil, err
 				}
 			}
 
 			switch {
 			// If the packet has a timeout time, and it has been reached, return a timeout packet
-			case consensusState != nil && rp.timeoutStamp > 0 && rp.timeoutStamp > consensusState.GetTimestamp():
+			case b != nil && rp.timeoutStamp > 0 && uint64(b.Block.Time.UnixNano()) > rp.timeoutStamp:
 				timeoutPackets = append(timeoutPackets, rp.timeoutPacket())
 			// If the packet has a timeout height, and it has been reached, return a timeout packet
 			case !rp.timeout.IsZero() && block.GetHeight().GTE(rp.timeout):


### PR DESCRIPTION
So turns out when composing the timestamp timeout we want to use the consensus state time as a reference but when checking the timestamp timeouts we want to use the current block time. I also set a comparison check backwards originally which was causing the relayer to try and timeout valid packets in an inconsistent manner.

For composing the timestamp timeout I checked what they do in [ibc-go](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/client/cli/tx.go#L94-L110)

I tested this with the integration tests, the ibc-test-framework, the interchain accounts demo and in production and don't see anymore of the timeout error messages.