### PR TITLE
CosmosChainProcessor light block provider

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/avast/retry-go/v4"
 	cosmosClient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/relayer/v2/relayer/processor"
@@ -19,6 +17,7 @@ import (
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 type CosmosChainProcessor struct {

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -50,6 +50,7 @@ type pathEndRuntime struct {
 	chainProvider provider.ChainProvider
 
 	// cached data
+	latestBlock          provider.LatestBlock
 	messageCache         IBCMessagesCache
 	connectionStateCache ConnectionStateCache
 	channelStateCache    ChannelStateCache
@@ -62,11 +63,12 @@ type pathEndRuntime struct {
 }
 
 func (pathEnd *pathEndRuntime) MergeCacheData(d ChainProcessorCacheData) {
+	pathEnd.inSync = d.InSync
+	pathEnd.latestBlock = d.LatestBlock
 	// TODO make sure passes channel filter for pathEnd1 before calling this
 	pathEnd.messageCache.Merge(d.IBCMessagesCache)             // Merge incoming packet IBC messages into the backlog
 	pathEnd.connectionStateCache.Merge(d.ConnectionStateCache) // Update latest connection open state for chain
 	pathEnd.channelStateCache.Merge(d.ChannelStateCache)       // Update latest channel open state for chain
-	pathEnd.inSync = d.InSync
 }
 
 // ibcMessageWithSequence holds a packet's sequence along with it,

--- a/relayer/processor/types.go
+++ b/relayer/processor/types.go
@@ -139,6 +139,7 @@ type ChainProcessorCacheData struct {
 	InSync bool
 	ConnectionStateCache
 	ChannelStateCache
+	LatestBlock provider.LatestBlock
 }
 
 // Clone will create a deep copy of a PacketMessagesCache.

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -38,6 +38,11 @@ type RelayerEvent struct {
 	Attributes map[string]string
 }
 
+type LatestBlock struct {
+	Height uint64
+	Time   time.Time
+}
+
 // loggableEvents is an unexported wrapper type for a slice of RelayerEvent,
 // to satisfy the zapcore.ArrayMarshaler interface.
 type loggableEvents []RelayerEvent


### PR DESCRIPTION
`CosmosChainProcessor` now makes two requests in parallel per block, `cc.Client.BlockResults` and `lightProvider.LightBlock`.

`LightBlock` tendermint data is needed for block header information, such as block timestamp, signed block header, and validator set. This data is not available through `BlockResults`. Will be used in future PR for constructing `MsgUpdateClient` messages.

Caches and shares the `latestBlock` height and timestamp with the `PathProcessor`, which will be needed for things like querying packet proofs for IBC message assembly.