### PR TITLE
PathProcessor Connection and Channel handshake correlation

### DIFF
--- a/relayer/chains/cosmos/msg_handlers_channel_test.go
+++ b/relayer/chains/cosmos/msg_handlers_channel_test.go
@@ -37,11 +37,13 @@ func TestHandleChannelHandshake(t *testing.T) {
 
 	require.Len(t, ibcMessagesCache.ChannelHandshake, 1)
 
-	channelMessages, hasChannelKey := ibcMessagesCache.ChannelHandshake[channelKey]
-	require.True(t, hasChannelKey, "no messages cached for channel key")
-
-	_, hasChannelOpenInit := channelMessages[processor.MsgChannelOpenInit]
+	openInitMessages, hasChannelOpenInit := ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenInit]
 	require.True(t, hasChannelOpenInit, "no messages cached for MsgChannelOpenInit")
+
+	openInitMessage, hasOpenInitMessage := openInitMessages[channelKey]
+	require.True(t, hasOpenInitMessage, "no open init messages cached for channel key")
+
+	require.NotNil(t, openInitMessage)
 
 	ccp.handleMsgChannelOpenAck(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
 
@@ -50,16 +52,21 @@ func TestHandleChannelHandshake(t *testing.T) {
 
 	require.True(t, channelOpen, "channel should be marked open now")
 
-	channelMessages, hasChannelKey = ibcMessagesCache.ChannelHandshake[channelKey]
-	require.True(t, hasChannelKey, "no messages cached for channel key")
-
-	require.Len(t, channelMessages, 2)
-
-	_, hasChannelOpenInit = channelMessages[processor.MsgChannelOpenInit]
+	openInitMessages, hasChannelOpenInit = ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenInit]
 	require.True(t, hasChannelOpenInit, "no messages cached for MsgChannelOpenInit")
 
-	_, hasChannelOpenAck := channelMessages[processor.MsgChannelOpenAck]
+	openAckMessages, hasChannelOpenAck := ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenAck]
 	require.True(t, hasChannelOpenAck, "no messages cached for MsgChannelOpenAck")
