### PR TITLE
avoid calls to `ValidateBasic()` in ibc-go

### DIFF
--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -265,9 +265,6 @@ func (cc *CosmosProvider) CreateClient(clientState ibcexported.ClientState, dstH
 		acc string
 		err error
 	)
-	if err := dstHeader.ValidateBasic(); err != nil {
-		return nil, err
-	}
 
 	tmHeader, ok := dstHeader.(*tmclient.Header)
 	if !ok {
@@ -305,10 +302,6 @@ func (cc *CosmosProvider) SubmitMisbehavior( /*TBD*/ ) (provider.RelayerMessage,
 }
 
 func (cc *CosmosProvider) UpdateClient(srcClientId string, dstHeader ibcexported.Header) (provider.RelayerMessage, error) {
-	if err := dstHeader.ValidateBasic(); err != nil {
-		return nil, err
-	}
-
 	acc, err := cc.Address()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before recent logging refactors we were ignoring errors that occur in `PrependUpdateClientMsg()`, now you see a lot of these errors when relaying against chains.

```
2022-04-12T18:51:58.372982Z     info    PrependUpdateClientMsg: failed to build message {"dst_chain_id": "osmosis-1", "attempt": 1, "attempt_limit": 5, "error": "TrustedHeight {3 3157976} must be less than header height {3 3157975}: invalid header height", "errorVerbose": "\ngithub.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.Header.ValidateBasic\n\t/Users/justintieri/go/pkg/mod/github.com/cosmos/ibc-go/v3@v3.0.0/modules/light-clients/07-tendermint/types/header.go:67\ngithub.com/cosmos/relayer/v2/relayer/provider/cosmos.(*CosmosProvider).UpdateClient\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/provider/cosmos/provider.go:308\ngithub.com/cosmos/relayer/v2/relayer.PrependUpdateClientMsg.func3\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:550\ngithub.com/avast/retry-go/v4.Do\n\t/Users/justintieri/go/pkg/mod/github.com/avast/retry-go/v4@v4.0.3/retry.go:109\ngithub.com/cosmos/relayer/v2/relayer.PrependUpdateClientMsg\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:548\ngithub.com/cosmos/relayer/v2/relayer.RelayPackets.func3\n\t/Users/justintieri/go/src/github.com/cosmos/relayer/relayer/naive-strategy.go:436\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/Users/justintieri/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57\nTrustedHeight {3 3157976} must be less than header height {3 3157975}: invalid header height"}
```

Part of the refactor to using the `Provider` interface was making sure we avoid calls to the constructors and `ValidateBasic()` but looks like two of these slipped through. Removing them gets rid of the errors that are occurring when attempting to build UpdateClientMsgs