### PR TITLE
Avoid using Tendermint `ResultTx` type in favor of `RelayerTxResponse` & check for nil `MsgAck` msgs

### DIFF
--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -315,7 +315,10 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 				return err
 			}
 
-			msgs.Src = append(msgs.Src, relayAckMsgs)
+			// Do not allow nil messages to the queued, or else we will panic in send()
+			if relayAckMsgs != nil {
+				msgs.Src = append(msgs.Src, relayAckMsgs)
+			}
 		}
 
 		// add messages for received packets on src
@@ -328,7 +331,10 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 				return err
 			}
 
-			msgs.Dst = append(msgs.Dst, relayAckMsgs)
+			// Do not allow nil messages to the queued, or else we will panic in send()
+			if relayAckMsgs != nil {
+				msgs.Dst = append(msgs.Dst, relayAckMsgs)
+			}
 		}
 
 		if !msgs.Ready() {
@@ -533,7 +539,6 @@ func PrependUpdateClientMsg(ctx context.Context, msgs *[]provider.RelayerMessage
 			zap.Error(err),
 		)
 
-		srch, _, _ = QueryLatestHeights(ctx, src, dst)
 	})); err != nil {
 		return err
 	}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -73,6 +73,8 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 		return nil, err
 	}
 
+	// Currently, we only call QueryTxs() in two spots and in both of them we are expecting there to only be,
+	// at most, one tx in the response. Because of this we don't want to initialize the slice with an initial size.
 	var txResps []*provider.RelayerTxResponse
 	for _, tx := range res.Txs {
 		events := parseEventsFromResponseDeliverTx(tx.TxResult)
@@ -90,7 +92,7 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 // parseEventsFromResponseDeliverTx parses the events from a ResponseDeliverTx and builds a map
 // where the keys are equal to event.Type+"."+attribute.Key and the values are the attribute.Value.
 func parseEventsFromResponseDeliverTx(resp abci.ResponseDeliverTx) (events map[string]string) {
-	events = make(map[string]string, 1)
+	events = make(map[string]string, len(resp.Events))
 	for _, event := range resp.Events {
 		for _, attribute := range event.Attributes {
 			key := event.Type + "." + string(attribute.Key)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -10,7 +10,6 @@ import (
 	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v3/modules/core/exported"
-	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -102,8 +101,8 @@ type ChainProvider interface {
 // Do we need intermediate types? i.e. can we use the SDK types for both substrate and cosmos?
 type QueryProvider interface {
 	// chain
-	QueryTx(ctx context.Context, hashHex string) (*ctypes.ResultTx, error)
-	QueryTxs(ctx context.Context, page, limit int, events []string) ([]*ctypes.ResultTx, error)
+	QueryTx(ctx context.Context, hashHex string) (*RelayerTxResponse, error)
+	QueryTxs(ctx context.Context, page, limit int, events []string) ([]*RelayerTxResponse, error)
 	QueryLatestHeight(ctx context.Context) (int64, error)
 	QueryHeaderAtHeight(ctx context.Context, height int64) (ibcexported.Header, error)
 


### PR DESCRIPTION
We need to avoid using Tendermint/Cosmos SDK types in the `Provider` interface so that it's flexible enough for non Tendermint/Cosmos chains to implement.

After making the changes necessary to remove `ResultTx` I was noticing an error that only showed up in production when prepending `UpdateClientMsg` to the slice of msgs to be sent in `RelayPackets`. The query height was being updated in the retries and this was creating height mismatch issues.

```
2022-04-11T17:42:05.224887Z     info    PrependUpdateClientMsg: failed to build message {"dst_chain_id": "osmosis-1", "attempt": 2, "attempt_limit": 5, "error": "TrustedHeight {3 3142607} must be less than header height {3 3142606}: invalid header height", "errorVerbose": "\ngithub.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.Header.ValidateBasic\n\t/Users/justintieri/go/pkg/mod/github.com/cosmos/ibc-go/v3@v3.0.0/modules/light-clients/07-tendermint/types/header.go:67\ngithub.com/cosmos/relayer/v2/relayer/provider/cosmos.(*CosmosProvider).UpdateClient\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/provider/cosmos/provider.go:308\ngithub.com/cosmos/relayer/v2/relayer.PrependUpdateClientMsg.func3\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:551\ngithub.com/avast/retry-go/v4.Do\n\t/Users/justintieri/go/pkg/mod/github.com/avast/retry-go/v4@v4.0.3/retry.go:109\ngithub.com/cosmos/relayer/v2/relayer.PrependUpdateClientMsg\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:549\ngithub.com/cosmos/relayer/v2/relayer.RelayPackets.func3\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:436\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/Users/justintieri/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57\nTrustedHeight {3 3142607} must be less than header height {3 3142606}: invalid header height"}
```

This also adds checks in `RelayAcknowledgements()` so that nil msgs are never added to the queue.

As a side note, event parsing could definitely use some TLC. 

Closes #637 