+
+	openInitMessage, hasOpenInitMessage = openInitMessages[channelKey]
+	require.True(t, hasOpenInitMessage, "no open init messages cached for channel key")
+
+	require.NotNil(t, openInitMessage)
+
+	openAckMessage, hasOpenAckMessage := openAckMessages[channelKey]
+	require.True(t, hasOpenAckMessage, "no open ack messages cached for channel key")
+
+	require.NotNil(t, openAckMessage)
 }
 
 func TestHandleChannelHandshakeCounterparty(t *testing.T) {
@@ -92,11 +99,13 @@ func TestHandleChannelHandshakeCounterparty(t *testing.T) {
 
 	require.Len(t, ibcMessagesCache.ChannelHandshake, 1)
 
-	channelMessages, hasChannelKey := ibcMessagesCache.ChannelHandshake[channelKey]
-	require.True(t, hasChannelKey, "no messages cached for channel key")
-
-	_, hasChannelOpenTry := channelMessages[processor.MsgChannelOpenTry]
+	openTryMessages, hasChannelOpenTry := ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenTry]
 	require.True(t, hasChannelOpenTry, "no messages cached for MsgChannelOpenTry")
+
+	openTryMessage, hasOpenTryMessage := openTryMessages[channelKey]
+	require.True(t, hasOpenTryMessage, "no open try messages cached for channel key")
+
+	require.NotNil(t, openTryMessage)
 
 	ccp.handleMsgChannelOpenConfirm(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
 
@@ -105,14 +114,20 @@ func TestHandleChannelHandshakeCounterparty(t *testing.T) {
 
 	require.True(t, channelOpen, "channel should be marked open now")
 
-	channelMessages, hasChannelKey = ibcMessagesCache.ChannelHandshake[channelKey]
-	require.True(t, hasChannelKey, "no messages cached for channel key")
-
-	require.Len(t, channelMessages, 2)
-
-	_, hasChannelOpenTry = channelMessages[processor.MsgChannelOpenTry]
+	openTryMessages, hasChannelOpenTry = ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenTry]
 	require.True(t, hasChannelOpenTry, "no messages cached for MsgChannelOpenTry")
 
-	_, hasChannelOpenConfirm := channelMessages[processor.MsgChannelOpenConfirm]
+	openConfirmMessages, hasChannelOpenConfirm := ibcMessagesCache.ChannelHandshake[processor.MsgChannelOpenConfirm]
 	require.True(t, hasChannelOpenConfirm, "no messages cached for MsgChannelOpenConfirm")
+
+	openTryMessage, hasOpenTryMessage = openTryMessages[channelKey]
+	require.True(t, hasOpenTryMessage, "no open try messages cached for channel key")
+
+	require.NotNil(t, openTryMessage)
+
+	openConfirmMessage, hasOpenConfirmMessage := openConfirmMessages[channelKey]
+	require.True(t, hasOpenConfirmMessage, "no open confirm messages cached for channel key")
+
+	require.Nil(t, openConfirmMessage)
+
 }

--- a/relayer/chains/cosmos/msg_handlers_connection_test.go
+++ b/relayer/chains/cosmos/msg_handlers_connection_test.go
@@ -37,11 +37,13 @@ func TestHandleConnectionHandshake(t *testing.T) {
 
 	require.Len(t, ibcMessagesCache.ConnectionHandshake, 1)
 
-	connectionMessages, hasConnectionKey := ibcMessagesCache.ConnectionHandshake[connectionKey]
-	require.True(t, hasConnectionKey, "no messages cached for connection key")
-
-	_, hasConnectionOpenInit := connectionMessages[processor.MsgConnectionOpenInit]
+	openInitMessages, hasConnectionOpenInit := ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenInit]
 	require.True(t, hasConnectionOpenInit, "no messages cached for MsgConnectionOpenInit")
+
+	openInitMessage, hasOpenInitMessage := openInitMessages[connectionKey]
+	require.True(t, hasOpenInitMessage, "no init messages cached for connection key")
+
+	require.NotNil(t, openInitMessage)
 
 	ccp.handleMsgConnectionOpenAck(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
 
@@ -50,16 +52,22 @@ func TestHandleConnectionHandshake(t *testing.T) {
 
 	require.True(t, connectionOpen, "connection should be marked open now")
 
-	connectionMessages, hasConnectionKey = ibcMessagesCache.ConnectionHandshake[connectionKey]
-	require.True(t, hasConnectionKey, "no messages cached for connection key")
-
-	require.Len(t, connectionMessages, 2)
-
-	_, hasConnectionOpenInit = connectionMessages[processor.MsgConnectionOpenInit]
+	openInitMessages, hasConnectionOpenInit = ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenInit]
 	require.True(t, hasConnectionOpenInit, "no messages cached for MsgConnectionOpenInit")
 
-	_, hasConnectionOpenAck := connectionMessages[processor.MsgConnectionOpenAck]
+	openAckMessages, hasConnectionOpenAck := ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenAck]
 	require.True(t, hasConnectionOpenAck, "no messages cached for MsgConnectionOpenAck")
+
+	openInitMessage, hasOpenInitMessage = openInitMessages[connectionKey]
+	require.True(t, hasOpenInitMessage, "no init messages cached for connection key")
+
+	require.NotNil(t, openInitMessage)
+
+	openAckMessage, hasOpenAckMessage := openAckMessages[connectionKey]
+	require.True(t, hasOpenAckMessage, "no ack messages cached for connection key")
+
+	require.NotNil(t, openAckMessage)
+
 }
 
 func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
@@ -92,11 +100,13 @@ func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
 
 	require.Len(t, ibcMessagesCache.ConnectionHandshake, 1)
 
-	connectionMessages, hasConnectionKey := ibcMessagesCache.ConnectionHandshake[connectionKey]
-	require.True(t, hasConnectionKey, "no messages cached for connection key")
-
-	_, hasConnectionOpenTry := connectionMessages[processor.MsgConnectionOpenTry]
+	openTryMessages, hasConnectionOpenTry := ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenTry]
 	require.True(t, hasConnectionOpenTry, "no messages cached for MsgConnectionOpenTry")
+
+	openTryMessage, hasOpenTryMessage := openTryMessages[connectionKey]
+	require.True(t, hasOpenTryMessage, "no messages cached for connection key")
+
+	require.NotNil(t, openTryMessage)
 
 	ccp.handleMsgConnectionOpenConfirm(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
 
@@ -105,14 +115,19 @@ func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
 
 	require.True(t, connectionOpen, "connection should be marked open now")
 
-	connectionMessages, hasConnectionKey = ibcMessagesCache.ConnectionHandshake[connectionKey]
-	require.True(t, hasConnectionKey, "no messages cached for connection key")
-
-	require.Len(t, connectionMessages, 2)
-
-	_, hasConnectionOpenTry = connectionMessages[processor.MsgConnectionOpenTry]
+	openTryMessages, hasConnectionOpenTry = ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenTry]
 	require.True(t, hasConnectionOpenTry, "no messages cached for MsgConnectionOpenTry")
 
