### PR TITLE
make integration tests more flexible for integrating non-Cosmos based chains

### DIFF
--- a/_test/test_queries.go
+++ b/_test/test_queries.go
@@ -41,7 +41,7 @@ func testClient(ctx context.Context, t *testing.T, src *relayer.Chain) {
 
 	cs, err := clientypes.UnpackClientState(client.ClientState)
 	require.NoError(t, err)
-	require.Equal(t, cs.ClientType(), "07-tendermint")
+	require.Equal(t, cs.ClientType(), "07-tendermint") // TODO remove this check or create separate test for substrate
 }
 
 // testConnectionPair tests that the only connection on src and dst is between the two chains

--- a/_test/test_setup.go
+++ b/_test/test_setup.go
@@ -181,7 +181,7 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 
 	// we used to poll here until the container is running without status errors but,
 	// we no longer expose the status error on the relayer.Chain struct.
-	// this sleep statement seems to
+	// this sleep statement seems to work fine in all cases that we have seen over a few months.
 	time.Sleep(time.Second * 5)
 
 	t.Logf("Chain ID %s's container at port %s", c.ChainID(), c.RPCAddr)

--- a/_test/test_setup.go
+++ b/_test/test_setup.go
@@ -144,6 +144,8 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 		Cmd: []string{
 			c.ChainID(),
 			addr,
+			// TODO getPrivValFileName() is not going to work with substrate.
+			// it's not immediately clear to me what we need to do here so will need to circle back on this.
 			getPrivValFileName(tc.seed),
 		},
 		PortBindings: map[dc.Port][]dc.PortBinding{
@@ -177,12 +179,9 @@ func spinUpTestContainer(t *testing.T, rchan chan<- *dockertest.Resource, pool *
 
 	t.Logf("Chain ID %s spun up in container %s from %s", c.ChainID(), resource.Container.Name, resource.Container.Config.Image)
 
-	// retry polling the container until status doesn't error
-	//if err = pool.Retry(c.StatusErr); err != nil {
-	//	return fmt.Errorf("could not connect to container at %s: %s", c.RPCAddr, err)
-	//}
-
-	// TODO maybe this works?
+	// we used to poll here until the container is running without status errors but,
+	// we no longer expose the status error on the relayer.Chain struct.
+	// this sleep statement seems to
 	time.Sleep(time.Second * 5)
 
 	t.Logf("Chain ID %s's container at port %s", c.ChainID(), c.RPCAddr)


### PR DESCRIPTION
To allow non-Cosmos chains to integrate with the docker tests we need to use the interface type `provider.ProviderConfig` on the `testChain` structs instead of the concrete types.

As a note, this does not fully solve the issue because we are using some Tendermint specific functions for generating the PrivValKey when spinning up the chains. I have no idea how we would handle this for Substrate so perhaps we wait to get some help from the Composable folks and then add a check here on the Provider type e.g. `provider.Type()` and then handle the different cases appropriately.

Closes #636 