### PR TITLE
Move cmd_test.System type into internal/relayertest package

### DIFF
--- a/cmd/chains_test.go
+++ b/cmd/chains_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cosmos/relayer/v2/cmd"
+	"github.com/cosmos/relayer/v2/internal/relayertest"
 	"github.com/cosmos/relayer/v2/relayer/provider/cosmos"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ import (
 func TestChainsList_Empty(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -29,7 +30,7 @@ func TestChainsList_Empty(t *testing.T) {
 func TestChainsAdd_File(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -51,7 +52,7 @@ func TestChainsAdd_File(t *testing.T) {
 func TestChainsAdd_URL(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -91,7 +92,7 @@ func TestChainsAdd_URL(t *testing.T) {
 func TestChainsAdd_Delete(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/relayer/v2/cmd"
+	"github.com/cosmos/relayer/v2/internal/relayertest"
 	"github.com/cosmos/relayer/v2/relayer/provider/cosmos"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ import (
 func TestKeysList_Empty(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -34,7 +35,7 @@ func TestKeysList_Empty(t *testing.T) {
 func TestKeysRestore_Delete(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -49,13 +50,13 @@ func TestKeysRestore_Delete(t *testing.T) {
 	})
 
 	// Restore a key with mnemonic to the chain.
-	res := sys.MustRun(t, "keys", "restore", "testcosmos", "default", ZeroMnemonic)
-	require.Equal(t, res.Stdout.String(), ZeroCosmosAddr+"\n")
+	res := sys.MustRun(t, "keys", "restore", "testcosmos", "default", relayertest.ZeroMnemonic)
+	require.Equal(t, res.Stdout.String(), relayertest.ZeroCosmosAddr+"\n")
 	require.Empty(t, res.Stderr.String())
 
 	// Restored key must show up in list.
 	res = sys.MustRun(t, "keys", "list", "testcosmos")
-	require.Equal(t, res.Stdout.String(), "key(default) -> "+ZeroCosmosAddr+"\n")
+	require.Equal(t, res.Stdout.String(), "key(default) -> "+relayertest.ZeroCosmosAddr+"\n")
 	require.Empty(t, res.Stderr.String())
 
 	// Deleting the key must succeed.
@@ -72,7 +73,7 @@ func TestKeysRestore_Delete(t *testing.T) {
 func TestKeysExport(t *testing.T) {
 	t.Parallel()
 
-	sys := NewSystem(t)
+	sys := relayertest.NewSystem(t)
 
 	_ = sys.MustRun(t, "config", "init")
 
@@ -87,8 +88,8 @@ func TestKeysExport(t *testing.T) {
 	})
 
 	// Restore a key with mnemonic to the chain.
-	res := sys.MustRun(t, "keys", "restore", "testcosmos", "default", ZeroMnemonic)
-	require.Equal(t, res.Stdout.String(), ZeroCosmosAddr+"\n")
+	res := sys.MustRun(t, "keys", "restore", "testcosmos", "default", relayertest.ZeroMnemonic)
+	require.Equal(t, res.Stdout.String(), relayertest.ZeroCosmosAddr+"\n")
 	require.Empty(t, res.Stderr.String())
 
 	// Export the key.

--- a/internal/relayertest/system.go
+++ b/internal/relayertest/system.go
@@ -1,4 +1,6 @@
-package cmd_test
+// Package relayertest enables testing the relayer command-line interface
+// from within Go unit tests.
+package relayertest
 
 import (
 	"bytes"


### PR DESCRIPTION
This will enable using the System type in the integration tests, which
cannot import from a different _test package.