### PR TITLE
Add local dockerfile for non-buildkit builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:alpine as BUILD
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine as BUILD
 
 WORKDIR /relayer
 

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:alpine as BUILD
+
+WORKDIR /relayer
+
+# Copy the files from host
+COPY . .
+
+# Update and install needed deps prioir to installing the binary.
+RUN apk update && \
+  apk --no-cache add make git && \
+  make install
+
+FROM alpine:latest
+
+ENV RELAYER /relayer
+
+RUN addgroup rlyuser && adduser -S -G rlyuser rlyuser -h "$RELAYER"
+
+USER rlyuser
+
+# Define working directory
+WORKDIR $RELAYER
+
+# Copy binary from BUILD
+COPY --from=BUILD /go/bin/rly /usr/bin/rly
+
+ENTRYPOINT ["/usr/bin/rly"]

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as BUILD
+FROM golang:1.18-alpine as BUILD
 
 WORKDIR /relayer
 


### PR DESCRIPTION
Non-buildkit docker builds complain about the `--platform=$BUILDPLATFORM` build arg, even if you provide `BUILDPLATFORM` as an arg and declare it as an arg prior to the `FROM` line.

Since this is required for cross-arch builds, but incompatible with local docker builds, bringing back the previous non-cross-arch Dockerfile as `local.Dockerfile`