### PR TITLE
Show usage when incorrect number of CLI args provided

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -44,10 +44,10 @@ func chainsCmd(a *appState) *cobra.Command {
 
 func chainsAddrCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "address [chain-id]",
+		Use:     "address chain_id",
 		Aliases: []string{"addr"},
 		Short:   "Returns a chain's configured key's address",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains address ibc-0
 $ %s ch addr ibc-0`, appName, appName)),
@@ -71,10 +71,10 @@ $ %s ch addr ibc-0`, appName, appName)),
 
 func chainsShowCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "show [chain-id]",
+		Use:     "show chain_id",
 		Aliases: []string{"s"},
 		Short:   "Returns a chain's configuration data",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains show ibc-0 --json
 $ %s chains show ibc-0 --yaml
@@ -120,10 +120,10 @@ $ %s ch s ibc-0 --yaml`, appName, appName, appName, appName)),
 
 func chainsDeleteCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete [chain-id]",
+		Use:     "delete chain_id",
 		Aliases: []string{"d"},
 		Short:   "Removes chain from config based off chain-id",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains delete ibc-0
 $ %s ch d ibc-0`, appName, appName)),
@@ -138,7 +138,7 @@ $ %s ch d ibc-0`, appName, appName)),
 func chainsRegistryList(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "registry-list",
-		Args:    cobra.NoArgs,
+		Args:    withUsage(cobra.NoArgs),
 		Aliases: []string{"rl"},
 		Short:   "List chains available for configuration from the registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -190,6 +190,7 @@ func chainsListCmd(a *appState) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"l"},
 		Short:   "Returns chain configuration data",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains list
 $ %s ch l`, appName, appName)),
@@ -259,11 +260,11 @@ $ %s ch l`, appName, appName)),
 
 func chainsAddCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add [[chain-name]]",
+		Use:     "add [chain-name...]",
 		Aliases: []string{"a"},
 		Short: "Add a new chain to the configuration file by fetching chain metadata from \n" +
 			"                the chain-registry or passing a file (-f) or url (-u)",
-		Args: cobra.MinimumNArgs(0),
+		Args: withUsage(cobra.MinimumNArgs(0)),
 		Example: fmt.Sprintf(` $ %s chains add cosmoshub
  $ %s chains add cosmoshub osmosis
  $ %s chains add --file chains/ibc0.json
@@ -304,9 +305,9 @@ func chainsAddCmd(a *appState) *cobra.Command {
 
 func chainsAddDirCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add-dir [dir]",
+		Use:     "add-dir dir",
 		Aliases: []string{"ad"},
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Short: `Add new chains to the configuration file from a directory 
 		full of chain configuration, useful for adding testnet configurations`,
 		Example: strings.TrimSpace(fmt.Sprintf(`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -62,6 +62,7 @@ func configShowCmd(a *appState) *cobra.Command {
 		Use:     "show",
 		Aliases: []string{"s", "list", "l"},
 		Short:   "Prints current configuration",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config show --home %s
 $ %s cfg list`, appName, defaultHome, appName)),
@@ -117,6 +118,7 @@ func configInitCmd() *cobra.Command {
 		Use:     "init",
 		Aliases: []string{"i"},
 		Short:   "Creates a default home directory at path defined by --home",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config init --home %s
 $ %s cfg i`, appName, defaultHome, appName)),
@@ -171,8 +173,8 @@ $ %s cfg i`, appName, defaultHome, appName)),
 
 func configAddChainsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "add-chains [/path/to/chains/]",
-		Args: cobra.ExactArgs(1),
+		Use:  "add-chains path_to_chains",
+		Args: withUsage(cobra.ExactArgs(1)),
 		Short: `Add new chains to the configuration file from a directory full of chain 
               configurations, useful for adding testnet configurations`,
 		Example: strings.TrimSpace(fmt.Sprintf(`
@@ -190,8 +192,8 @@ $ %s config add-chains configs/chains`, appName)),
 
 func configAddPathsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "add-paths [/path/to/paths/]",
