### PR TITLE
Check previously ignored error in `InjectTrustedFields()`

### DIFF
--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -756,10 +756,15 @@ func (cc *CosmosProvider) InjectTrustedFields(ctx context.Context, header ibcexp
 	var trustedHeader *tmclient.Header
 	if err := retry.Do(func() error {
 		tmpHeader, err := cc.GetLightSignedHeaderAtHeight(ctx, int64(h.TrustedHeight.RevisionHeight+1))
+		if err != nil {
+			return err
+		}
+
 		th, ok := tmpHeader.(*tmclient.Header)
 		if !ok {
 			err = errors.New("non-tm client header")
 		}
+
 		trustedHeader = th
 		return err
 	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {


### PR DESCRIPTION
There was an error that was never being checked before immediately performing a type assertion which resulted in the error always being overwritten