### PR TITLE
Disambiguate some duplicate log messages

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -15,7 +15,14 @@ import (
 )
 
 // CreateOpenChannels runs the channel creation messages on timeout until they pass.
-func (c *Chain) CreateOpenChannels(ctx context.Context, dst *Chain, maxRetries uint64, to time.Duration, srcPortID, dstPortID, order, version string, override bool) (modified bool, err error) {
+func (c *Chain) CreateOpenChannels(
+	ctx context.Context,
+	dst *Chain,
+	maxRetries uint64,
+	to time.Duration,
+	srcPortID, dstPortID, order, version string,
+	override bool,
+) (modified bool, err error) {
 	// client and connection identifiers must be filled in
 	if err := ValidateConnectionPaths(c, dst); err != nil {
 		return modified, err
@@ -85,7 +92,7 @@ func (c *Chain) CreateOpenChannels(ctx context.Context, dst *Chain, maxRetries u
 		// In the case of failure, increment the failures counter and exit if this is the 3rd failure
 		case !success:
 			failures++
-			c.log.Info("Retrying transaction...")
+			c.log.Info("Delaying before retrying channel open transaction...")
 			select {
 			case <-time.After(5 * time.Second):
 				// Nothing to do.

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -14,7 +14,12 @@ import (
 
 // CreateOpenConnections runs the connection creation messages on timeout until they pass.
 // The returned boolean indicates that the path end has been modified.
-func (c *Chain) CreateOpenConnections(ctx context.Context, dst *Chain, maxRetries uint64, to time.Duration) (modified bool, err error) {
+func (c *Chain) CreateOpenConnections(
+	ctx context.Context,
+	dst *Chain,
+	maxRetries uint64,
+	to time.Duration,
+) (modified bool, err error) {
 	// client identifiers must be filled in
 	if err = ValidateClientPaths(c, dst); err != nil {
 		return modified, err
@@ -70,7 +75,7 @@ func (c *Chain) CreateOpenConnections(ctx context.Context, dst *Chain, maxRetrie
 		// increment the failures counter and exit if we used all retry attempts
 		case !success:
 			failed++
-			c.log.Info("Retrying transaction...")
+			c.log.Info("Delaying before retrying connection open transaction...")
 			select {
 			case <-time.After(5 * time.Second):
 				// Nothing to do.

--- a/relayer/provider/cosmos/log.go
+++ b/relayer/provider/cosmos/log.go
@@ -10,7 +10,7 @@ import (
 func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
 	if err != nil {
 		cc.log.Error(
-			"Failed sending transaction",
+			"Failed sending cosmos transaction",
 			zap.String("chain_id", cc.ChainId()),
 			msgTypesField(msgs),
 			zap.Error(err),


### PR DESCRIPTION
This should slightly increase log clarity.

Also split two long method declarations onto multiple lines for
readability.