### PR TITLE
Zero state bug

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -892,10 +892,7 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
-			if err != nil {
-				return err
-			}
+			sp := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
 
 			out, err := json.Marshal(sp)
 			if err != nil {
@@ -947,10 +944,7 @@ $ %s query unrelayed-acks demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
-			if err != nil {
-				return err
-			}
+			sp := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
 
 			out, err := json.Marshal(sp)
 			if err != nil {

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -727,10 +727,7 @@ $ %s tx relay-pkts demo-path channel-0`,
 				return err
 			}
 
-			sp, err := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
-			if err != nil {
-				return err
-			}
+			sp := relayer.UnrelayedSequences(cmd.Context(), c[src], c[dst], channel)
 
 			if err = relayer.RelayPackets(cmd.Context(), a.Log, c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
 				return err
@@ -777,10 +774,7 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 
 			// sp.Src contains all sequences acked on SRC but acknowledgement not processed on DST
 			// sp.Dst contains all sequences acked on DST but acknowledgement not processed on SRC
-			sp, err := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
-			if err != nil {
-				return err
-			}
+			sp := relayer.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], channel)
 
 			if err = relayer.RelayAcknowledgements(cmd.Context(), a.Log, c[src], c[dst], sp, maxTxSize, maxMsgLength, channel); err != nil {
 				return err

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -14,15 +14,16 @@ import (
 )
 
 // UnrelayedSequences returns the unrelayed sequence numbers between two chains
-func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) *RelaySequences {
+func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) RelaySequences {
 	var (
 		srcPacketSeq = []uint64{}
 		dstPacketSeq = []uint64{}
-		rs           = &RelaySequences{Src: []uint64{}, Dst: []uint64{}}
+		rs           = RelaySequences{Src: []uint64{}, Dst: []uint64{}}
 	)
 
 	srch, dsth, err := QueryLatestHeights(ctx, src, dst)
 	if err != nil {
+		src.log.Error("Error querying latest heights", zap.Error(err))
 		return rs
 	}
 
@@ -241,15 +242,16 @@ func UnrelayedSequences(ctx context.Context, src, dst *Chain, srcChannel *chanty
 }
 
 // UnrelayedAcknowledgements returns the unrelayed sequence numbers between two chains
-func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) *RelaySequences {
+func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel *chantypes.IdentifiedChannel) RelaySequences {
 	var (
 		srcPacketSeq = []uint64{}
 		dstPacketSeq = []uint64{}
-		rs           = &RelaySequences{Src: []uint64{}, Dst: []uint64{}}
+		rs           = RelaySequences{Src: []uint64{}, Dst: []uint64{}}
 	)
 
 	srch, dsth, err := QueryLatestHeights(ctx, src, dst)
 	if err != nil {
+		src.log.Error("Error querying latest heights", zap.Error(err))
 		return rs
 	}
 
@@ -276,7 +278,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			src.log.Error(
-				"Failed to query packet commitments after max attempts",
+				"Failed to query packet acknowledgement commitments after max attempts",
 				zap.String("channel_id", srcChannel.ChannelId),
 				zap.String("port_id", srcChannel.PortId),
 				zap.Uint("attempts", RtyAttNum),
@@ -309,7 +311,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
 		})); err != nil {
 			dst.log.Error(
-				"Failed to query packet commitments after max attempts",
+				"Failed to query packet acknowledgement commitments after max attempts",
 				zap.String("channel_id", srcChannel.Counterparty.ChannelId),
 				zap.String("port_id", srcChannel.Counterparty.PortId),
 				zap.Uint("attempts", RtyAttNum),
@@ -389,7 +391,7 @@ func (rs *RelaySequences) Empty() bool {
 }
 
 // RelayAcknowledgements creates transactions to relay acknowledgements from src to dst and from dst to src
-func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *RelaySequences, maxTxSize, maxMsgLength uint64, srcChannel *chantypes.IdentifiedChannel) error {
+func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain, sp RelaySequences, maxTxSize, maxMsgLength uint64, srcChannel *chantypes.IdentifiedChannel) error {
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []provider.RelayerMessage{},
@@ -514,7 +516,7 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 }
 
 // RelayPackets creates transactions to relay packets from src to dst and from dst to src
-func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp *RelaySequences, maxTxSize, maxMsgLength uint64, srcChannel *chantypes.IdentifiedChannel) error {
+func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp RelaySequences, maxTxSize, maxMsgLength uint64, srcChannel *chantypes.IdentifiedChannel) error {
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []provider.RelayerMessage{},

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -348,6 +348,7 @@ func UnrelayedAcknowledgements(ctx context.Context, src, dst *Chain, srcChannel 
 	}
 
 	if len(dstPacketSeq) > 0 {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			// Query all packets sent by dst that have been received by src

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -208,16 +208,7 @@ func relayUnrelayedPacketsAndAcks(ctx context.Context, log *zap.Logger, wg *sync
 // Otherwise, it logs the errors and returns false.
 func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
 	// Fetch any unrelayed sequences depending on the channel order
-	sp, err := UnrelayedSequences(ctx, src, dst, srcChannel)
-	if err != nil {
-		src.log.Warn(
-			"Error retrieving unrelayed sequences",
-			zap.String("src_chain_id", src.ChainID()),
-			zap.String("src_channel_id", srcChannel.ChannelId),
-			zap.Error(err),
-		)
-		return false
-	}
+	sp := UnrelayedSequences(ctx, src, dst, srcChannel)
 
 	// If there are no unrelayed packets, stop early.
 	if sp.Empty() {
@@ -287,16 +278,7 @@ func relayUnrelayedPackets(ctx context.Context, log *zap.Logger, src, dst *Chain
 // Otherwise, it logs the errors and returns false.
 func relayUnrelayedAcks(ctx context.Context, log *zap.Logger, src, dst *Chain, maxTxSize, maxMsgLength uint64, srcChannel *types.IdentifiedChannel) bool {
 	// Fetch any unrelayed acks depending on the channel order
-	ap, err := UnrelayedAcknowledgements(ctx, src, dst, srcChannel)
-	if err != nil {
-		log.Warn(
-			"Error retrieving unrelayed acknowledgements",
-			zap.String("src_chain_id", src.ChainID()),
-			zap.String("src_channel_id", srcChannel.ChannelId),
-			zap.Error(err),
-		)
-		return false
-	}
+	ap := UnrelayedAcknowledgements(ctx, src, dst, srcChannel)
 
 	// If there are no unrelayed acks, stop early.
 	if ap.Empty() {


### PR DESCRIPTION
Relay packet flows in one direction even if there are errors with the other direction.

Replaces error groups with wait groups so that relaying can proceed for packet flows from src to dst if there are errors for queries from dst to src, for example.

Reason for this change:
- We are using the ibc-go imported module: `chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"`
- `chantypes.QueryClient` has a method `PacketAcknowledgements` which we are using to query the packet commitments on the destination chain in order to assemble `MsgAcknowledgement` messages to send back to the source chain.
- The `PacketAcknowledgements` query will return `nil` error, and also `nil` response, if no `MsgTransfer` messages have been committed to the chain.
- This condition was being transformed into a custom error in the relayer, `errQueryUnrelayedPacketAcks`.
- The relayer method making these queries, `UnrelayedAcknowledgements`, was using an error group to make this query on both chains. If this error occurred on one chain involved in the path, it would return the error and refuse to continue with a success for the other chain.
- This brought up the idea of replacing the error groups in both `UnrelayedAcknowledgements` and `UnrelayedSequences` with wait groups, and only proceeding for the non-error condition packet flows. This allows packet flows in one direction to continue to be processed even if the other chain has an error with one of the queries throughout the process.
- The `errQueryUnrelayedPacketAcks` is still a valid error, since we cannot query packet commitments on a chain that does not have any `MsgTransfer` messages sent yet. But, it does not need to halt the processing of the packet flows in the opposite direction.