### PR TITLE
Remove duplicate package import & fix var name/package name collision

### DIFF
--- a/relayer/chains/cosmos/sdk_helper.go
+++ b/relayer/chains/cosmos/sdk_helper.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/client"
 	cosmosClient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -25,7 +24,7 @@ import (
 type Codec struct {
 	InterfaceRegistry types.InterfaceRegistry
 	Marshaler         codec.Codec
-	TxConfig          client.TxConfig
+	TxConfig          cosmosClient.TxConfig
 	Amino             *codec.LegacyAmino
 }
 
@@ -77,15 +76,15 @@ func getCosmosClient(rpcAddress string, chainID string, input io.Reader, output 
 	if err != nil {
 		return nil, err
 	}
-	codec := makeCodec([]module.AppModuleBasic{})
+	cdc := makeCodec([]module.AppModuleBasic{})
 	return &cosmosClient.Context{
 		Client:            client,
 		ChainID:           chainID,
 		Input:             input,
 		Output:            output,
-		TxConfig:          codec.TxConfig,
-		Codec:             codec.Marshaler,
-		InterfaceRegistry: codec.InterfaceRegistry,
+		TxConfig:          cdc.TxConfig,
+		Codec:             cdc.Marshaler,
+		InterfaceRegistry: cdc.InterfaceRegistry,
 		OutputFormat:      "json",
 	}, nil
 }

--- a/relayer/chains/cosmos/sdk_helper.go
+++ b/relayer/chains/cosmos/sdk_helper.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	cosmosClient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
@@ -24,7 +24,7 @@ import (
 type Codec struct {
 	InterfaceRegistry types.InterfaceRegistry
 	Marshaler         codec.Codec
-	TxConfig          cosmosClient.TxConfig
+	TxConfig          client.TxConfig
 	Amino             *codec.LegacyAmino
 }
 
@@ -71,14 +71,14 @@ func newClient(addr string) (rpcclient.Client, error) {
 	return rpcClient, nil
 }
 
-func getCosmosClient(rpcAddress string, chainID string, input io.Reader, output io.Writer) (*cosmosClient.Context, error) {
-	client, err := newClient(rpcAddress)
+func getCosmosClient(rpcAddress string, chainID string, input io.Reader, output io.Writer) (*client.Context, error) {
+	c, err := newClient(rpcAddress)
 	if err != nil {
 		return nil, err
 	}
 	cdc := makeCodec([]module.AppModuleBasic{})
-	return &cosmosClient.Context{
-		Client:            client,
+	return &client.Context{
+		Client:            c,
 		ChainID:           chainID,
 		Input:             input,
 		Output:            output,


### PR DESCRIPTION
Addresses staticcheck ST1019, duplicate package import.

Also addresses a name collision between a local variable and a package name.