### PR TITLE
Support multiple relay paths in a single process

### DIFF
--- a/ibctest/go.mod
+++ b/ibctest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/cosmos/relayer/v2 v2.0.0
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/strangelove-ventures/ibctest v0.0.0-20220531195112-60cd4d1fb280
+	github.com/strangelove-ventures/ibctest v0.0.0-20220602154249-e446a78d4d9b
 	go.uber.org/zap v1.21.0
 )
 

--- a/ibctest/go.sum
+++ b/ibctest/go.sum
@@ -933,6 +933,8 @@ github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570/go.mod h1:8
 github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
 github.com/strangelove-ventures/ibctest v0.0.0-20220531195112-60cd4d1fb280 h1:0vHiVCjkMDZAo9DNrwZzXcQ2OsPR21wma/4j6aqOPmA=
 github.com/strangelove-ventures/ibctest v0.0.0-20220531195112-60cd4d1fb280/go.mod h1:tjebUS5nIzM70ewwvFMC8CT32Al4yfbjQx3RKmYRq7s=
+github.com/strangelove-ventures/ibctest v0.0.0-20220602154249-e446a78d4d9b h1:cHqWdKBx4H6qpi1ipGWi/bdHoiUrz+uds6ceMg3dlIs=
+github.com/strangelove-ventures/ibctest v0.0.0-20220602154249-e446a78d4d9b/go.mod h1:vHZ9wcaf9gQg4tSiBYLEzKibzLFEa1InkGFcN2i6ceg=
 github.com/strangelove-ventures/lens v0.3.1-0.20220407203447-bcb1fa2e7b3a h1:9nwCWqs6BHJomom4TEQXCSQ0I8AKPwXNzSXZRr3i2vk=
 github.com/strangelove-ventures/lens v0.3.1-0.20220407203447-bcb1fa2e7b3a/go.mod h1:17n4M/9F6YWAvmaqJLh0/8dZgUz23grtImvd58gBe28=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/ibctest/relaymany_test.go
+++ b/ibctest/relaymany_test.go
@@ -90,9 +90,9 @@ func TestRelayMany_WIP(t *testing.T) {
 	test.WaitForBlocks(ctx, 5, gaia, osmosis)
 	afterOsmoBalance, err := osmosis.GetBalance(ctx, osmosisFaucetAddr, gaiaOsmoIBCDenom)
 	require.NoError(t, err)
-	require.Equal(t, afterOsmoBalance, gaiaOsmoTxAmount)
+	require.Equal(t, afterOsmoBalance, int64(gaiaOsmoTxAmount))
 
-	gaiaAck, err := test.PollForAck(ctx, gaia, beforeGaiaTxHeight, afterGaiaTxHeight+15, gaiaTx.Packet)
+	gaiaAck, err := test.PollForAck(ctx, gaia, beforeGaiaTxHeight, afterGaiaTxHeight+150, gaiaTx.Packet)
 	require.NoError(t, err, "failed to get acknowledgement on gaia")
 	require.NoError(t, gaiaAck.Validate(), "invalid acknowledgement on gaia")
 }

