### PR TITLE
Use pointer receiver type & return using a type conversion vs. struct literal

### DIFF
--- a/relayer/processor/event_processor.go
+++ b/relayer/processor/event_processor.go
@@ -55,11 +55,7 @@ func (ep EventProcessorBuilder) Build() EventProcessor {
 		chainProcessor.SetPathProcessors(pathProcessorsForThisChain)
 	}
 
-	return EventProcessor{
-		chainProcessors:     ep.chainProcessors,
-		initialBlockHistory: ep.initialBlockHistory,
-		pathProcessors:      ep.pathProcessors,
-	}
+	return EventProcessor(ep)
 }
 
 // Run is a blocking call that launches all provided PathProcessors and ChainProcessors in parallel.

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -147,11 +147,11 @@ type PathEndProcessedResponse struct {
 	ToDeleteDst map[string][]uint64
 }
 
-func (m PathEndProcessedResponse) appendPacket(sequence uint64, msgRecvPacket provider.RelayerMessage) {
+func (m *PathEndProcessedResponse) appendPacket(sequence uint64, msgRecvPacket provider.RelayerMessage) {
 	m.UnrelayedPackets = append(m.UnrelayedPackets, IBCMessageWithSequence{Sequence: sequence, Message: msgRecvPacket})
 }
 
-func (m PathEndProcessedResponse) appendAcknowledgement(sequence uint64, msgAcknowledgement provider.RelayerMessage) {
+func (m *PathEndProcessedResponse) appendAcknowledgement(sequence uint64, msgAcknowledgement provider.RelayerMessage) {
 	m.UnrelayedAcknowledgements = append(m.UnrelayedAcknowledgements, IBCMessageWithSequence{Sequence: sequence, Message: msgAcknowledgement})
 }
 


### PR DESCRIPTION
Addresses staticcheck S1016, should convert var using type conversion vs. struct literal.
Addresses staticcheck SA4005, ineffective assignment to a structs field.