### PR TITLE
Run release workflow on any tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+' # Push to tags that look like a semantic version
+      - '*' # Run release on any tag. Will be marked as draft by default anyway.
 
 jobs:
   goreleaser:


### PR DESCRIPTION
Examples out in the wild seem to follow this pattern. Since we are
marking releases as drafts anyway, this shouldn't do anything bad.