### PR TITLE
arm64 docker

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v2.7.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM golang:alpine as BUILD
+FROM --platform=$BUILDPLATFORM golang:alpine as BUILD
 
 WORKDIR /relayer
 
 # Copy the files from host
 COPY . .
 
+ARG TARGETARCH
+ARG TARGETOS
+
 # Update and install needed deps prioir to installing the binary.
 RUN apk update && \
   apk --no-cache add make git && \
+  export GOOS=${TARGETOS} GOARCH=${TARGETARCH} && \
   make install
 
 FROM alpine:latest


### PR DESCRIPTION
Build and push `linux/arm64` images in addition to current `linux/amd64`, helpful for things like testing in [ibc-test-framework](https://github.com/strangelove-ventures/ibc-test-framework) on m1 mac, deployments to AWS graviton, etc.

https://github.com/cosmos/relayer/pkgs/container/relayer/20904750?tag=andrew-arm64