### PR TITLE
Change log levels for when there are or are not packets/acks to be relayed

### DIFF
--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -205,7 +205,7 @@ func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain
 
 	// If there are no unrelayed packets, stop early.
 	if sp.Empty() {
-		src.log.Info(
+		src.log.Debug(
 			"No packets in queue",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -218,7 +218,7 @@ func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain
 	}
 
 	if len(sp.Src) > 0 {
-		src.log.Debug(
+		src.log.Info(
 			"Unrelayed source packets",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -227,7 +227,7 @@ func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain
 	}
 
 	if len(sp.Dst) > 0 {
-		src.log.Debug(
+		src.log.Info(
 			"Unrelayed destination packets",
 			zap.String("dst_chain_id", dst.ChainID()),
 			zap.String("dst_channel_id", srcChannel.Counterparty.ChannelId),
@@ -287,7 +287,7 @@ func relayUnrelayedAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, m
 
 	// If there are no unrelayed acks, stop early.
 	if ap.Empty() {
-		log.Info(
+		log.Debug(
 			"No acknowledgements in queue",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -300,7 +300,7 @@ func relayUnrelayedAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, m
 	}
 
 	if len(ap.Src) > 0 {
-		log.Debug(
+		log.Info(
 			"Unrelayed source acknowledgements",
 			zap.String("src_chain_id", src.ChainID()),
 			zap.String("src_channel_id", srcChannel.ChannelId),
@@ -309,7 +309,7 @@ func relayUnrelayedAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, m
 	}
 
 	if len(ap.Dst) > 0 {
-		log.Debug(
+		log.Info(
 			"Unrelayed destination acknowledgements",
 			zap.String("dst_chain_id", dst.ChainID()),
 			zap.String("dst_channel_id", srcChannel.Counterparty.ChannelId),


### PR DESCRIPTION
This PR switches the log level to `DEBUG` for when there are no packets/acks to be relayed and switches the log level to `INFO` for when there are packets/acks to be relayed.

This makes it much easier to follow logs from a terminal.

Closes #692 