--- a/ibctest/relaymany_test.go
+++ b/ibctest/relaymany_test.go
@@ -1,0 +1,124 @@
+package ibctest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestRelayMany(t *testing.T) {
+	t.Parallel()
+
+	pool, network := ibctest.DockerSetup(t)
+	home := t.TempDir()
+
+	cf := ibctest.NewBuiltinChainFactory([]ibctest.BuiltinChainFactoryEntry{
+		gaiaFactoryEntry,
+		osmosisFactoryEntry,
+		junoFactoryEntry,
+	}, zaptest.NewLogger(t))
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	gaia, osmosis, juno := chains[0], chains[1], chains[2]
+
+	r := relayerFactory{}.Build(t, pool, network, home).(*relayer)
+
+	ic := ibctest.NewInterchain().
+		AddChain(gaia).
+		AddChain(osmosis).
+		AddChain(juno).
+		AddRelayer(r, "r").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  osmosis,
+			Relayer: r,
+			Path:    "gaia-osmo",
+		}).
+		AddLink(ibctest.InterchainLink{
+			Chain1:  osmosis,
+			Chain2:  juno,
+			Relayer: r,
+			Path:    "osmo-juno",
+		})
+
+	eRep := testreporter.NewReporter(newNopWriteCloser()).RelayerExecReporter(t)
+
+	ctx := context.Background()
+
+	err = ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName: t.Name(),
+		HomeDir:  home,
+
+		Pool:      pool,
+		NetworkID: network,
+	})
+	require.NoError(t, err)
+
+	// Note, StartRelayerMany is a method on *relayer,
+	// not part of the ibc.Relayer interface.
+	r.StartRelayerMany(ctx, "gaia-osmo", "osmo-juno")
+	defer r.StopRelayer(ctx, eRep)
+
+	// Gaia and juno faucets will just send IBC to the osmosis faucet,
+	// so get its bech32 address first.
+	osmosisFaucetAddrBytes, err := osmosis.GetAddress(ctx, ibctest.FaucetAccountKeyName)
+	require.NoError(t, err)
+	osmosisFaucetAddr, err := types.Bech32ifyAddressBytes(osmosis.Config().Bech32Prefix, osmosisFaucetAddrBytes)
+	require.NoError(t, err)
+
+	osmosisHeightBeforeTransfers, err := osmosis.Height(ctx)
+	require.NoError(t, err)
+
+	var gaiaTx, junoTx ibc.Tx
+
+	// Concurrently send IBC transfers.
+	// Each one independently takes about 4 seconds,
+	// so it's worth it for a little time saved.
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	// Send the gaia transfer.
+	eg.Go(func() error {
+		gaiaChannels, err := r.GetChannels(egCtx, eRep, gaia.Config().ChainID)
+		require.NoError(t, err)
+		gaiaTx, err = gaia.SendIBCTransfer(egCtx, gaiaChannels[0].ChannelID, ibctest.FaucetAccountKeyName, ibc.WalletAmount{
+			Address: osmosisFaucetAddr,
+			Denom:   gaia.Config().Denom,
+			Amount:  100,
+		}, nil)
+
+		return err
+	})
+
+	// Send the juno transfer.
+	eg.Go(func() error {
+		junoChannels, err := r.GetChannels(egCtx, eRep, juno.Config().ChainID)
+		require.NoError(t, err)
+		junoTx, err = juno.SendIBCTransfer(egCtx, junoChannels[0].ChannelID, ibctest.FaucetAccountKeyName, ibc.WalletAmount{
+			Address: osmosisFaucetAddr,
+			Denom:   juno.Config().Denom,
+			Amount:  100,
+		}, nil)
+		return err
+	})
+
+	require.NoError(t, eg.Wait())
+
+	osmosisHeightAfterTransfers, err := osmosis.Height(ctx)
+	require.NoError(t, err)
+
+	_, err = test.PollForAck(ctx, osmosis, osmosisHeightBeforeTransfers, osmosisHeightAfterTransfers+15, gaiaTx.Packet)
+	require.NoError(t, err)
+
+	_, err = test.PollForAck(ctx, osmosis, osmosisHeightBeforeTransfers, osmosisHeightAfterTransfers+15, junoTx.Packet)
+	require.NoError(t, err)
+}

--- a/ibctest/relaymany_test.go
+++ b/ibctest/relaymany_test.go
@@ -43,6 +43,13 @@ func TestRelayMany_WIP(t *testing.T) {
 			Relayer: r,
 
 			Path: "gaia-osmo",
+		}).
+		AddLink(ibctest.InterchainLink{
+			Chain1:  osmosis,
+			Chain2:  juno,
+			Relayer: r,
+
+			Path: "osmo-juno",
 		})
 
 	ctx := context.Background()


### PR DESCRIPTION
This allows one instance of rly to relay multiple defined paths. While I
believe this is correctly functioning right now, I would prefer to work
on an ibc-test-framework addition to support testing more than two
chains at once before merging this.