### PR TITLE
Remove NewRelayMsgs function

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -687,7 +687,7 @@ func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, src
 		return nil, false, err
 	}
 
-	out := NewRelayMsgs()
+	out := new(RelayMsgs)
 	if err := ValidatePaths(c, dst); err != nil {
 		return nil, false, err
 	}

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -22,11 +22,6 @@ type RelayMsgs struct {
 	MaxMsgLength uint64                    `json:"max_msg_length"` // maximum amount of messages in a bundled relay transaction
 }
 
-// NewRelayMsgs returns an initialized version of relay messages
-func NewRelayMsgs() *RelayMsgs {
-	return &RelayMsgs{Src: []provider.RelayerMessage{}, Dst: []provider.RelayerMessage{}}
-}
-
 // Ready returns true if there are messages to relay
 func (r *RelayMsgs) Ready() bool {
 	if r == nil {


### PR DESCRIPTION
It was only called in one place, and it only set nil slices as empty
slices, so it doesn't seem necessary to keep around.