### PR TITLE
Including channel-id in successful / failed packets

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -222,9 +222,9 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 		}
 		if !success {
 			return srcChanID, dstChanID, false, false, false, err
@@ -268,9 +268,9 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 		}
 		if !success {
 			return srcChanID, dstChanID, false, false, false, err
@@ -312,9 +312,9 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
+			dst.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 		}
 		if !success {
 			return srcChanID, dstChanID, false, false, false, err
@@ -356,9 +356,9 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 
 		last = true
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 		}
 		if !success {
 			return srcChanID, dstChanID, false, false, false, err
@@ -398,9 +398,9 @@ func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChan
 			return srcChanID, dstChanID, false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
+			dst.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 		}
 		if !success {
 			return srcChanID, dstChanID, false, false, false, err
@@ -474,9 +474,9 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 			if err != nil {
-				src.LogFailedTx(res, err, msgs)
+				src.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 			}
 			if !success {
 				return srcChanID, dstChanID, false, false, err
@@ -542,9 +542,9 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 			if err != nil {
-				src.LogFailedTx(res, err, msgs)
+				src.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 			}
 			if !success {
 				return srcChanID, dstChanID, false, false, err
@@ -610,9 +610,9 @@ func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanI
 				return srcChanID, dstChanID, false, false, err
 			}
 
-			res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = dst.ChainProvider.SendMessages(ctx, srcChanID, dstChanID, msgs)
 			if err != nil {
-				dst.LogFailedTx(res, err, msgs)
+				dst.LogFailedTx(res, srcChanID, dstChanID, err, msgs)
 			}
 			if !success {
 				return srcChanID, dstChanID, false, false, err
@@ -658,7 +658,7 @@ func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, 
 			break
 		}
 
-		result := closeSteps.Send(ctx, c.log, AsRelayMsgSender(c), AsRelayMsgSender(dst))
+		result := closeSteps.Send(ctx, c.log, AsRelayMsgSender(c, srcChanID, dstChanID), AsRelayMsgSender(dst, srcChanID, dstChanID))
 		if err := result.Error(); err != nil {
 			c.log.Info(
 				"Error when attempting to close channel",

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -186,14 +186,14 @@ func CreateClient(ctx context.Context, src, dst *Chain, srcUpdateHeader, dstUpda
 	if err := retry.Do(func() error {
 		var success bool
 		var err error
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, "", "", err, msgs)
 			return fmt.Errorf("failed to send messages on chain{%s}: %w", src.ChainID(), err)
 		}
 
 		if !success {
-			src.LogFailedTx(res, nil, msgs)
+			src.LogFailedTx(res, "", "", nil, msgs)
 			return fmt.Errorf("tx failed on chain{%s}: %s", src.ChainID(), res.Data)
 		}
 
@@ -290,7 +290,7 @@ func (c *Chain) UpdateClients(ctx context.Context, dst *Chain) (err error) {
 	}
 
 	// Send msgs to both chains
-	result := clients.Send(ctx, c.log, AsRelayMsgSender(c), AsRelayMsgSender(dst))
+	result := clients.Send(ctx, c.log, AsRelayMsgSender(c, "", ""), AsRelayMsgSender(dst, "", ""))
 	if err := result.Error(); err != nil {
 		if result.PartiallySent() {
 			c.log.Info(
@@ -360,9 +360,9 @@ func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) er
 		upgradeMsg,
 	}
 
-	res, _, err := c.ChainProvider.SendMessages(ctx, msgs)
+	res, _, err := c.ChainProvider.SendMessages(ctx, "", "", msgs)
 	if err != nil {
-		c.LogFailedTx(res, err, msgs)
+		c.LogFailedTx(res, "", "", err, msgs)
 		return err
 	}
 

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -204,9 +204,9 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, "", "", err, msgs)
 		}
 		if !success {
 			return false, false, false, err
@@ -226,9 +226,9 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, "", "", err, msgs)
 		}
 		if !success {
 			return false, false, false, err
@@ -247,9 +247,9 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
+			dst.LogFailedTx(res, "", "", err, msgs)
 		}
 		if !success {
 			return false, false, false, err
@@ -266,9 +266,9 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			src.LogFailedTx(res, err, msgs)
+			src.LogFailedTx(res, "", "", err, msgs)
 		}
 		if !success {
 			return false, false, false, err
@@ -287,9 +287,9 @@ func ExecuteConnectionStep(ctx context.Context, src, dst *Chain) (success, last,
 			return false, false, false, err
 		}
 
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+		res, success, err = dst.ChainProvider.SendMessages(ctx, "", "", msgs)
 		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
+			dst.LogFailedTx(res, "", "", err, msgs)
 		}
 		if !success {
 			return false, false, false, err
@@ -363,9 +363,9 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 			if err != nil {
-				src.LogFailedTx(res, err, msgs)
+				src.LogFailedTx(res, "", "", err, msgs)
 			}
 			if !success {
 				return false, false, err
@@ -406,9 +406,9 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = src.ChainProvider.SendMessages(ctx, "", "", msgs)
 			if err != nil {
-				src.LogFailedTx(res, err, msgs)
+				src.LogFailedTx(res, "", "", err, msgs)
 			}
 			if !success {
 				return false, false, err
@@ -449,9 +449,9 @@ func InitializeConnection(ctx context.Context, src, dst *Chain) (success, modifi
 				return false, false, err
 			}
 
-			res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
+			res, success, err = dst.ChainProvider.SendMessages(ctx, "", "", msgs)
 			if err != nil {
-				dst.LogFailedTx(res, err, msgs)
+				dst.LogFailedTx(res, "", "", err, msgs)
 			}
 			if !success {
 				return false, false, err

--- a/relayer/log-chain.go
+++ b/relayer/log-chain.go
@@ -11,7 +11,7 @@ import (
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 )
 
-func logFailedTx(log *zap.Logger, chainID string, res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+func logFailedTx(log *zap.Logger, chainID string, srcChanID, dstChanID string, res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
 	fields := make([]zap.Field, 1+len(msgs), 2+len(msgs))
 	fields[0] = zap.String("chain_id", chainID)
 	for i, msg := range msgs {
@@ -40,6 +40,8 @@ func logFailedTx(log *zap.Logger, chainID string, res *provider.RelayerTxRespons
 		log.Info(
 			"Sent transaction that resulted in error",
 			zap.String("chain_id", chainID),
+			zap.String("source_channel", srcChanID),
+			zap.String("dest_channel", dstChanID),
 			zap.Int64("height", res.Height),
 			zap.Strings("msg_types", msgTypes),
 			zap.Uint32("error_code", res.Code),
@@ -53,8 +55,8 @@ func logFailedTx(log *zap.Logger, chainID string, res *provider.RelayerTxRespons
 }
 
 // LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
-func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
-	logFailedTx(c.log, c.ChainID(), res, err, msgs)
+func (c *Chain) LogFailedTx(res *provider.RelayerTxResponse, srcChanID, dstChanID string, err error, msgs []provider.RelayerMessage) {
+	logFailedTx(c.log, c.ChainID(), srcChanID, dstChanID, res, err, msgs)
 }
 
 func (c *Chain) logPacketsRelayed(dst *Chain, num int, srcChannel *chantypes.IdentifiedChannel) {

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -356,7 +356,7 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 		}
 
 		// send messages to their respective chains
-		result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst))
+		result := msgs.Send(ctx, log, AsRelayMsgSender(src, "", ""), AsRelayMsgSender(dst, "", ""))
 		if err := result.Error(); err != nil {
 			if result.PartiallySent() {
 				log.Info(
@@ -443,7 +443,7 @@ func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *Rel
 		}
 
 		// send messages to their respective chains
-		result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst))
+		result := msgs.Send(ctx, log, AsRelayMsgSender(src, "", ""), AsRelayMsgSender(dst, "", ""))
 		if err := result.Error(); err != nil {
 			if result.PartiallySent() {
 				log.Info(
@@ -679,7 +679,7 @@ func RelayPacket(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *Rela
 	}
 
 	// send messages to their respective chains
-	result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst))
+	result := msgs.Send(ctx, log, AsRelayMsgSender(src, "", ""), AsRelayMsgSender(dst, "", ""))
 	if err := result.Error(); err != nil {
 		if result.PartiallySent() {
 			log.Info(

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -88,7 +88,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		Src: []provider.RelayerMessage{msg},
 	}
 
-	result := txs.Send(ctx, log, AsRelayMsgSender(c), AsRelayMsgSender(dst))
+	result := txs.Send(ctx, log, AsRelayMsgSender(c, srcChannel.ChannelId, ""), AsRelayMsgSender(dst, srcChannel.ChannelId, ""))
 	if err := result.Error(); err != nil {
 		if result.PartiallySent() {
 			c.log.Info(

--- a/relayer/provider/cosmos/log.go
+++ b/relayer/provider/cosmos/log.go
@@ -13,11 +13,13 @@ import (
 )
 
 // LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
-func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, err error, msgs []provider.RelayerMessage) {
+func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, srcChanID, dstChanID string, err error, msgs []provider.RelayerMessage) {
 	if err != nil {
 		cc.log.Error(
 			"Failed sending cosmos transaction",
 			zap.String("chain_id", cc.ChainId()),
+			zap.String("source_channel", srcChanID),
+			zap.String("dest_channel", dstChanID),
 			msgTypesField(msgs),
 			zap.Error(err),
 		)
@@ -31,6 +33,8 @@ func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, err error
 		cc.log.Warn(
 			"Sent transaction but received failure response",
 			zap.String("chain_id", cc.ChainId()),
+			zap.String("source_channel", srcChanID),
+			zap.String("dest_channel", dstChanID),
 			msgTypesField(msgs),
 			zap.Object("response", res),
 		)
@@ -38,7 +42,7 @@ func (cc *CosmosProvider) LogFailedTx(res *provider.RelayerTxResponse, err error
 }
 
 // LogSuccessTx take the transaction and the messages to create it and logs the appropriate data
-func (cc *CosmosProvider) LogSuccessTx(res *sdk.TxResponse, msgs []provider.RelayerMessage) {
+func (cc *CosmosProvider) LogSuccessTx(res *sdk.TxResponse, srcChanID, dstChanID string, msgs []provider.RelayerMessage) {
 	feesField := zap.Skip()
 	feePayerField := zap.Skip()
 
@@ -64,6 +68,8 @@ func (cc *CosmosProvider) LogSuccessTx(res *sdk.TxResponse, msgs []provider.Rela
 	cc.log.Info(
 		"Successful transaction",
 		zap.String("chain_id", cc.ChainId()),
+		zap.String("source_channel", srcChanID),
+		zap.String("dest_channel", dstChanID),
 		zap.Int64("gas_used", res.GasUsed),
 		feesField,
 		feePayerField,

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -540,7 +540,7 @@ func (cc *CosmosProvider) ChannelOpenInit(srcClientId, srcConnId, srcPortId, src
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanID, dstChanID, srcVersion, srcConnectionId, srcClientId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -554,7 +554,7 @@ func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider p
 		return nil, err
 	}
 
-	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanId, dstPortId)
+	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanID, dstPortId)
 	if err != nil {
 		return nil, err
 	}
@@ -573,13 +573,13 @@ func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider p
 
 	msg := &chantypes.MsgChannelOpenTry{
 		PortId:            srcPortId,
-		PreviousChannelId: srcChanId,
+		PreviousChannelId: srcChanID,
 		Channel: chantypes.Channel{
 			State:    chantypes.TRYOPEN,
 			Ordering: counterpartyChannelRes.Channel.Ordering,
 			Counterparty: chantypes.Counterparty{
 				PortId:    dstPortId,
-				ChannelId: dstChanId,
+				ChannelId: dstChanID,
 			},
 			ConnectionHops: []string{srcConnectionId},
 			Version:        srcVersion,
@@ -593,7 +593,7 @@ func (cc *CosmosProvider) ChannelOpenTry(ctx context.Context, dstQueryProvider p
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanID, dstChanID, dstPortId string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -608,7 +608,7 @@ func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider p
 		return nil, err
 	}
 
-	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanId, dstPortId)
+	counterpartyChannelRes, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanID, dstPortId)
 	if err != nil {
 		return nil, err
 	}
@@ -619,8 +619,8 @@ func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider p
 
 	msg := &chantypes.MsgChannelOpenAck{
 		PortId:                srcPortId,
-		ChannelId:             srcChanId,
-		CounterpartyChannelId: dstChanId,
+		ChannelId:             srcChanID,
+		CounterpartyChannelId: dstChanID,
 		CounterpartyVersion:   counterpartyChannelRes.Channel.Version,
 		ProofTry:              counterpartyChannelRes.Proof,
 		ProofHeight:           counterpartyChannelRes.ProofHeight,
@@ -630,7 +630,7 @@ func (cc *CosmosProvider) ChannelOpenAck(ctx context.Context, dstQueryProvider p
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChanId string) ([]provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanID, dstPortId, dstChanID string) ([]provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -644,7 +644,7 @@ func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvid
 		return nil, err
 	}
 
-	counterpartyChanState, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanId, dstPortId)
+	counterpartyChanState, err := dstQueryProvider.QueryChannel(ctx, cph, dstChanID, dstPortId)
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvid
 
 	msg := &chantypes.MsgChannelOpenConfirm{
 		PortId:      srcPortId,
-		ChannelId:   srcChanId,
+		ChannelId:   srcChanID,
 		ProofAck:    counterpartyChanState.Proof,
 		ProofHeight: counterpartyChanState.ProofHeight,
 		Signer:      acc,
@@ -664,7 +664,7 @@ func (cc *CosmosProvider) ChannelOpenConfirm(ctx context.Context, dstQueryProvid
 	return []provider.RelayerMessage{updateMsg, NewCosmosMessage(msg)}, nil
 }
 
-func (cc *CosmosProvider) ChannelCloseInit(srcPortId, srcChanId string) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelCloseInit(srcPortId, srcChanID string) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -675,19 +675,19 @@ func (cc *CosmosProvider) ChannelCloseInit(srcPortId, srcChanId string) (provide
 
 	msg := &chantypes.MsgChannelCloseInit{
 		PortId:    srcPortId,
-		ChannelId: srcChanId,
+		ChannelId: srcChanID,
 		Signer:    acc,
 	}
 
 	return NewCosmosMessage(msg), nil
 }
 
-func (cc *CosmosProvider) ChannelCloseConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dsth int64, dstChanId, dstPortId, srcPortId, srcChanId string) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) ChannelCloseConfirm(ctx context.Context, dstQueryProvider provider.QueryProvider, dsth int64, dstChanID, dstPortId, srcPortId, srcChanID string) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
 	)
-	dstChanResp, err := dstQueryProvider.QueryChannel(ctx, dsth, dstChanId, dstPortId)
+	dstChanResp, err := dstQueryProvider.QueryChannel(ctx, dsth, dstChanID, dstPortId)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (cc *CosmosProvider) ChannelCloseConfirm(ctx context.Context, dstQueryProvi
 
 	msg := &chantypes.MsgChannelCloseConfirm{
 		PortId:      srcPortId,
-		ChannelId:   srcChanId,
+		ChannelId:   srcChanID,
 		ProofInit:   dstChanResp.Proof,
 		ProofHeight: dstChanResp.ProofHeight,
 		Signer:      acc,
@@ -800,7 +800,7 @@ func (cc *CosmosProvider) InjectTrustedFields(ctx context.Context, header ibcexp
 
 // MsgRelayAcknowledgement constructs the MsgAcknowledgement which is to be sent to the sending chain.
 // The counterparty represents the receiving chain where the acknowledgement would be stored.
-func (cc *CosmosProvider) MsgRelayAcknowledgement(ctx context.Context, dst provider.ChainProvider, dstChanId, dstPortId, srcChanId, srcPortId string, dsth int64, packet provider.RelayPacket) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) MsgRelayAcknowledgement(ctx context.Context, dst provider.ChainProvider, dstChanID, dstPortId, srcChanID, srcPortId string, dsth int64, packet provider.RelayPacket) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -814,7 +814,7 @@ func (cc *CosmosProvider) MsgRelayAcknowledgement(ctx context.Context, dst provi
 		return nil, err
 	}
 
-	ackRes, err := dst.QueryPacketAcknowledgement(ctx, dsth, dstChanId, dstPortId, packet.Seq())
+	ackRes, err := dst.QueryPacketAcknowledgement(ctx, dsth, dstChanID, dstPortId, packet.Seq())
 	switch {
 	case err != nil:
 		return nil, err
@@ -827,9 +827,9 @@ func (cc *CosmosProvider) MsgRelayAcknowledgement(ctx context.Context, dst provi
 			Packet: chantypes.Packet{
 				Sequence:           packet.Seq(),
 				SourcePort:         srcPortId,
-				SourceChannel:      srcChanId,
+				SourceChannel:      srcChanID,
 				DestinationPort:    dstPortId,
-				DestinationChannel: dstChanId,
+				DestinationChannel: dstChanID,
 				Data:               packet.Data(),
 				TimeoutHeight:      packet.Timeout(),
 				TimeoutTimestamp:   packet.TimeoutStamp(),
@@ -845,7 +845,7 @@ func (cc *CosmosProvider) MsgRelayAcknowledgement(ctx context.Context, dst provi
 }
 
 // MsgTransfer creates a new transfer message
-func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcPortId, srcChanId string, timeoutHeight, timeoutTimestamp uint64) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcPortId, srcChanID string, timeoutHeight, timeoutTimestamp uint64) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -859,7 +859,7 @@ func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcP
 	if timeoutHeight == 0 {
 		msg = &transfertypes.MsgTransfer{
 			SourcePort:       srcPortId,
-			SourceChannel:    srcChanId,
+			SourceChannel:    srcChanID,
 			Token:            amount,
 			Sender:           acc,
 			Receiver:         dstAddr,
@@ -870,7 +870,7 @@ func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcP
 
 		msg = &transfertypes.MsgTransfer{
 			SourcePort:    srcPortId,
-			SourceChannel: srcChanId,
+			SourceChannel: srcChanID,
 			Token:         amount,
 			Sender:        acc,
 			Receiver:      dstAddr,
@@ -888,7 +888,7 @@ func (cc *CosmosProvider) MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcP
 // MsgRelayTimeout constructs the MsgTimeout which is to be sent to the sending chain.
 // The counterparty represents the receiving chain where the receipts would have been
 // stored.
-func (cc *CosmosProvider) MsgRelayTimeout(ctx context.Context, dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) MsgRelayTimeout(ctx context.Context, dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanID, dstPortId, srcChanID, srcPortId string) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -897,7 +897,7 @@ func (cc *CosmosProvider) MsgRelayTimeout(ctx context.Context, dst provider.Chai
 		return nil, err
 	}
 
-	recvRes, err := dst.QueryPacketReceipt(ctx, dsth, dstChanId, dstPortId, packet.Seq())
+	recvRes, err := dst.QueryPacketReceipt(ctx, dsth, dstChanID, dstPortId, packet.Seq())
 	switch {
 	case err != nil:
 		return nil, err
@@ -910,9 +910,9 @@ func (cc *CosmosProvider) MsgRelayTimeout(ctx context.Context, dst provider.Chai
 			Packet: chantypes.Packet{
 				Sequence:           packet.Seq(),
 				SourcePort:         srcPortId,
-				SourceChannel:      srcChanId,
+				SourceChannel:      srcChanID,
 				DestinationPort:    dstPortId,
-				DestinationChannel: dstChanId,
+				DestinationChannel: dstChanID,
 				Data:               packet.Data(),
 				TimeoutHeight:      packet.Timeout(),
 				TimeoutTimestamp:   packet.TimeoutStamp(),
@@ -929,7 +929,7 @@ func (cc *CosmosProvider) MsgRelayTimeout(ctx context.Context, dst provider.Chai
 
 // MsgRelayRecvPacket constructs the MsgRecvPacket which is to be sent to the receiving chain.
 // The counterparty represents the sending chain where the packet commitment would be stored.
-func (cc *CosmosProvider) MsgRelayRecvPacket(ctx context.Context, dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
+func (cc *CosmosProvider) MsgRelayRecvPacket(ctx context.Context, dst provider.ChainProvider, dsth int64, packet provider.RelayPacket, dstChanID, dstPortId, srcChanID, srcPortId string) (provider.RelayerMessage, error) {
 	var (
 		acc string
 		err error
@@ -938,7 +938,7 @@ func (cc *CosmosProvider) MsgRelayRecvPacket(ctx context.Context, dst provider.C
 		return nil, err
 	}
 
-	comRes, err := dst.QueryPacketCommitment(ctx, dsth, dstChanId, dstPortId, packet.Seq())
+	comRes, err := dst.QueryPacketCommitment(ctx, dsth, dstChanID, dstPortId, packet.Seq())
 	switch {
 	case err != nil:
 		return nil, err
@@ -951,9 +951,9 @@ func (cc *CosmosProvider) MsgRelayRecvPacket(ctx context.Context, dst provider.C
 			Packet: chantypes.Packet{
 				Sequence:           packet.Seq(),
 				SourcePort:         dstPortId,
-				SourceChannel:      dstChanId,
+				SourceChannel:      dstChanID,
 				DestinationPort:    srcPortId,
-				DestinationChannel: srcChanId,
+				DestinationChannel: srcChanID,
 				Data:               packet.Data(),
 				TimeoutHeight:      packet.Timeout(),
 				TimeoutTimestamp:   packet.TimeoutStamp(),
@@ -968,8 +968,8 @@ func (cc *CosmosProvider) MsgRelayRecvPacket(ctx context.Context, dst provider.C
 }
 
 // RelayPacketFromSequence relays a packet with a given seq on src and returns recvPacket msgs, timeoutPacketmsgs and error
-func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst provider.ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId string) (provider.RelayerMessage, provider.RelayerMessage, error) {
-	txs, err := cc.QueryTxs(ctx, 1, 1000, rcvPacketQuery(srcChanId, int(seq)))
+func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst provider.ChainProvider, srch, dsth, seq uint64, dstChanID, dstPortId, dstClientId, srcChanID, srcPortId, srcClientId string) (provider.RelayerMessage, provider.RelayerMessage, error) {
+	txs, err := cc.QueryTxs(ctx, 1, 1000, rcvPacketQuery(srcChanID, int(seq)))
 	switch {
 	case err != nil:
 		return nil, nil, err
@@ -979,7 +979,7 @@ func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst 
 		return nil, nil, fmt.Errorf("more than one transaction returned with query")
 	}
 
-	rcvPackets, timeoutPackets, err := cc.relayPacketsFromResultTx(ctx, src, dst, int64(dsth), txs[0], dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId)
+	rcvPackets, timeoutPackets, err := cc.relayPacketsFromResultTx(ctx, src, dst, int64(dsth), txs[0], dstChanID, dstPortId, dstClientId, srcChanID, srcPortId, srcClientId)
 	switch {
 	case err != nil:
 		return nil, nil, err
@@ -995,7 +995,7 @@ func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst 
 			return nil, nil, fmt.Errorf("wrong sequence: expected(%d) got(%d)", seq, pkt.Seq())
 		}
 
-		packet, err := dst.MsgRelayRecvPacket(ctx, src, int64(srch), pkt, srcChanId, srcPortId, dstChanId, dstPortId)
+		packet, err := dst.MsgRelayRecvPacket(ctx, src, int64(srch), pkt, srcChanID, srcPortId, dstChanID, dstPortId)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1009,7 +1009,7 @@ func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst 
 			return nil, nil, fmt.Errorf("wrong sequence: expected(%d) got(%d)", seq, pkt.Seq())
 		}
 
-		timeout, err := src.MsgRelayTimeout(ctx, dst, int64(dsth), pkt, dstChanId, dstPortId, srcChanId, srcPortId)
+		timeout, err := src.MsgRelayTimeout(ctx, dst, int64(dsth), pkt, dstChanID, dstPortId, srcChanID, srcPortId)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1020,8 +1020,8 @@ func (cc *CosmosProvider) RelayPacketFromSequence(ctx context.Context, src, dst 
 }
 
 // AcknowledgementFromSequence relays an acknowledgement with a given seq on src, source is the sending chain, destination is the receiving chain
-func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst provider.ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (provider.RelayerMessage, error) {
-	txs, err := dst.QueryTxs(ctx, 1, 1000, ackPacketQuery(dstChanId, int(seq)))
+func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst provider.ChainProvider, dsth, seq uint64, dstChanID, dstPortId, srcChanID, srcPortId string) (provider.RelayerMessage, error) {
+	txs, err := dst.QueryTxs(ctx, 1, 1000, ackPacketQuery(dstChanID, int(seq)))
 	switch {
 	case err != nil:
 		return nil, err
@@ -1031,7 +1031,7 @@ func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst p
 		return nil, fmt.Errorf("more than one transaction returned with query")
 	}
 
-	acks, err := acknowledgementsFromResultTx(dstChanId, dstPortId, srcChanId, srcPortId, txs[0])
+	acks, err := acknowledgementsFromResultTx(dstChanID, dstPortId, srcChanID, srcPortId, txs[0])
 	switch {
 	case err != nil:
 		return nil, err
@@ -1044,7 +1044,7 @@ func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst p
 		if seq != ack.Seq() {
 			continue
 		}
-		msg, err := cc.MsgRelayAcknowledgement(ctx, dst, dstChanId, dstPortId, srcChanId, srcPortId, int64(dsth), ack)
+		msg, err := cc.MsgRelayAcknowledgement(ctx, dst, dstChanID, dstPortId, srcChanID, srcPortId, int64(dsth), ack)
 		if err != nil {
 			return nil, err
 		}
@@ -1065,7 +1065,7 @@ func ackPacketQuery(channelID string, seq int) []string {
 
 // relayPacketsFromResultTx looks through the events in a *ctypes.ResultTx
 // and returns relayPackets with the appropriate data
-func (cc *CosmosProvider) relayPacketsFromResultTx(ctx context.Context, src, dst provider.ChainProvider, dsth int64, resp *provider.RelayerTxResponse, dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId string) ([]provider.RelayPacket, []provider.RelayPacket, error) {
+func (cc *CosmosProvider) relayPacketsFromResultTx(ctx context.Context, src, dst provider.ChainProvider, dsth int64, resp *provider.RelayerTxResponse, dstChanID, dstPortId, dstClientId, srcChanID, srcPortId, srcClientId string) ([]provider.RelayPacket, []provider.RelayPacket, error) {
 	var (
 		rcvPackets     []provider.RelayPacket
 		timeoutPackets []provider.RelayPacket
@@ -1081,12 +1081,12 @@ func (cc *CosmosProvider) relayPacketsFromResultTx(ctx context.Context, src, dst
 
 		switch event.AttributeKey {
 		case srcChanTag:
-			if event.AttributeValue != srcChanId {
+			if event.AttributeValue != srcChanID {
 				rp.pass = true
 				continue
 			}
 		case dstChanTag:
-			if event.AttributeValue != dstChanId {
+			if event.AttributeValue != dstChanID {
 				rp.pass = true
 				continue
 			}
@@ -1166,7 +1166,7 @@ func (cc *CosmosProvider) relayPacketsFromResultTx(ctx context.Context, src, dst
 
 // acknowledgementsFromResultTx looks through the events in a *ctypes.ResultTx and returns
 // relayPackets with the appropriate data
-func acknowledgementsFromResultTx(dstChanId, dstPortId, srcChanId, srcPortId string, resp *provider.RelayerTxResponse) ([]provider.RelayPacket, error) {
+func acknowledgementsFromResultTx(dstChanID, dstPortId, srcChanID, srcPortId string, resp *provider.RelayerTxResponse) ([]provider.RelayPacket, error) {
 	var ackPackets []provider.RelayPacket
 
 	rp := &relayMsgPacketAck{pass: false}
@@ -1179,12 +1179,12 @@ func acknowledgementsFromResultTx(dstChanId, dstPortId, srcChanId, srcPortId str
 
 		switch event.AttributeKey {
 		case srcChanTag:
-			if event.AttributeValue != srcChanId {
+			if event.AttributeValue != srcChanID {
 				rp.pass = true
 				continue
 			}
 		case dstChanTag:
-			if event.AttributeValue != dstChanId {
+			if event.AttributeValue != dstChanID {
 				rp.pass = true
 				continue
 			}
@@ -1343,9 +1343,9 @@ func (cc *CosmosProvider) AutoUpdateClient(ctx context.Context, dst provider.Cha
 
 	msgs := []provider.RelayerMessage{updateMsg}
 
-	res, success, err := cc.SendMessages(ctx, msgs)
+	res, success, err := cc.SendMessages(ctx, "", "", msgs)
 	if err != nil {
-		// cp.LogFailedTx(res, err, CosmosMsgs(msgs...))
+		// cp.LogFailedTx(res, "", "", err, CosmosMsgs(msgs...))
 		return 0, err
 	}
 	if !success {
@@ -1599,8 +1599,8 @@ func MustGetHeight(h ibcexported.Height) clienttypes.Height {
 
 // SendMessage attempts to sign, encode & send a RelayerMessage
 // This is used extensively in the relayer as an extension of the Provider interface
-func (cc *CosmosProvider) SendMessage(ctx context.Context, msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
-	return cc.SendMessages(ctx, []provider.RelayerMessage{msg})
+func (cc *CosmosProvider) SendMessage(ctx context.Context, srcChanID, dstChanID string, msg provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+	return cc.SendMessages(ctx, srcChanID, dstChanID, []provider.RelayerMessage{msg})
 }
 
 // SendMessages attempts to sign, encode, & send a slice of RelayerMessages
@@ -1610,7 +1610,7 @@ func (cc *CosmosProvider) SendMessage(ctx context.Context, msg provider.RelayerM
 // transaction will not return an error. If a transaction is successfully sent, the result of the execution
 // of that transaction will be logged. A boolean indicating if a transaction was successfully
 // sent and executed successfully is returned.
-func (cc *CosmosProvider) SendMessages(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+func (cc *CosmosProvider) SendMessages(ctx context.Context, srcChanID, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 	var resp *sdk.TxResponse
 
 	if err := retry.Do(func() error {
@@ -1719,11 +1719,11 @@ func (cc *CosmosProvider) SendMessages(ctx context.Context, msgs []provider.Rela
 	// NOTE: error is nil, logic should use the returned error to determine if the
 	// transaction was successfully executed.
 	if rlyResp.Code != 0 {
-		cc.LogFailedTx(rlyResp, nil, msgs)
+		cc.LogFailedTx(rlyResp, srcChanID, dstChanID, nil, msgs)
 		return rlyResp, false, fmt.Errorf("transaction failed with code: %d", resp.Code)
 	}
 
-	cc.LogSuccessTx(resp, msgs)
+	cc.LogSuccessTx(resp, srcChanID, dstChanID, msgs)
 	return rlyResp, true, nil
 }
 

--- a/relayer/provider/cosmos/relayer_packets.go
+++ b/relayer/provider/cosmos/relayer_packets.go
@@ -41,8 +41,8 @@ func (rp relayMsgTimeout) TimeoutStamp() uint64 {
 	return rp.timeoutStamp
 }
 
-func (rp relayMsgTimeout) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
-	dstRecvRes, err := dst.QueryPacketReceipt(ctx, int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+func (rp relayMsgTimeout) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanID, dstPortId string) error {
+	dstRecvRes, err := dst.QueryPacketReceipt(ctx, int64(queryHeight)-1, dstChanID, dstPortId, rp.seq)
 	switch {
 	case err != nil:
 		return err
@@ -54,7 +54,7 @@ func (rp relayMsgTimeout) FetchCommitResponse(ctx context.Context, dst provider.
 	}
 }
 
-func (rp relayMsgTimeout) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+func (rp relayMsgTimeout) Msg(src provider.ChainProvider, srcPortId, srcChanID, dstPortId, dstChanID string) (provider.RelayerMessage, error) {
 	if rp.dstRecvRes == nil {
 		return nil, fmt.Errorf("timeout packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
 	}
@@ -67,9 +67,9 @@ func (rp relayMsgTimeout) Msg(src provider.ChainProvider, srcPortId, srcChanId, 
 		Packet: chantypes.Packet{
 			Sequence:           rp.seq,
 			SourcePort:         srcPortId,
-			SourceChannel:      srcChanId,
+			SourceChannel:      srcChanID,
 			DestinationPort:    dstPortId,
-			DestinationChannel: dstChanId,
+			DestinationChannel: dstChanID,
 			Data:               rp.packetData,
 			TimeoutHeight:      rp.timeout,
 			TimeoutTimestamp:   rp.timeoutStamp,
@@ -120,8 +120,8 @@ func (rp relayMsgRecvPacket) TimeoutStamp() uint64 {
 	return rp.timeoutStamp
 }
 
-func (rp relayMsgRecvPacket) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
-	dstCommitRes, err := dst.QueryPacketCommitment(ctx, int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+func (rp relayMsgRecvPacket) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanID, dstPortId string) error {
+	dstCommitRes, err := dst.QueryPacketCommitment(ctx, int64(queryHeight)-1, dstChanID, dstPortId, rp.seq)
 	switch {
 	case err != nil:
 		return err
@@ -135,7 +135,7 @@ func (rp relayMsgRecvPacket) FetchCommitResponse(ctx context.Context, dst provid
 	}
 }
 
-func (rp relayMsgRecvPacket) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+func (rp relayMsgRecvPacket) Msg(src provider.ChainProvider, srcPortId, srcChanID, dstPortId, dstChanID string) (provider.RelayerMessage, error) {
 	if rp.dstComRes == nil {
 		return nil, fmt.Errorf("receive packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
 	}
@@ -148,9 +148,9 @@ func (rp relayMsgRecvPacket) Msg(src provider.ChainProvider, srcPortId, srcChanI
 		Packet: chantypes.Packet{
 			Sequence:           rp.seq,
 			SourcePort:         dstPortId,
-			SourceChannel:      dstChanId,
+			SourceChannel:      dstChanID,
 			DestinationPort:    srcPortId,
-			DestinationChannel: srcChanId,
+			DestinationChannel: srcChanID,
 			Data:               rp.packetData,
 			TimeoutHeight:      rp.timeout,
 			TimeoutTimestamp:   rp.timeoutStamp,
@@ -188,7 +188,7 @@ func (rp relayMsgPacketAck) TimeoutStamp() uint64 {
 	return rp.timeoutStamp
 }
 
-func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (provider.RelayerMessage, error) {
+func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanID, dstPortId, dstChanID string) (provider.RelayerMessage, error) {
 	if rp.dstComRes == nil {
 		return nil, fmt.Errorf("ack packet [%s]seq{%d} has no associated proofs", src.ChainId(), rp.seq)
 	}
@@ -202,9 +202,9 @@ func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanId
 		Packet: chantypes.Packet{
 			Sequence:           rp.seq,
 			SourcePort:         srcPortId,
-			SourceChannel:      srcChanId,
+			SourceChannel:      srcChanID,
 			DestinationPort:    dstPortId,
-			DestinationChannel: dstChanId,
+			DestinationChannel: dstChanID,
 			Data:               rp.packetData,
 			TimeoutHeight:      rp.timeout,
 			TimeoutTimestamp:   rp.timeoutStamp,
@@ -218,8 +218,8 @@ func (rp relayMsgPacketAck) Msg(src provider.ChainProvider, srcPortId, srcChanId
 	return NewCosmosMessage(msg), nil
 }
 
-func (rp relayMsgPacketAck) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error {
-	dstCommitRes, err := dst.QueryPacketAcknowledgement(ctx, int64(queryHeight)-1, dstChanId, dstPortId, rp.seq)
+func (rp relayMsgPacketAck) FetchCommitResponse(ctx context.Context, dst provider.ChainProvider, queryHeight uint64, dstChanID, dstPortId string) error {
+	dstCommitRes, err := dst.QueryPacketAcknowledgement(ctx, int64(queryHeight)-1, dstChanID, dstPortId, rp.seq)
 	switch {
 	case err != nil:
 		return err

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -94,22 +94,22 @@ type ChainProvider interface {
 	ConnectionOpenAck(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcConnId, dstClientId, dstConnId string) ([]RelayerMessage, error)
 	ConnectionOpenConfirm(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, dstConnId, srcClientId, srcConnId string) ([]RelayerMessage, error)
 	ChannelOpenInit(srcClientId, srcConnId, srcPortId, srcVersion, dstPortId string, order chantypes.Order, dstHeader ibcexported.Header) ([]RelayerMessage, error)
-	ChannelOpenTry(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanId, dstChanId, srcVersion, srcConnectionId, srcClientId string) ([]RelayerMessage, error)
-	ChannelOpenAck(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstChanId, dstPortId string) ([]RelayerMessage, error)
-	ChannelOpenConfirm(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanId, dstPortId, dstChannId string) ([]RelayerMessage, error)
-	ChannelCloseInit(srcPortId, srcChanId string) (RelayerMessage, error)
-	ChannelCloseConfirm(ctx context.Context, dstQueryProvider QueryProvider, dsth int64, dstChanId, dstPortId, srcPortId, srcChanId string) (RelayerMessage, error)
+	ChannelOpenTry(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcPortId, dstPortId, srcChanID, dstChanID, srcVersion, srcConnectionId, srcClientId string) ([]RelayerMessage, error)
+	ChannelOpenAck(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanID, dstChanID, dstPortId string) ([]RelayerMessage, error)
+	ChannelOpenConfirm(ctx context.Context, dstQueryProvider QueryProvider, dstHeader ibcexported.Header, srcClientId, srcPortId, srcChanID, dstPortId, dstChannId string) ([]RelayerMessage, error)
+	ChannelCloseInit(srcPortId, srcChanID string) (RelayerMessage, error)
+	ChannelCloseConfirm(ctx context.Context, dstQueryProvider QueryProvider, dsth int64, dstChanID, dstPortId, srcPortId, srcChanID string) (RelayerMessage, error)
 
-	MsgRelayAcknowledgement(ctx context.Context, dst ChainProvider, dstChanId, dstPortId, srcChanId, srcPortId string, dsth int64, packet RelayPacket) (RelayerMessage, error)
-	MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcPortId, srcChanId string, timeoutHeight, timeoutTimestamp uint64) (RelayerMessage, error)
-	MsgRelayTimeout(ctx context.Context, dst ChainProvider, dsth int64, packet RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
-	MsgRelayRecvPacket(ctx context.Context, dst ChainProvider, dsth int64, packet RelayPacket, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
+	MsgRelayAcknowledgement(ctx context.Context, dst ChainProvider, dstChanID, dstPortId, srcChanID, srcPortId string, dsth int64, packet RelayPacket) (RelayerMessage, error)
+	MsgTransfer(amount sdk.Coin, dstChainId, dstAddr, srcPortId, srcChanID string, timeoutHeight, timeoutTimestamp uint64) (RelayerMessage, error)
+	MsgRelayTimeout(ctx context.Context, dst ChainProvider, dsth int64, packet RelayPacket, dstChanID, dstPortId, srcChanID, srcPortId string) (RelayerMessage, error)
+	MsgRelayRecvPacket(ctx context.Context, dst ChainProvider, dsth int64, packet RelayPacket, dstChanID, dstPortId, srcChanID, srcPortId string) (RelayerMessage, error)
 	MsgUpgradeClient(srcClientId string, consRes *clienttypes.QueryConsensusStateResponse, clientRes *clienttypes.QueryClientStateResponse) (RelayerMessage, error)
-	RelayPacketFromSequence(ctx context.Context, src, dst ChainProvider, srch, dsth, seq uint64, dstChanId, dstPortId, dstClientId, srcChanId, srcPortId, srcClientId string) (RelayerMessage, RelayerMessage, error)
-	AcknowledgementFromSequence(ctx context.Context, dst ChainProvider, dsth, seq uint64, dstChanId, dstPortId, srcChanId, srcPortId string) (RelayerMessage, error)
+	RelayPacketFromSequence(ctx context.Context, src, dst ChainProvider, srch, dsth, seq uint64, dstChanID, dstPortId, dstClientId, srcChanID, srcPortId, srcClientId string) (RelayerMessage, RelayerMessage, error)
+	AcknowledgementFromSequence(ctx context.Context, dst ChainProvider, dsth, seq uint64, dstChanID, dstPortId, srcChanID, srcPortId string) (RelayerMessage, error)
 
-	SendMessage(ctx context.Context, msg RelayerMessage) (*RelayerTxResponse, bool, error)
-	SendMessages(ctx context.Context, msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
+	SendMessage(ctx context.Context, srcChanID, dstChanID string, msg RelayerMessage) (*RelayerTxResponse, bool, error)
+	SendMessages(ctx context.Context, srcChanID, dstChanID string, msgs []RelayerMessage) (*RelayerTxResponse, bool, error)
 
 	GetLightSignedHeaderAtHeight(ctx context.Context, h int64) (ibcexported.Header, error)
 	GetIBCUpdateHeader(ctx context.Context, srch int64, dst ChainProvider, dstClientId string) (ibcexported.Header, error)
@@ -181,8 +181,8 @@ type QueryProvider interface {
 }
 
 type RelayPacket interface {
-	Msg(src ChainProvider, srcPortId, srcChanId, dstPortId, dstChanId string) (RelayerMessage, error)
-	FetchCommitResponse(ctx context.Context, dst ChainProvider, queryHeight uint64, dstChanId, dstPortId string) error
+	Msg(src ChainProvider, srcPortId, srcChanID, dstPortId, dstChanID string) (RelayerMessage, error)
+	FetchCommitResponse(ctx context.Context, dst ChainProvider, queryHeight uint64, dstChanID, dstPortId string) error
 	Data() []byte
 	Seq() uint64
 	Timeout() clienttypes.Height

--- a/relayer/relaymsgs_test.go
+++ b/relayer/relaymsgs_test.go
@@ -62,7 +62,7 @@ func TestRelayMsgs_Send_Success(t *testing.T) {
 	var srcSent []provider.RelayerMessage
 	src := relayer.RelayMsgSender{
 		ChainID: "src",
-		SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+		SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 			srcSent = append(srcSent, msgs...)
 			return nil, true, nil
 		},
@@ -71,7 +71,7 @@ func TestRelayMsgs_Send_Success(t *testing.T) {
 	var dstSent []provider.RelayerMessage
 	dst := relayer.RelayMsgSender{
 		ChainID: "dst",
-		SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+		SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 			dstSent = append(dstSent, msgs...)
 			return nil, true, nil
 		},
@@ -150,7 +150,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		srcErr := fmt.Errorf("source error")
 		src := relayer.RelayMsgSender{
 			ChainID: "src",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				return nil, false, srcErr
 			},
 		}
@@ -158,7 +158,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		dstErr := fmt.Errorf("dest error")
 		dst := relayer.RelayMsgSender{
 			ChainID: "dst",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				return nil, false, dstErr
 			},
 		}
@@ -183,7 +183,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		var srcCalls int
 		src := relayer.RelayMsgSender{
 			ChainID: "src",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				srcCalls++
 				switch srcCalls {
 				case 1:
@@ -200,7 +200,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		var dstCalls int
 		dst := relayer.RelayMsgSender{
 			ChainID: "dst",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				dstCalls++
 				switch dstCalls {
 				case 1:
@@ -237,7 +237,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		var srcCalls int
 		src := relayer.RelayMsgSender{
 			ChainID: "src",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				srcCalls++
 				switch srcCalls {
 				case 1:
@@ -254,7 +254,7 @@ func TestRelayMsgs_Send_Errors(t *testing.T) {
 		var dstCalls int
 		dst := relayer.RelayMsgSender{
 			ChainID: "dst",
-			SendMessages: func(ctx context.Context, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
+			SendMessages: func(ctx context.Context, srcChanID string, dstChanID string, msgs []provider.RelayerMessage) (*provider.RelayerTxResponse, bool, error) {
 				dstCalls++
 				switch dstCalls {
 				case 1:


### PR DESCRIPTION
fixes #694 

Plumbing through the channel ids to SendMessages/SendMessage and Success/Fail log messages..

- [ ] TODO: omit channel-ids when empty.
- [ ] TODO: Consider adding a SendPackets form of SendMessages.. since only Packets are sent along Channels?