-		Args: cobra.ExactArgs(1),
+		Use:  "add-paths path_to_paths",
+		Args: withUsage(cobra.ExactArgs(1)),
 		//nolint:lll
 		Short: `Add new paths to the configuration file from a directory full of path 
               configurations, useful for adding testnet configurations. 

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -55,10 +55,10 @@ func keysCmd(a *appState) *cobra.Command {
 // keysAddCmd respresents the `keys add` command
 func keysAddCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add [chain-id] [name]",
+		Use:     "add chain_id name",
 		Aliases: []string{"a"},
 		Short:   "Adds a key to the keychain associated with a particular chain",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys add ibc-0
 $ %s keys add ibc-1 key2
@@ -101,10 +101,10 @@ $ %s k a ibc-2 testkey`, appName, appName, appName)),
 // keysRestoreCmd respresents the `keys add` command
 func keysRestoreCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "restore [chain-id] [name] [mnemonic]",
+		Use:     "restore chain_id name mnemonic",
 		Aliases: []string{"r"},
 		Short:   "Restores a mnemonic to the keychain associated with a particular chain",
-		Args:    cobra.ExactArgs(3),
+		Args:    withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys restore ibc-0 testkey "[mnemonic-words]"
 $ %s k r ibc-1 faucet-key "[mnemonic-words]"`, appName, appName)),
@@ -141,10 +141,10 @@ $ %s k r ibc-1 faucet-key "[mnemonic-words]"`, appName, appName)),
 // keysDeleteCmd respresents the `keys delete` command
 func keysDeleteCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete [chain-id] [name]",
+		Use:     "delete chain_id name",
 		Aliases: []string{"d"},
 		Short:   "Deletes a key from the keychain associated with a particular chain",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys delete ibc-0 -y
 $ %s keys delete ibc-1 key2 -y
@@ -202,10 +202,10 @@ func askForConfirmation(a *appState, stdin io.Reader, stderr io.Writer) bool {
 // keysListCmd respresents the `keys list` command
 func keysListCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list [chain-id]",
+		Use:     "list chain_id",
 		Aliases: []string{"l"},
 		Short:   "Lists keys from the keychain associated with a particular chain",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys list ibc-0
 $ %s k l ibc-1`, appName, appName)),
@@ -240,10 +240,10 @@ $ %s k l ibc-1`, appName, appName)),
 // keysShowCmd respresents the `keys show` command
 func keysShowCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "show [chain-id] [[name]]",
+		Use:     "show chain_id [name]",
 		Aliases: []string{"s"},
 		Short:   "Shows a key from the keychain associated with a particular chain",
-		Args:    cobra.RangeArgs(1, 2),
+		Args:    withUsage(cobra.RangeArgs(1, 2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys show ibc-0
 $ %s keys show ibc-1 key2
@@ -281,10 +281,10 @@ $ %s k s ibc-2 testkey`, appName, appName, appName)),
 // keysExportCmd respresents the `keys export` command
 func keysExportCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "export [chain-id] [name]",
+		Use:     "export chain_id name",
 		Aliases: []string{"e"},
 		Short:   "Exports a privkey from the keychain associated with a particular chain",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys export ibc-0 testkey
 $ %s k e ibc-2 testkey`, appName, appName)),

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -45,10 +45,10 @@ This includes the client, connection, and channel ids from both the source and d
 
 func pathsDeleteCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete [index]",
+		Use:     "delete index",
 		Aliases: []string{"d"},
 		Short:   "Delete a path with a given index",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths delete demo-path
 $ %s pth d path-name`, appName, appName)),
@@ -68,6 +68,7 @@ func pathsListCmd(a *appState) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"l"},
 		Short:   "Print out configured paths",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths list --yaml
 $ %s paths list --json
@@ -127,10 +128,10 @@ func checkmark(status bool) string {
 
 func pathsShowCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "show [path-name]",
+		Use:     "show path_name",
 		Aliases: []string{"s"},
 		Short:   "Show a path given its name",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths show demo-path --yaml
 $ %s paths show demo-path --json
@@ -176,10 +177,10 @@ $ %s pth s path-name`, appName, appName, appName)),
 
 func pathsAddCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add [src-chain-id] [dst-chain-id] [path-name]",
+		Use:     "add src_chain_id dst_chain_id path_name",
 		Aliases: []string{"a"},
 		Short:   "Add a path to the list of paths",
-		Args:    cobra.ExactArgs(3),
+		Args:    withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths add ibc-0 ibc-1 demo-path
 $ %s paths add ibc-0 ibc-1 demo-path --file paths/demo.json
