### PR TITLE
Refactor events used in `Provider` implementation 

### DIFF
--- a/relayer/events.go
+++ b/relayer/events.go
@@ -11,7 +11,7 @@ import (
 
 // ParseClientIDFromEvents parses events emitted from a MsgCreateClient and returns the
 // client identifier.
-func ParseClientIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+func ParseClientIDFromEvents(events []provider.RelayerEvent) (string, error) {
 	for _, event := range events {
 		if event.EventType == clienttypes.EventTypeCreateClient {
 			if event.AttributeKey == clienttypes.AttributeKeyClientID {
@@ -24,7 +24,7 @@ func ParseClientIDFromEvents(events []*provider.RelayerEvent) (string, error) {
 
 // ParseConnectionIDFromEvents parses events emitted from a MsgConnectionOpenInit or
 // MsgConnectionOpenTry and returns the connection identifier.
-func ParseConnectionIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+func ParseConnectionIDFromEvents(events []provider.RelayerEvent) (string, error) {
 	for _, event := range events {
 		if event.EventType == connectiontypes.EventTypeConnectionOpenInit || event.EventType == connectiontypes.EventTypeConnectionOpenTry {
 			if event.AttributeKey == connectiontypes.AttributeKeyConnectionID {
@@ -37,7 +37,7 @@ func ParseConnectionIDFromEvents(events []*provider.RelayerEvent) (string, error
 
 // ParseChannelIDFromEvents parses events emitted from a MsgChannelOpenInit or
 // MsgChannelOpenTry and returns the channel identifier.
-func ParseChannelIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+func ParseChannelIDFromEvents(events []provider.RelayerEvent) (string, error) {
 	for _, event := range events {
 		if event.EventType == channeltypes.EventTypeChannelOpenInit || event.EventType == channeltypes.EventTypeChannelOpenTry {
 			if event.AttributeKey == channeltypes.AttributeKeyChannelID {

--- a/relayer/events.go
+++ b/relayer/events.go
@@ -2,21 +2,20 @@ package relayer
 
 import (
 	"fmt"
-	"strings"
 
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	"github.com/cosmos/relayer/v2/relayer/provider"
 )
 
 // ParseClientIDFromEvents parses events emitted from a MsgCreateClient and returns the
 // client identifier.
-func ParseClientIDFromEvents(events map[string]string) (string, error) {
-	for k, v := range events {
-		eventType, attrKey := splitEventKey(k)
-		if eventType == clienttypes.EventTypeCreateClient {
-			if attrKey == clienttypes.AttributeKeyClientID {
-				return v, nil
+func ParseClientIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+	for _, event := range events {
+		if event.EventType == clienttypes.EventTypeCreateClient {
+			if event.AttributeKey == clienttypes.AttributeKeyClientID {
+				return event.AttributeValue, nil
 			}
 		}
 	}
@@ -25,13 +24,11 @@ func ParseClientIDFromEvents(events map[string]string) (string, error) {
 
 // ParseConnectionIDFromEvents parses events emitted from a MsgConnectionOpenInit or
 // MsgConnectionOpenTry and returns the connection identifier.
-func ParseConnectionIDFromEvents(events map[string]string) (string, error) {
-	for k, v := range events {
-		eventType, attrKey := splitEventKey(k)
-		if eventType == connectiontypes.EventTypeConnectionOpenInit ||
-			eventType == connectiontypes.EventTypeConnectionOpenTry {
-			if attrKey == connectiontypes.AttributeKeyConnectionID {
-				return v, nil
+func ParseConnectionIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+	for _, event := range events {
+		if event.EventType == connectiontypes.EventTypeConnectionOpenInit || event.EventType == connectiontypes.EventTypeConnectionOpenTry {
+			if event.AttributeKey == connectiontypes.AttributeKeyConnectionID {
+				return event.AttributeValue, nil
 			}
 		}
 	}
@@ -40,64 +37,13 @@ func ParseConnectionIDFromEvents(events map[string]string) (string, error) {
 
 // ParseChannelIDFromEvents parses events emitted from a MsgChannelOpenInit or
 // MsgChannelOpenTry and returns the channel identifier.
-func ParseChannelIDFromEvents(events map[string]string) (string, error) {
-	for k, v := range events {
-		eventType, attrKey := splitEventKey(k)
-		if eventType == channeltypes.EventTypeChannelOpenInit || eventType == channeltypes.EventTypeChannelOpenTry {
-			if attrKey == channeltypes.AttributeKeyChannelID {
-				return v, nil
+func ParseChannelIDFromEvents(events []*provider.RelayerEvent) (string, error) {
+	for _, event := range events {
+		if event.EventType == channeltypes.EventTypeChannelOpenInit || event.EventType == channeltypes.EventTypeChannelOpenTry {
+			if event.AttributeKey == channeltypes.AttributeKeyChannelID {
+				return event.AttributeValue, nil
 			}
 		}
 	}
 	return "", fmt.Errorf("channel identifier event attribute not found")
 }
-
-func splitEventKey(key string) (string, string) {
-	stuff := strings.Split(key, ".")
-	eventType := stuff[0]
-	attrKey := stuff[1]
-	return eventType, attrKey
-}
-
-// ParseClientIDFromEvents parses events emitted from a MsgCreateClient and returns the
-// client identifier.
-//func ParseClientIDFromEvents(events sdk.StringEvents) (string, error) {
-//	for _, ev := range events {
-//		if ev.Type == clienttypes.EventTypeCreateClient {
-//			for _, attr := range ev.Attributes {
-//				if attr.Key == clienttypes.AttributeKeyClientID {
-//					return attr.Value, nil
-//				}
-//			}
-//		}
-//	}
-//	return "", fmt.Errorf("client identifier event attribute not found")
-//}
-
-//
-//func ParseConnectionIDFromEvents(events sdk.StringEvents) (string, error) {
-//	for _, ev := range events {
-//		if ev.Type == connectiontypes.EventTypeConnectionOpenInit ||
-//			ev.Type == connectiontypes.EventTypeConnectionOpenTry {
-//			for _, attr := range ev.Attributes {
-//				if attr.Key == connectiontypes.AttributeKeyConnectionID {
-//					return attr.Value, nil
-//				}
-//			}
-//		}
-//	}
-//	return "", fmt.Errorf("connection identifier event attribute not found")
-//}
-
-//func ParseChannelIDFromEvents(events sdk.StringEvents) (string, error) {
-//	for _, ev := range events {
-//		if ev.Type == channeltypes.EventTypeChannelOpenInit || ev.Type == channeltypes.EventTypeChannelOpenTry {
-//			for _, attr := range ev.Attributes {
-//				if attr.Key == channeltypes.AttributeKeyChannelID {
-//					return attr.Value, nil
-//				}
-//			}
-//		}
-//	}
-//	return "", fmt.Errorf("channel identifier event attribute not found")
-//}

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -91,17 +91,19 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 
 // parseEventsFromResponseDeliverTx parses the events from a ResponseDeliverTx and builds a slice
 // of provider.RelayerEvent's.
-func parseEventsFromResponseDeliverTx(resp abci.ResponseDeliverTx) (events []*provider.RelayerEvent) {
+func parseEventsFromResponseDeliverTx(resp abci.ResponseDeliverTx) []provider.RelayerEvent {
+	var events []provider.RelayerEvent
+
 	for _, event := range resp.Events {
 		for _, attribute := range event.Attributes {
-			events = append(events, &provider.RelayerEvent{
+			events = append(events, provider.RelayerEvent{
 				EventType:      event.Type,
 				AttributeKey:   string(attribute.Key),
 				AttributeValue: string(attribute.Value),
 			})
 		}
 	}
-	return
+	return events
 }
 
 // QueryBalance returns the amount of coins in the relayer account

--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -77,26 +77,28 @@ func (cc *CosmosProvider) QueryTxs(ctx context.Context, page, limit int, events 
 	// at most, one tx in the response. Because of this we don't want to initialize the slice with an initial size.
 	var txResps []*provider.RelayerTxResponse
 	for _, tx := range res.Txs {
-		events := parseEventsFromResponseDeliverTx(tx.TxResult)
+		relayerEvents := parseEventsFromResponseDeliverTx(tx.TxResult)
 		txResps = append(txResps, &provider.RelayerTxResponse{
 			Height: tx.Height,
 			TxHash: string(tx.Hash),
 			Code:   tx.TxResult.Code,
 			Data:   string(tx.TxResult.Data),
-			Events: events,
+			Events: relayerEvents,
 		})
 	}
 	return txResps, nil
 }
 
-// parseEventsFromResponseDeliverTx parses the events from a ResponseDeliverTx and builds a map
-// where the keys are equal to event.Type+"."+attribute.Key and the values are the attribute.Value.
-func parseEventsFromResponseDeliverTx(resp abci.ResponseDeliverTx) (events map[string]string) {
-	events = make(map[string]string, len(resp.Events))
+// parseEventsFromResponseDeliverTx parses the events from a ResponseDeliverTx and builds a slice
+// of provider.RelayerEvent's.
+func parseEventsFromResponseDeliverTx(resp abci.ResponseDeliverTx) (events []*provider.RelayerEvent) {
 	for _, event := range resp.Events {
 		for _, attribute := range event.Attributes {
-			key := event.Type + "." + string(attribute.Key)
-			events[key] = string(attribute.Value)
+			events = append(events, &provider.RelayerEvent{
+				EventType:      event.Type,
+				AttributeKey:   string(attribute.Key),
+				AttributeValue: string(attribute.Value),
+			})
 		}
 	}
 	return

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -29,7 +29,13 @@ type RelayerTxResponse struct {
 	TxHash string
 	Code   uint32
 	Data   string
-	Events map[string]string
+	Events []*RelayerEvent
+}
+
+type RelayerEvent struct {
+	EventType      string
+	AttributeKey   string
+	AttributeValue string
 }
 
 func (r RelayerTxResponse) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -37,8 +43,8 @@ func (r RelayerTxResponse) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("tx_hash", r.TxHash)
 	enc.AddUint32("code", r.Code)
 	enc.AddString("data", r.Data)
-	for k, v := range r.Events {
-		enc.AddString("event:"+k, v)
+	for _, event := range r.Events {
+		enc.AddString("event:"+event.EventType, event.AttributeKey+"="+event.AttributeValue)
 	}
 	return nil
 }

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -29,7 +29,7 @@ type RelayerTxResponse struct {
 	TxHash string
 	Code   uint32
 	Data   string
-	Events []*RelayerEvent
+	Events []RelayerEvent
 }
 
 type RelayerEvent struct {
@@ -38,14 +38,33 @@ type RelayerEvent struct {
 	AttributeValue string
 }
 
+// loggableEvents is an unexported wrapper type for a slice of RelayerEvent,
+// to satisfy the zapcore.ArrayMarshaler interface.
+type loggableEvents []RelayerEvent
+
+// MarshalLogObject satisfies the zapcore.ObjectMarshaler interface.
+func (e RelayerEvent) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("event_type", e.EventType)
+	enc.AddString("attr_key", e.AttributeKey)
+	enc.AddString("attr_value", e.AttributeValue)
+	return nil
+}
+
+// MarshalLogArray satisfies the zapcore.ArrayMarshaler interface.
+func (es loggableEvents) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, e := range es {
+		enc.AppendObject(e)
+	}
+	return nil
+}
+
+// MarshalLogObject satisfies the zapcore.ObjectMarshaler interface.
 func (r RelayerTxResponse) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddInt64("height", r.Height)
 	enc.AddString("tx_hash", r.TxHash)
 	enc.AddUint32("code", r.Code)
 	enc.AddString("data", r.Data)
-	for _, event := range r.Events {
-		enc.AddString("event:"+event.EventType, event.AttributeKey+"="+event.AttributeValue)
-	}
+	enc.AddArray("events", loggableEvents(r.Events))
 	return nil
 }
 


### PR DESCRIPTION
We previously had the `events` field on `RelayerTxResponse` defined as a `map[string]string` where the key was `EventType.AttributeKey` and the value was `AttributeValue`. 

This design did not account for the fact that a tx can contain multiple events with the same type and attribute key so we were effectively overwriting values and only handling one event type/attribute key pair per tx.

This PR moves away from a `map[string]string` to represent events and introduces a new struct in `provider.go`
```
type RelayerEvent struct {
	EventType      string
	AttributeKey   string
	AttributeValue string
}
```

Closes #722 