### PR TITLE
Create connections faster

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -74,7 +74,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	})
 	require.NoError(t, eg.Wait())
 
-	t.Log("Creating path between chains")
+	t.Log("Creating clients")
 	_, err = src.CreateClients(ctx, dst, true, true, false)
 	require.NoError(t, err)
 	testClientPair(ctx, t, src, dst)
@@ -82,10 +82,12 @@ func chainTest(t *testing.T, tcs []testChain) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
+	t.Log("Creating connections")
 	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
+	t.Log("Creating channels")
 	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -169,7 +169,10 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 
 				if !success {
 					src.LogFailedTx(res, err, msgs)
-					return fmt.Errorf("tx failed on chain{%s}: %s", src.ChainID(), res.Data)
+					if res != nil {
+						return fmt.Errorf("tx failed on chain{%s}: %s", src.ChainID(), res.Data)
+					}
+
 				}
 				return err
 			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -169,10 +169,7 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 
 				if !success {
 					src.LogFailedTx(res, err, msgs)
-					if res != nil {
-						return fmt.Errorf("tx failed on chain{%s}: %s", src.ChainID(), res.Data)
-					}
-
+					return fmt.Errorf("tx failed on chain{%s}: %s", src.ChainID(), res.Data)
 				}
 				return err
 			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {


### PR DESCRIPTION
In a totally successful connection creation without retries, this speeds
up the connection creation step of integration tests from around 53s to
around 51s -- mostly due to immediately attempting the next connection
step instead of waiting for a full timeout cycle.

However, when there are retries, this has a significant speedup by
breaking out of an invalid connection state case in the retry loop.