@@ -214,10 +215,10 @@ $ %s pth a ibc-0 ibc-1 demo-path`, appName, appName, appName)),
 
 func pathsNewCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "new [src-chain-id] [dst-chain-id] [path-name]",
+		Use:     "new src_chain_id dst_chain_id path_name",
 		Aliases: []string{"n"},
 		Short:   "Create a new blank path to be used in generating a new path (connection & client) between two chains",
-		Args:    cobra.ExactArgs(3),
+		Args:    withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths new ibc-0 ibc-1 demo-path
 $ %s pth n ibc-0 ibc-1 demo-path`, appName, appName)),
@@ -250,6 +251,7 @@ func pathsFetchCmd(a *appState) *cobra.Command {
 		Use:     "fetch",
 		Aliases: []string{"fch"},
 		Short:   "Fetches the json files necessary to setup the paths for the configured chains",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths fetch --home %s
 $ %s pth fch`, appName, defaultHome, appName)),

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -53,9 +53,9 @@ func queryCmd(a *appState) *cobra.Command {
 
 func queryIBCDenoms(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ibc-denoms [chain-id]",
+		Use:   "ibc-denoms chain_id",
 		Short: "query denomination traces for a given network by chain ID",
-		Args:  cobra.ExactArgs(1),
+		Args:  withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query ibc-denoms ibc-0
 $ %s q ibc-denoms ibc-0`,
@@ -89,9 +89,9 @@ $ %s q ibc-denoms ibc-0`,
 
 func queryBaseDenomFromIBCDenom(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "denom-trace [chain-id] [denom-hash]",
+		Use:   "denom-trace chain_id denom_hash",
 		Short: "query that retrieves the base denom from the IBC denomination trace",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query denom-trace osmosis-1 9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E
 $ %s q denom-trace osmosis-1 9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E`,
@@ -117,9 +117,9 @@ $ %s q denom-trace osmosis-1 9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118
 
 func queryTx(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tx [chain-id] [tx-hash]",
+		Use:   "tx chain_id tx_hash",
 		Short: "query for a transaction on a given network by transaction hash and chain ID",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query tx ibc-0 [tx-hash]
 $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE`,
@@ -151,7 +151,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 
 func queryTxs(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "txs [chain-id] [events]",
+		Use:   "txs chain_id events",
 		Short: "query for transactions on a given network by chain ID and a set of transaction events",
 		Long: strings.TrimSpace(`Search for a paginated list of transactions that match the given set of
 events. Each event takes the form of '{eventType}.{eventAttribute}={value}' with multiple events
@@ -160,7 +160,7 @@ separated by '&'.
 Please refer to each module's documentation for the full set of events to query for. Each module
 documents its respective events under 'cosmos-sdk/x/{module}/spec/xx_events.md'.`,
 		),
-		Args: cobra.ExactArgs(2),
+		Args: withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query txs ibc-0 "message.action=transfer" --offset 1 --limit 10
 $ %s q txs ibc-0 "message.action=transfer"`,
@@ -255,10 +255,10 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 
 func queryBalanceCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "balance [chain-id] [[key-name]]",
+		Use:     "balance chain_id [key_name]",
 		Aliases: []string{"bal"},
 		Short:   "query the relayer's account balance on a given network by chain-ID",
-		Args:    cobra.RangeArgs(1, 2),
+		Args:    withUsage(cobra.RangeArgs(1, 2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query balance ibc-0
 $ %s query balance ibc-0 testkey`,
@@ -304,9 +304,9 @@ $ %s query balance ibc-0 testkey`,
 
 func queryHeaderCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "header [chain-id] [[height]]",
+		Use:   "header chain_id [height]",
 		Short: "query the header of a network by chain ID at a given height or the latest height",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  withUsage(cobra.RangeArgs(1, 2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query header ibc-0
 $ %s query header ibc-0 1400`,
@@ -351,9 +351,9 @@ $ %s query header ibc-0 1400`,
 // the chain as defined in https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics#query
 func queryNodeStateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "node-state [chain-id]",
+		Use:   "node-state chain_id",
 		Short: "query the consensus state of a network by chain ID",
-		Args:  cobra.ExactArgs(1),
+		Args:  withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query node-state ibc-0
 $ %s q node-state ibc-1`,
@@ -391,9 +391,9 @@ $ %s q node-state ibc-1`,
 
 func queryClientCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "client [chain-id] [client-id]",
+		Use:   "client chain_id client_id",
 		Short: "query the state of a light client on a network by chain ID",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query client ibc-0 ibczeroclient
 $ %s query client ibc-0 ibczeroclient --height 1205`,
@@ -442,10 +442,10 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 
 func queryClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "clients [chain-id]",
+		Use:     "clients chain_id",
 		Aliases: []string{"clnts"},
 		Short:   "query for all light client states on a network by chain ID",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query clients ibc-0
 $ %s query clients ibc-2 --offset 2 --limit 30`,
@@ -523,10 +523,10 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 
 func queryConnections(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "connections [chain-id]",
+		Use:     "connections chain_id",
 		Aliases: []string{"conns"},
 		Short:   "query for all connections on a network by chain ID",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query connections ibc-0
 $ %s query connections ibc-2 --offset 2 --limit 30
@@ -570,9 +570,9 @@ $ %s q conns ibc-1`,
 
 func queryConnectionsUsingClient(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "client-connections [chain-id] [client-id]",
+		Use:   "client-connections chain_id client_id",
 		Short: "query for all connections for a given client on a network by chain ID",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query client-connections ibc-0 ibczeroclient
 $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
@@ -621,10 +621,10 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 
 func queryConnection(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "connection [chain-id] [connection-id]",
+		Use:     "connection chain_id connection_id",
 		Aliases: []string{"conn"},
 		Short:   "query the connection state for a given connection id on a network by chain ID",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query connection ibc-0 ibconnection0
 $ %s q conn ibc-1 ibconeconn`,
@@ -666,9 +666,9 @@ $ %s q conn ibc-1 ibconeconn`,
 
 func queryConnectionChannels(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "connection-channels [chain-id] [connection-id]",
+		Use:   "connection-channels chain_id connection_id",
 		Short: "query all channels associated with a given connection on a network by chain ID",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query connection-channels ibc-0 ibcconnection1
 $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
@@ -715,9 +715,9 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 
 func queryChannel(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "channel [chain-id] [channel-id] [port-id]",
+		Use:   "channel chain_id channel_id port_id",
 		Short: "query a channel by channel and port ID on a network by chain ID",
-		Args:  cobra.ExactArgs(3),
+		Args:  withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query channel ibc-0 ibczerochannel transfer
 $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
@@ -768,9 +768,9 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 
 func queryChannels(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "channels [chain-id]",
+		Use:   "channels chain_id",
 		Short: "query for all channels on a network by chain ID",
-		Args:  cobra.ExactArgs(1),
+		Args:  withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query channels ibc-0
 $ %s query channels ibc-2 --offset 2 --limit 30`,
@@ -813,9 +813,9 @@ $ %s query channels ibc-2 --offset 2 --limit 30`,
 
 func queryPacketCommitment(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "packet-commit [chain-id] [channel-id] [port-id] [seq]",
+		Use:   "packet-commit chain_id channel_id port_id seq",
 		Short: "query for the packet commitment given a sequence and channel ID on a network by chain ID",
-		Args:  cobra.ExactArgs(4),
+		Args:  withUsage(cobra.ExactArgs(4)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query packet-commit ibc-0 ibczerochannel transfer 32
 $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
@@ -856,10 +856,10 @@ $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
 
 func queryUnrelayedPackets(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "unrelayed-packets [path] [src-channel-id]",
+		Use:     "unrelayed-packets path src_channel_id",
 		Aliases: []string{"unrelayed-pkts"},
 		Short:   "query for the packet sequence numbers that remain to be relayed on a given path",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s q unrelayed-packets demo-path channel-0
 $ %s query unrelayed-packets demo-path channel-0
@@ -912,10 +912,10 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 
 func queryUnrelayedAcknowledgements(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "unrelayed-acknowledgements [path] [src-channel-id]",
+		Use:     "unrelayed-acknowledgements path src_channel_id",
 		Aliases: []string{"unrelayed-acks"},
 		Short:   "query for unrelayed acknowledgement sequence numbers that remain to be relayed on a given path",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s q unrelayed-acknowledgements demo-path channel-0
 $ %s query unrelayed-acknowledgements demo-path channel-0

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -232,3 +232,17 @@ func lineBreakCommand() *cobra.Command {
 	var cmd cobra.Command = *flags.LineBreak
 	return &cmd
 }
+
+// withUsage wraps a PositionalArgs to display usage only when the PositionalArgs
+// variant is violated.
+func withUsage(inner cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := inner(cmd, args); err != nil {
+			cmd.Root().SilenceUsage = false
+			cmd.SilenceUsage = false
+			return err
+		}
+
+		return nil
+	}
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -38,10 +38,10 @@ import (
 // NOTE: This is basically pseudocode
 func startCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "start [path-name]",
+		Use:     "start path_name",
 		Aliases: []string{"st"},
 		Short:   "Start the listening relayer on a given path",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s start demo-path --max-msgs 3
 $ %s start demo-path2 --max-tx-size 10`, appName, appName)),

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -106,11 +106,11 @@ Most of these commands take a [path] argument. Make sure:
 
 func createClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clients [path-name]",
+		Use:   "clients path_name",
 		Short: "create a clients between two configured chains with a configured path",
 		Long: "Creates a working ibc client for chain configured on each end of the" +
 			" path by querying headers from each chain and then sending the corresponding create-client messages",
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`$ %s transact clients demo-path`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			allowUpdateAfterExpiry, err := cmd.Flags().GetBool(flagUpdateAfterExpiry)
@@ -160,11 +160,11 @@ func createClientsCmd(a *appState) *cobra.Command {
 
 func createClientCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "client [src-chain-id] [dst-chain-id] [path-name]",
+		Use:   "client src_chain_id dst_chain_id path_name",
 		Short: "create a client between two configured chains with a configured path",
 		Long: "Creates a working ibc client for chain configured on each end of the" +
 			" path by querying headers from each chain and then sending the corresponding create-client messages",
-		Args:    cobra.ExactArgs(3),
+		Args:    withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`$ %s transact client demo-path`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			allowUpdateAfterExpiry, err := cmd.Flags().GetBool(flagUpdateAfterExpiry)
@@ -261,12 +261,12 @@ func createClientCmd(a *appState) *cobra.Command {
 
 func updateClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-clients [path-name]",
+		Use:   "update-clients path_name",
 		Short: "update IBC clients between two configured chains with a configured path",
 		Long: `Updates IBC client for chain configured on each end of the supplied path.
 Clients are updated by querying headers from each chain and then sending the
 corresponding update-client messages.`,
-		Args:    cobra.ExactArgs(1),
+		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`$ %s transact update-clients demo-path`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, src, dst, err := a.Config.ChainsFromPath(args[0])
@@ -291,9 +291,9 @@ corresponding update-client messages.`,
 
 func upgradeClientsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "upgrade-clients [path-name] [chain-id]",
+		Use:   "upgrade-clients path_name chain_id",
 		Short: "upgrades IBC clients between two configured chains with a configured path and chain-id",
-		Args:  cobra.ExactArgs(2),
+		Args:  withUsage(cobra.ExactArgs(2)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
@@ -329,13 +329,13 @@ func upgradeClientsCmd(a *appState) *cobra.Command {
 
 func createConnectionCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "connection [path-name]",
+		Use:     "connection path_name",
 		Aliases: []string{"conn"},
 		Short:   "create a connection between two configured chains with a configured path",
 		Long: strings.TrimSpace(`Create or repair a connection between two IBC-connected networks
 along a specific path.`,
 		),
-		Args: cobra.ExactArgs(1),
+		Args: withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact connection demo-path
 $ %s tx conn demo-path --timeout 5s`,
@@ -410,13 +410,13 @@ $ %s tx conn demo-path --timeout 5s`,
 
 func createChannelCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "channel [path-name]",
+		Use:     "channel path_name",
 		Aliases: []string{"chan"},
 		Short:   "create a channel between two configured chains with a configured path using specified or default channel identifiers",
 		Long: strings.TrimSpace(`Create or repair a channel between two IBC-connected networks
 along a specific path.`,
 		),
-		Args: cobra.ExactArgs(1),
+		Args: withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact channel demo-path --src-port transfer --dst-port transfer --order unordered --version ics20-1
 $ %s tx chan demo-path --timeout 5s --max-retries 10`,
@@ -492,9 +492,9 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 
 func closeChannelCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "channel-close [path-name] [src-channel-id] [src-port-id]",
+		Use:   "channel-close path_name src_channel_id src_port_id",
 		Short: "close a channel between two configured chains with a configured path",
-		Args:  cobra.ExactArgs(3),
+		Args:  withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact channel-close demo-path channel-0 transfer
 $ %s tx channel-close demo-path channel-0 transfer --timeout 5s
@@ -543,13 +543,13 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 
 func linkCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "link [path-name]",
+		Use:     "link path_name",
 		Aliases: []string{"connect"},
 		Short:   "create clients, connection, and channel between two configured chains with a configured path",
 		Long: strings.TrimSpace(`Create an IBC client between two IBC-enabled networks, in addition
 to creating a connection and a channel between the two networks on a configured path.`,
 		),
-		Args: cobra.ExactArgs(1),
+		Args: withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact link demo-path --src-port transfer --dst-port transfer
 $ %s tx link demo-path
@@ -666,13 +666,13 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 
 func linkThenStartCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "link-then-start [path-name]",
+		Use:     "link-then-start path_name",
 		Aliases: []string{"connect-then-start"},
 		Short:   "a shorthand command to execute 'link' followed by 'start'",
 		Long: strings.TrimSpace(`Create IBC clients, connection, and channel between two configured IBC
 networks with a configured path and then start the relayer on that path.`,
 		),
-		Args: cobra.ExactArgs(1),
+		Args: withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact link-then-start demo-path
 $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
@@ -699,10 +699,10 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 
 func relayMsgCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "relay-packet [path-name] [src-channel-id] [seq-num]",
+		Use:     "relay-packet path_name src_channel_id seq_num",
 		Aliases: []string{"relay-pkt"},
 		Short:   "relay a non-relayed packet with a specific sequence number, in both directions",
-		Args:    cobra.ExactArgs(3),
+		Args:    withUsage(cobra.ExactArgs(3)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact relay-packet demo-path channel-1 1
 $ %s tx relay-pkt demo-path channel-1 1`,
@@ -748,10 +748,10 @@ $ %s tx relay-pkt demo-path channel-1 1`,
 
 func relayMsgsCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "relay-packets [path-name] [src-channel-id]",
+		Use:     "relay-packets path_name src_channel_id",
 		Aliases: []string{"relay-pkts"},
 		Short:   "relay any remaining non-relayed packets on a given path, in both directions",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact relay-packets demo-path channel-0
 $ %s tx relay-pkts demo-path channel-0`,
@@ -796,10 +796,10 @@ $ %s tx relay-pkts demo-path channel-0`,
 
 func relayAcksCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "relay-acknowledgements [path-name] [src-channel-id]",
+		Use:     "relay-acknowledgements path_name src_channel_id",
 		Aliases: []string{"relay-acks"},
 		Short:   "relay any remaining non-relayed acknowledgements on a given path, in both directions",
-		Args:    cobra.ExactArgs(2),
+		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s transact relay-acknowledgements demo-path channel-0
 $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
@@ -911,11 +911,11 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 
 func xfersend(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "transfer [src-chain-id] [dst-chain-id] [amount] [dst-addr] [src-channel-id]",
+		Use:   "transfer src_chain_id dst_chain_id amount dst_addr src_channel_id",
 		Short: "initiate a transfer from one network to another",
 		Long: `Initiate a token transfer via IBC between two networks. The created packet
 must be relayed to the destination chain.`,
-		Args: cobra.ExactArgs(5),
+		Args: withUsage(cobra.ExactArgs(5)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s tx transfer ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk channel-0 --path demo-path
 $ %s tx transfer ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk channel-0 --path demo -y 2 -c 10

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,6 +29,7 @@ func getVersionCmd(a *appState) *cobra.Command {
 		Use:     "version",
 		Aliases: []string{"v"},
 		Short:   "Print the relayer version info",
+		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s version --json
 $ %s v`,


### PR DESCRIPTION
Prior to this change, using an incorrect number of arguments would show
a not-very-helpful error message like:

Error: accepts 3 arg(s), received 2

Now, also include the command's usage after that error message, so the
user doesn't have to re-run the command with --help to figure out what
they've missed.

Also adjust the usage lines to only use square brackets when indicating
an optional argument, as recommended by POSIX Utility Conventions and
the cobra documentation for Command. Also prefer underscores rather than
hyphens for parameter names per POSIX.