### PR TITLE
Remove ineffective height queries + quit retrying on `RelayPacketFromSequence`

### DIFF
--- a/relayer/provider/cosmos/query.go
+++ b/relayer/provider/cosmos/query.go
@@ -150,7 +150,7 @@ func (cc *CosmosProvider) QueryUnbondingPeriod(ctx context.Context) (time.Durati
 // performed at one below this height (at the IAVL version) in order to obtain
 // the correct merkle proof. Proof queries at height less than or equal to 2 are
 // not supported. Queries with a client context height of 0 will perform a query
-// at the lastest state available.
+// at the latest state available.
 // Issue: https://github.com/cosmos/cosmos-sdk/issues/6567
 func (cc *CosmosProvider) QueryTendermintProof(ctx context.Context, height int64, key []byte) ([]byte, []byte, clienttypes.Height, error) {
 	// ABCI queries at heights 1, 2 or less than or equal to 0 are not supported.


### PR DESCRIPTION
In several of the calls inside the main relayer loop we were re-querying the latest block height on retries but the function calls no longer utilize the height anyways so they are ineffective.

We were also retrying on `RelayPacketFromSequence()` but this is one of those calls that we want to back out from and go through the entire call stack again.

I've noticed some significant performance increases without this retry in both the tests and when relaying against chains in production. You get much less `portID (transfer), channelID (channel-0), sequence (3475): packet commitment not found"` errors