-	_, hasConnectionOpenConfirm := connectionMessages[processor.MsgConnectionOpenConfirm]
+	openConfirmMessages, hasConnectionOpenConfirm := ibcMessagesCache.ConnectionHandshake[processor.MsgConnectionOpenConfirm]
 	require.True(t, hasConnectionOpenConfirm, "no messages cached for MsgConnectionOpenConfirm")
+
+	openTryMessage, hasOpenTryMessage = openTryMessages[connectionKey]
+	require.True(t, hasOpenTryMessage, "no open try messages cached for connection key")
+
+	require.NotNil(t, openTryMessage)
+
+	openConfirmMessage, hasOpenConfirmMessage := openConfirmMessages[connectionKey]
+	require.True(t, hasOpenConfirmMessage, "no open confirm messages cached for connection key")
+
+	require.Nil(t, openConfirmMessage)
 }

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -76,6 +76,20 @@ type IBCMessageWithSequence struct {
 	Message  provider.RelayerMessage
 }
 
+// IBCMessageWithChannel holds a channel handshake message's channel along with it,
+// useful for sending messages around internal to the PathProcessor.
+type IBCMessageWithChannel struct {
+	ChannelKey
+	Message provider.RelayerMessage
+}
+
+// IBCMessageWithConnection holds a connection handshake message's connection along with it,
+// useful for sending messages around internal to the PathProcessor.
+type IBCMessageWithConnection struct {
+	ConnectionKey
+	Message provider.RelayerMessage
+}
+
 func NewPathProcessor(log *zap.Logger, pathEnd1 PathEnd, pathEnd2 PathEnd) *PathProcessor {
 	return &PathProcessor{
 		log: log,
@@ -110,6 +124,11 @@ func (pp *PathProcessor) PathEnd2Messages(channelKey ChannelKey, message string)
 type channelPair struct {
 	pathEnd1ChannelKey ChannelKey
 	pathEnd2ChannelKey ChannelKey
+}
+
+type connectionPair struct {
+	pathEnd1ConnectionKey ConnectionKey
+	pathEnd2ConnectionKey ConnectionKey
 }
 
 func (pp *PathProcessor) channelPairs() []channelPair {
@@ -211,12 +230,47 @@ type PathEndPacketFlowMessages struct {
 	SrcMsgTimeoutOnClose  PacketSequenceCache
 }
 
+type PathEndConnectionHandshakeMessages struct {
+	SrcMsgConnectionOpenInit    ConnectionMessageCache
+	DstMsgConnectionOpenTry     ConnectionMessageCache
+	SrcMsgConnectionOpenAck     ConnectionMessageCache
+	DstMsgConnectionOpenConfirm ConnectionMessageCache
+}
+
+type PathEndChannelHandshakeMessages struct {
+	SrcMsgChannelOpenInit    ChannelMessageCache
+	DstMsgChannelOpenTry     ChannelMessageCache
+	SrcMsgChannelOpenAck     ChannelMessageCache
+	DstMsgChannelOpenConfirm ChannelMessageCache
+}
+
+type PathEndChannelCloseMessages struct {
+	SrcMsgChannelCloseInit    ChannelMessageCache
+	DstMsgChannelCloseConfirm ChannelMessageCache
+}
+
 type PathEndProcessedResponse struct {
 	UnrelayedPackets          []IBCMessageWithSequence
 	UnrelayedAcknowledgements []IBCMessageWithSequence
 
 	ToDeleteSrc map[string][]uint64
 	ToDeleteDst map[string][]uint64
+}
+
+type PathEndChannelHandshakeResponse struct {
+	SrcMessages []IBCMessageWithChannel
+	DstMessages []IBCMessageWithChannel
+
+	ToDeleteSrc map[string][]ChannelKey
+	ToDeleteDst map[string][]ChannelKey
+}
+
+type PathEndConnectionHandshakeResponse struct {
+	SrcMessages []IBCMessageWithConnection
+	DstMessages []IBCMessageWithConnection
+
+	ToDeleteSrc map[string][]ConnectionKey
+	ToDeleteDst map[string][]ConnectionKey
 }
 
 func (m *PathEndProcessedResponse) appendPacket(sequence uint64, msgRecvPacket provider.RelayerMessage) {
@@ -291,13 +345,153 @@ MsgTransferLoop:
 	}
 }
 
-func (pp *PathProcessor) sendMessages(pathEnd *PathEndRuntime, messages []IBCMessageWithSequence) error {
-	if len(messages) == 0 {
+func (pp *PathProcessor) getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEndConnectionHandshakeMessages PathEndConnectionHandshakeMessages, wg *sync.WaitGroup, res *PathEndConnectionHandshakeResponse) {
+	defer wg.Done()
+	res.SrcMessages = nil
+	res.DstMessages = nil
+	res.ToDeleteSrc = make(map[string][]ConnectionKey)
+	res.ToDeleteDst = make(map[string][]ConnectionKey)
+
+ConnectionHandshakeLoop:
+	for openInitKey, openInitMsg := range pathEndConnectionHandshakeMessages.SrcMsgConnectionOpenInit {
+		var foundOpenTry provider.RelayerMessage
+		for openTryKey, openTryMsg := range pathEndConnectionHandshakeMessages.DstMsgConnectionOpenTry {
+			if openInitKey == openTryKey {
+				foundOpenTry = openTryMsg
+				break
+			}
+		}
+		if foundOpenTry == nil {
+			// need to send an open try to dst
+			res.DstMessages = append(res.DstMessages, IBCMessageWithConnection{
+				ConnectionKey: openInitKey,
+				Message:       openInitMsg,
+			})
+			continue ConnectionHandshakeLoop
+		}
+		var foundOpenAck provider.RelayerMessage
+		for openAckKey, openAckMsg := range pathEndConnectionHandshakeMessages.SrcMsgConnectionOpenAck {
+			if openInitKey == openAckKey {
+				foundOpenAck = openAckMsg
+				break
+			}
+		}
+		if foundOpenAck == nil {
+			// need to send an open ack to src
+			res.SrcMessages = append(res.SrcMessages, IBCMessageWithConnection{
+				ConnectionKey: openInitKey,
+				Message:       foundOpenTry,
+			})
+			continue ConnectionHandshakeLoop
+		}
+		var foundOpenConfirm provider.RelayerMessage
+		for openConfirmKey, openConfirmMsg := range pathEndConnectionHandshakeMessages.DstMsgConnectionOpenConfirm {
+			if openInitKey == openConfirmKey {
+				foundOpenConfirm = openConfirmMsg
+				break
+			}
+		}
+		if foundOpenConfirm == nil {
+			// need to send an open confirm to dst
+			res.DstMessages = append(res.DstMessages, IBCMessageWithConnection{
+				ConnectionKey: openInitKey,
+				Message:       foundOpenAck,
+			})
+			continue ConnectionHandshakeLoop
+		}
+		// handshake is complete for this connection, remove all retention.
+		res.ToDeleteSrc[MsgConnectionOpenInit] = append(res.ToDeleteSrc[MsgConnectionOpenInit], openInitKey)
+		res.ToDeleteDst[MsgConnectionOpenTry] = append(res.ToDeleteDst[MsgConnectionOpenTry], openInitKey)
+		res.ToDeleteSrc[MsgConnectionOpenAck] = append(res.ToDeleteSrc[MsgConnectionOpenAck], openInitKey)
+		res.ToDeleteDst[MsgConnectionOpenConfirm] = append(res.ToDeleteDst[MsgConnectionOpenConfirm], openInitKey)
+	}
+
+	// now iterate through connection-handshake-complete messages and remove any leftover messages
+	for openConfirmKey := range pathEndConnectionHandshakeMessages.DstMsgConnectionOpenConfirm {
+		res.ToDeleteSrc[MsgConnectionOpenInit] = append(res.ToDeleteSrc[MsgConnectionOpenInit], openConfirmKey)
+		res.ToDeleteDst[MsgConnectionOpenTry] = append(res.ToDeleteDst[MsgConnectionOpenTry], openConfirmKey)
+		res.ToDeleteSrc[MsgConnectionOpenAck] = append(res.ToDeleteSrc[MsgConnectionOpenAck], openConfirmKey)
+		res.ToDeleteDst[MsgConnectionOpenConfirm] = append(res.ToDeleteDst[MsgConnectionOpenConfirm], openConfirmKey)
+	}
+}
+
+func (pp *PathProcessor) getUnrelayedChannelHandshakeMessagesAndToDelete(pathEndChannelHandshakeMessages PathEndChannelHandshakeMessages, wg *sync.WaitGroup, res *PathEndChannelHandshakeResponse) {
+	defer wg.Done()
+	res.SrcMessages = nil
+	res.DstMessages = nil
+	res.ToDeleteSrc = make(map[string][]ChannelKey)
+	res.ToDeleteDst = make(map[string][]ChannelKey)
+
+ChannelHandshakeLoop:
+	for openInitKey, openInitMsg := range pathEndChannelHandshakeMessages.SrcMsgChannelOpenInit {
+		var foundOpenTry provider.RelayerMessage
+		for openTryKey, openTryMsg := range pathEndChannelHandshakeMessages.DstMsgChannelOpenTry {
+			if openInitKey == openTryKey {
+				foundOpenTry = openTryMsg
+				break
+			}
+		}
+		if foundOpenTry == nil {
+			// need to send an open try to dst
+			res.DstMessages = append(res.DstMessages, IBCMessageWithChannel{
+				ChannelKey: openInitKey,
+				Message:    openInitMsg,
+			})
+			continue ChannelHandshakeLoop
+		}
+		var foundOpenAck provider.RelayerMessage
+		for openAckKey, openAckMsg := range pathEndChannelHandshakeMessages.SrcMsgChannelOpenAck {
+			if openInitKey == openAckKey {
+				foundOpenAck = openAckMsg
+				break
+			}
+		}
+		if foundOpenAck == nil {
+			// need to send an open ack to src
+			res.SrcMessages = append(res.SrcMessages, IBCMessageWithChannel{
+				ChannelKey: openInitKey,
+				Message:    foundOpenTry,
+			})
+			continue ChannelHandshakeLoop
+		}
+		var foundOpenConfirm provider.RelayerMessage
+		for openConfirmKey, openConfirmMsg := range pathEndChannelHandshakeMessages.DstMsgChannelOpenConfirm {
+			if openInitKey == openConfirmKey {
+				foundOpenConfirm = openConfirmMsg
+				break
+			}
+		}
+		if foundOpenConfirm == nil {
+			// need to send an open confirm to dst
+			res.DstMessages = append(res.DstMessages, IBCMessageWithChannel{
+				ChannelKey: openInitKey,
+				Message:    foundOpenAck,
+			})
+			continue ChannelHandshakeLoop
+		}
+		// handshake is complete for this channel, remove all retention.
+		res.ToDeleteSrc[MsgChannelOpenInit] = append(res.ToDeleteSrc[MsgChannelOpenInit], openInitKey)
+		res.ToDeleteDst[MsgChannelOpenTry] = append(res.ToDeleteDst[MsgChannelOpenTry], openInitKey)
+		res.ToDeleteSrc[MsgChannelOpenAck] = append(res.ToDeleteSrc[MsgChannelOpenAck], openInitKey)
+		res.ToDeleteDst[MsgChannelOpenConfirm] = append(res.ToDeleteDst[MsgChannelOpenConfirm], openInitKey)
+	}
+
+	// now iterate through channel-handshake-complete messages and remove any leftover messages
+	for openConfirmKey := range pathEndChannelHandshakeMessages.DstMsgChannelOpenConfirm {
+		res.ToDeleteSrc[MsgChannelOpenInit] = append(res.ToDeleteSrc[MsgChannelOpenInit], openConfirmKey)
+		res.ToDeleteDst[MsgChannelOpenTry] = append(res.ToDeleteDst[MsgChannelOpenTry], openConfirmKey)
+		res.ToDeleteSrc[MsgChannelOpenAck] = append(res.ToDeleteSrc[MsgChannelOpenAck], openConfirmKey)
+		res.ToDeleteDst[MsgChannelOpenConfirm] = append(res.ToDeleteDst[MsgChannelOpenConfirm], openConfirmKey)
+	}
+}
+
+func (pp *PathProcessor) sendMessages(pathEnd *PathEndRuntime, packetMessages []IBCMessageWithSequence, connectionMessages []IBCMessageWithConnection, channelMessages []IBCMessageWithChannel) error {
+	if len(packetMessages) == 0 && len(connectionMessages) == 0 && len(channelMessages) == 0 {
 		return nil
 	}
 	// TODO construct MsgUpdateClient for this pathEnd, using the latest trusted IBC header from other pathEnd, prepend messages with the MsgUpdateClient, then send the messages to this pathEnd
 
-	pp.log.Debug("will send", zap.Any("messages", messages))
+	pp.log.Debug("will send", zap.Any("packet_messages", packetMessages), zap.Any("connection_messages", connectionMessages), zap.Any("channel_messages", channelMessages))
 
 	return nil
 }
@@ -310,7 +504,42 @@ func (pp *PathProcessor) processLatestMessages() error {
 	pathEnd1ProcessRes := make([]*PathEndProcessedResponse, len(channelPairs))
 	pathEnd2ProcessRes := make([]*PathEndProcessedResponse, len(channelPairs))
 
+	var pathEnd1ConnectionHandshakeRes, pathEnd2ConnectionHandshakeRes PathEndConnectionHandshakeResponse
+	var pathEnd1ChannelHandshakeRes, pathEnd2ChannelHandshakeRes PathEndChannelHandshakeResponse
+
 	var wg sync.WaitGroup
+
+	pathEnd1ConnectionHandshakeMessages := PathEndConnectionHandshakeMessages{
+		SrcMsgConnectionOpenInit:    pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenInit],
+		DstMsgConnectionOpenTry:     pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenTry],
+		SrcMsgConnectionOpenAck:     pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenAck],
+		DstMsgConnectionOpenConfirm: pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenConfirm],
+	}
+	pathEnd2ConnectionHandshakeMessages := PathEndConnectionHandshakeMessages{
+		SrcMsgConnectionOpenInit:    pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenInit],
+		DstMsgConnectionOpenTry:     pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenTry],
+		SrcMsgConnectionOpenAck:     pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenAck],
+		DstMsgConnectionOpenConfirm: pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenConfirm],
+	}
+	wg.Add(2)
+	go pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd1ConnectionHandshakeMessages, &wg, &pathEnd1ConnectionHandshakeRes)
+	go pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd2ConnectionHandshakeMessages, &wg, &pathEnd2ConnectionHandshakeRes)
+
+	pathEnd1ChannelHandshakeMessages := PathEndChannelHandshakeMessages{
+		SrcMsgChannelOpenInit:    pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenInit],
+		DstMsgChannelOpenTry:     pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenTry],
+		SrcMsgChannelOpenAck:     pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenAck],
+		DstMsgChannelOpenConfirm: pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenConfirm],
+	}
+	pathEnd2ChannelHandshakeMessages := PathEndChannelHandshakeMessages{
+		SrcMsgChannelOpenInit:    pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenInit],
+		DstMsgChannelOpenTry:     pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenTry],
+		SrcMsgChannelOpenAck:     pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenAck],
+		DstMsgChannelOpenConfirm: pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenConfirm],
+	}
+	wg.Add(2)
+	go pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd1ChannelHandshakeMessages, &wg, &pathEnd1ChannelHandshakeRes)
+	go pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd2ChannelHandshakeMessages, &wg, &pathEnd2ChannelHandshakeRes)
 
 	for i, pair := range channelPairs {
 		pathEnd1PacketFlowMessages := PathEndPacketFlowMessages{
@@ -338,13 +567,34 @@ func (pp *PathProcessor) processLatestMessages() error {
 	wg.Wait()
 
 	// concatenate applicable messages for pathend
-	var pathEnd1Messages, pathEnd2Messages []IBCMessageWithSequence
-	for i := 0; i < len(channelPairs); i++ {
-		pathEnd1Messages = append(pathEnd1Messages, pathEnd2ProcessRes[i].UnrelayedPackets...)
-		pathEnd1Messages = append(pathEnd1Messages, pathEnd1ProcessRes[i].UnrelayedAcknowledgements...)
+	var pathEnd1PacketMessages, pathEnd2PacketMessages []IBCMessageWithSequence
+	var pathEnd1ConnectionMessages, pathEnd2ConnectionMessages []IBCMessageWithConnection
+	var pathEnd1ChannelMessages, pathEnd2ChannelMessages []IBCMessageWithChannel
 
-		pathEnd2Messages = append(pathEnd2Messages, pathEnd1ProcessRes[i].UnrelayedPackets...)
-		pathEnd2Messages = append(pathEnd2Messages, pathEnd2ProcessRes[i].UnrelayedAcknowledgements...)
+	pathEnd1ConnectionMessages = append(pathEnd1ConnectionMessages, pathEnd1ConnectionHandshakeRes.SrcMessages...)
+	pathEnd1ConnectionMessages = append(pathEnd1ConnectionMessages, pathEnd2ConnectionHandshakeRes.DstMessages...)
+
+	pathEnd2ConnectionMessages = append(pathEnd2ConnectionMessages, pathEnd2ConnectionHandshakeRes.SrcMessages...)
+	pathEnd2ConnectionMessages = append(pathEnd2ConnectionMessages, pathEnd1ConnectionHandshakeRes.DstMessages...)
+
+	pp.pathEnd1.messageCache.ConnectionHandshake.DeleteCachedMessages(pathEnd1ConnectionHandshakeRes.ToDeleteSrc, pathEnd2ConnectionHandshakeRes.ToDeleteDst)
+	pp.pathEnd2.messageCache.ConnectionHandshake.DeleteCachedMessages(pathEnd2ConnectionHandshakeRes.ToDeleteSrc, pathEnd1ConnectionHandshakeRes.ToDeleteDst)
+
+	pathEnd1ChannelMessages = append(pathEnd1ChannelMessages, pathEnd1ChannelHandshakeRes.SrcMessages...)
+	pathEnd1ChannelMessages = append(pathEnd1ChannelMessages, pathEnd2ChannelHandshakeRes.DstMessages...)
+
+	pathEnd2ChannelMessages = append(pathEnd2ChannelMessages, pathEnd2ChannelHandshakeRes.SrcMessages...)
+	pathEnd2ChannelMessages = append(pathEnd2ChannelMessages, pathEnd1ChannelHandshakeRes.DstMessages...)
+
+	pp.pathEnd1.messageCache.ChannelHandshake.DeleteCachedMessages(pathEnd1ChannelHandshakeRes.ToDeleteSrc, pathEnd2ChannelHandshakeRes.ToDeleteDst)
+	pp.pathEnd2.messageCache.ChannelHandshake.DeleteCachedMessages(pathEnd2ChannelHandshakeRes.ToDeleteSrc, pathEnd1ChannelHandshakeRes.ToDeleteDst)
+
+	for i := 0; i < len(channelPairs); i++ {
+		pathEnd1PacketMessages = append(pathEnd1PacketMessages, pathEnd2ProcessRes[i].UnrelayedPackets...)
+		pathEnd1PacketMessages = append(pathEnd1PacketMessages, pathEnd1ProcessRes[i].UnrelayedAcknowledgements...)
+
+		pathEnd2PacketMessages = append(pathEnd2PacketMessages, pathEnd1ProcessRes[i].UnrelayedPackets...)
+		pathEnd2PacketMessages = append(pathEnd2PacketMessages, pathEnd2ProcessRes[i].UnrelayedAcknowledgements...)
 
 		pp.pathEnd1.messageCache.PacketFlow[channelPairs[i].pathEnd1ChannelKey].DeleteCachedMessages(pathEnd1ProcessRes[i].ToDeleteSrc, pathEnd2ProcessRes[i].ToDeleteDst)
 		pp.pathEnd2.messageCache.PacketFlow[channelPairs[i].pathEnd2ChannelKey].DeleteCachedMessages(pathEnd2ProcessRes[i].ToDeleteSrc, pathEnd1ProcessRes[i].ToDeleteDst)
@@ -352,8 +602,12 @@ func (pp *PathProcessor) processLatestMessages() error {
 
 	// now send messages in parallel
 	var eg errgroup.Group
-	eg.Go(func() error { return pp.sendMessages(pp.pathEnd1, pathEnd1Messages) })
-	eg.Go(func() error { return pp.sendMessages(pp.pathEnd2, pathEnd2Messages) })
+	eg.Go(func() error {
+		return pp.sendMessages(pp.pathEnd1, pathEnd1PacketMessages, pathEnd1ConnectionMessages, pathEnd1ChannelMessages)
+	})
+	eg.Go(func() error {
+		return pp.sendMessages(pp.pathEnd2, pathEnd2PacketMessages, pathEnd2ConnectionMessages, pathEnd2ChannelMessages)
+	})
 	return eg.Wait()
 }
 


### PR DESCRIPTION
Adds `PathProcessor` book-keeping for channel and connection handshake messages. Prepares for sending of the next message in the handshake process.

Changes `ChannelMessagesCache` and `ConnectionMessagesCache` highest level key to be the IBC message type string to simplify correlation