### PR TITLE
Concurrently create clients in CreateClients

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -142,13 +142,16 @@ func createClientsCmd(a *appState) *cobra.Command {
 			}
 
 			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			if err != nil {
+				return err
+			}
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
 
-			return err
+			return nil
 		},
 	}
 
@@ -240,6 +243,9 @@ func createClientCmd(a *appState) *cobra.Command {
 			}
 
 			modified, err := relayer.CreateClient(cmd.Context(), c[src], c[dst], srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			if err != nil {
+				return err
+			}
 			if modified {
 				if err = a.OverwriteConfig(a.Config); err != nil {
 					return err
@@ -376,23 +382,26 @@ $ %s tx conn demo-path --timeout 5s`,
 
 			// ensure that the clients exist
 			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
-			if modified {
-				if err := a.OverwriteConfig(a.Config); err != nil {
-					return err
-				}
-			}
 			if err != nil {
 				return err
 			}
-
-			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to)
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
 			}
 
-			return err
+			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to)
+			if err != nil {
+				return err
+			}
+			if modified {
+				if err := a.OverwriteConfig(a.Config); err != nil {
+					return err
+				}
+			}
+
+			return nil
 		},
 	}
 
@@ -617,35 +626,35 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 
 			// create clients if they aren't already created
 			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override)
+			if err != nil {
+				return fmt.Errorf("error creating clients: %w", err)
+			}
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
-			}
-			if err != nil {
-				return fmt.Errorf("error creating clients: %w", err)
 			}
 
 			// create connection if it isn't already created
 			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to)
+			if err != nil {
+				return fmt.Errorf("error creating connections: %w", err)
+			}
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
-			}
-			if err != nil {
-				return fmt.Errorf("error creating connections: %w", err)
 			}
 
 			// create channel if it isn't already created
 			modified, err = c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
+			if err != nil {
+				return fmt.Errorf("error creating channels: %w", err)
+			}
 			if modified {
 				if err := a.OverwriteConfig(a.Config); err != nil {
 					return err
 				}
-			}
-			if err != nil {
-				return fmt.Errorf("error creating channels: %w", err)
 			}
 
 			return nil

--- a/relayer/provider/cosmos/log.go
+++ b/relayer/provider/cosmos/log.go
@@ -97,9 +97,12 @@ func getFeePayer(tx *typestx.Tx) string {
 		// We don't need the address conversion; just the sender is all that
 		// GetSigners is doing under the hood anyway.
 		return firstMsg.Sender
-	case *clienttypes.MsgUpdateClient:
+	case *clienttypes.MsgCreateClient:
 		// Without this particular special case, there is a panic in ibc-go
 		// due to the sdk config singleton expecting one bech32 prefix but seeing another.
+		return firstMsg.Signer
+	case *clienttypes.MsgUpdateClient:
+		// Same failure mode as MsgCreateClient.
 		return firstMsg.Signer
 	default:
 		return firstMsg.GetSigners()[0].String()


### PR DESCRIPTION
This saves between a quarter and a half second in integration tests that
create clients. A small but easy win.

Also fix some error handling in a few tx commands that were previously
checking the modified flag before checking the error.