### PR TITLE
Documentation for updated config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Additional information on how IBC works can be found [here](https://ibc.cosmos.n
 
 </div>
 
+
+**If you are updating the relayer from any version prior to `v2.0.0-rc1`, your current config file is not compatible. See: [config_migration](docs/config_migration.md)
+
 ---
 
 ## Table Of Contents
@@ -134,6 +137,8 @@ Additional information on how IBC works can be found [here](https://ibc.cosmos.n
 7. **Configure path meta-data in config file.**
    <br>
    We have the chain meta-data configured, now we need path meta-data. For more info on `path` terminology visit [here](docs/troubleshooting.md).  
+   >NOTE: Thinking of chains in the config as "source" and "destination" can be confusing. Be aware that most path are bi-directional.
+
    <br>
    `rly paths fetch` will check for the relevant `path.json` files for ALL configured chains in your config file.  
    The path meta-data is queried from the [interchain](https://github.com/cosmos/relayer/tree/main/interchain) directory.
@@ -178,6 +183,7 @@ Additional information on how IBC works can be found [here](https://ibc.cosmos.n
    ```
    
    >Because two channels between chains are tightly coupled, there is no need to specify the dst channels.
+   >If you only know the "dst" channel-ID you can query the "src" channel-ID by running: `rly q channel <dst_chain_name> <dst_channel_id> <port> | jq '.channel.counterparty.channel_id'`
 
 10. **Finally, we start the relayer on the desired path.**
 

--- a/docs/config_migration.md
+++ b/docs/config_migration.md
@@ -1,0 +1,32 @@
+# Migrating old config files (prior to v2.0.0-rc1)
+
+Version v2.0.0-rc1 introduces a new config layout. Old config files will not be compatible. 
+
+To migrate, you will need to re-initialize your config file. Follow the steps below:
+
+1) Delete old config (assuming it's in default location).
+```sh
+ rm -r ~/.relayer/config
+```
+
+2) Re-init config.
+```sh
+rly config init
+```
+
+3) Add chains to relay for to the config. This fetches chain meta-data from `cosmos/chain-registry`. Example:
+```sh
+rly chains add cosmoshub osmosis juno
+```
+
+4) Auto configure path meta-data from `cosmos/chain-registry/_IBC` (you can optionally do this manually).
+```sh
+rly paths fetch
+```
+OPTIONAL: Manually add channel filters. See: [configure-channel-filter]https://github.com/cosmos/relayer#configure-the-channel-filter
+
+
+>NOTE: Naming of the auto-configured paths has changed to be less abbreviated. So for example "hubosmo" is now "cosmoshub-osmosis". These paths are bi-directional and only need to be added to the config once. So having both "hubosmo" and "osmohub" is not necessary, you just need "cosmoshub-osmosis" 
+
+
+As long as you do not delete `~/.relayer/config/keys/`, you will not have to restore your keys. 


### PR DESCRIPTION
Adds documentation on how to "migrate" the config file to the new chain_name mapping.