### PR TITLE
Use `strings.EqualFold`

### DIFF
--- a/helpers/query.go
+++ b/helpers/query.go
@@ -42,7 +42,7 @@ func QueryBalance(ctx context.Context, chain *relayer.Chain, address string, sho
 		}
 
 		for i, d := range dts {
-			if strings.ToLower(c.Denom) == strings.ToLower(d.IBCDenom()) {
+			if strings.EqualFold(c.Denom, d.IBCDenom()) {
 				out = append(out, sdk.Coin{Denom: d.GetFullDenomPath(), Amount: c.Amount})
 				break
 			}


### PR DESCRIPTION
Addresses staticcheck SA6005, should use `strings.EqualFold` instead of testing string equality with a call to `strings.ToLower`