### PR TITLE
Update cosmwasm bash test scripts and bump cosmwasm version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT  := $(shell git log -1 --format='%H')
 GAIA_VERSION := v6.0.0
 AKASH_VERSION := v0.12.1
 OSMOSIS_VERSION := v6.4.0
-WASMD_VERSION := v0.16.0
+WASMD_VERSION := v0.25.0
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(GOPATH)/bin

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -991,23 +991,13 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 				return err
 			}
 
-			// TODO this needs to be rewritten for non-cosmos chains to be able to use the command
 			// If the argument begins with "raw:" then use the suffix directly.
 			rawDstAddr := strings.TrimPrefix(args[3], "raw:")
 			var dstAddr string
-			if rawDstAddr == args[3] {
-				// not "raw:", so we treat the dstAddr as bech32
-				//done := c[dst].UseSDKContext()
-				dst, err := sdk.AccAddressFromBech32(args[3])
-				if err != nil {
-					return err
-				}
-				dstAddr = dst.String()
-				//done()
-			} else {
+			dstAddr = args[3]
+			if rawDstAddr != args[3] {
 				// Don't parse the rest of the dstAddr... it's raw.
 				dstAddr = rawDstAddr
-
 			}
 
 			return c[src].SendTransferMsg(cmd.Context(), a.Log, c[dst], amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)

--- a/configs/wasmd/chains/ibc-0.json
+++ b/configs/wasmd/chains/ibc-0.json
@@ -1,1 +1,17 @@
-{"key":"testkey","chain-id":"ibc-0","rpc-addr":"http://localhost:26657","account-prefix":"wasm","gas-adjustment":1.5,"gas-prices":"0.025stake","trusting-period":"336h"}
+{
+  "type": "cosmos",
+  "value": {
+    "key": "testkey",
+    "chain-id": "ibc-0",
+    "rpc-addr": "http://localhost:26657",
+    "grpc-addr": "",
+    "account-prefix": "wasm",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.5,
+    "gas-prices": "0.025stake",
+    "debug": true,
+    "timeout": "10s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/configs/wasmd/chains/ibc-1.json
+++ b/configs/wasmd/chains/ibc-1.json
@@ -1,1 +1,17 @@
-{"key":"testkey","chain-id":"ibc-1","rpc-addr":"http://localhost:26557","account-prefix":"wasm","gas-adjustment":1.5,"gas-prices":"0.025stake", "trusting-period":"336h"}
+{
+  "type": "cosmos",
+  "value": {
+    "key": "testkey",
+    "chain-id": "ibc-1",
+    "rpc-addr": "http://localhost:26657",
+    "grpc-addr": "",
+    "account-prefix": "wasm",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.5,
+    "gas-prices": "0.025stake",
+    "debug": true,
+    "timeout": "10s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/configs/wasmd/chains/ibc-1.json
+++ b/configs/wasmd/chains/ibc-1.json
@@ -3,7 +3,7 @@
   "value": {
     "key": "testkey",
     "chain-id": "ibc-1",
-    "rpc-addr": "http://localhost:26657",
+    "rpc-addr": "http://localhost:26557",
     "grpc-addr": "",
     "account-prefix": "wasm",
     "keyring-backend": "test",

--- a/configs/wasmd/paths/demo.json
+++ b/configs/wasmd/paths/demo.json
@@ -1,1 +1,12 @@
-{"src":{"chain-id":"ibc-0","client-id":"","connection-id":"","channel-id":"","port-id":"transfer","order":"unordered","version":"ics20-1"},"dst":{"chain-id":"ibc-1","client-id":"","connection-id":"","channel-id":"","port-id":"transfer","order":"unordered","version":"ics20-1"},"strategy":{"type":"naive"}}
+{
+  "src": {
+    "chain-id": "ibc-0"
+  },
+  "dst": {
+    "chain-id": "ibc-1"
+  },
+  "src-channel-filter": {
+    "rule": null,
+    "channel-list": []
+  }
+}

--- a/dev-env
+++ b/dev-env
@@ -15,7 +15,7 @@ fi
 cd $RELAYER_DIR
 rm -rf $RELAYER_CONF &> /dev/null
 pwd
-bash scripts/two-chainz "skip"
+bash scripts/two-chainz-wasmd "skip"
 
 echo "waiting for blocks..."
 sleep 3

--- a/scripts/two-chainz-wasmd
+++ b/scripts/two-chainz-wasmd
@@ -67,8 +67,3 @@ echo "Key $(rly keys restore ibc-0 testkey "$SEED0") imported from ibc-0 to rela
 echo "Key $(rly keys restore ibc-1 testkey "$SEED1") imported from ibc-1 to relayer..."
 
 rly config add-paths configs/wasmd/paths
-
-echo "Creating light clients..."
-sleep 3
-rly light init ibc-0 -f
-rly light init ibc-1 -f


### PR DESCRIPTION
Updated the configs to the correct format, bumped to most recent release of cosmwasmd, and removed old relayer light client commands.

Edit: didn't point the `dev-env` script to the right scripts for starting up wasmd nodes and upon correcting it there were errors due to `rly tx transfer` invoking the global singleton in the SDK and causing bech32 errors. 

Including a fix for that here as well. I don't see any reason why we can't just use the string since the call to `SendTransferMsg()` expects a string anyways.

Closes #674 