### PR TITLE
Usercase extension with 'rly tx transfer'

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -898,15 +898,14 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			// Query all channels for the configured connection on the src chain
 			srcChannelID := args[4]
-			srcChainID := args[0]
 
 			var pathConnectionID string
-			if srcChainID == path.Src.ChainID {
+			if src.ChainID()  == path.Src.ChainID {
 				pathConnectionID = path.Src.ConnectionID
-			} else if srcChainID == path.Dst.ChainID {
+			} else if src.ChainID()  == path.Dst.ChainID {
 				pathConnectionID = path.Dst.ConnectionID
 			} else {
-				return fmt.Errorf("no path configured using chain-id: %s", src.Chainid)
+				return fmt.Errorf("no path configured using chain-id: %s", src.ChainID())
 			}
 
 			channels, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, pathConnectionID)
@@ -925,7 +924,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			if srcChannel == nil {
 				return fmt.Errorf("could not find channel{%s} for chain{%s}@connection{%s}",
-					srcChannelID, src, path.Dst.ConnectionID)
+					srcChannelID, src, pathConnectionID)
 			}
 
 			dts, err := src.ChainProvider.QueryDenomTraces(cmd.Context(), 0, 100, srch)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -898,32 +898,25 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			// Query all channels for the configured connection on the src chain
 			srcChannelID := args[4]
-			channels_s, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Src.ConnectionID)
+			srcChainID := args[0]
+
+			var pathConnectionID string
+			if srcChainID == path.Src.ChainID {
+				pathConnectionID = path.Src.ConnectionID
+			} else if srcChainID == path.Dst.ChainID {
+				pathConnectionID = path.Dst.ConnectionID
+			} else {
+				return fmt.Errorf("no path configured using chain-id: %s", src.Chainid)
+			}
+
+			channels, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, pathConnectionID)
 			if err != nil {
 				return err
 			}
 
 			// Ensure the specified channel exists for the given path
 			var srcChannel *chantypes.IdentifiedChannel
-			for _, channel := range channels_s {
-				if channel.ChannelId == srcChannelID {
-					srcChannel = channel
-					break
-				}
-			}
-
-			if srcChannel == nil {
-				fmt.Errorf("could not find channel{%s} for chain{%s}@connection{%s}",
-					srcChannelID, src, path.Src.ConnectionID)
-			}
-
-			channels_d, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Dst.ConnectionID)
-			if err != nil {
-				return err
-			}
-
-			// Ensure the specified channel exists for the given path
-			for _, channel := range channels_d {
+			for _, channel := range channels {
 				if channel.ChannelId == srcChannelID {
 					srcChannel = channel
 					break

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -898,14 +898,32 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			// Query all channels for the configured connection on the src chain
 			srcChannelID := args[4]
-			channels, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Src.ConnectionID)
+			channels_s, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Src.ConnectionID)
 			if err != nil {
 				return err
 			}
 
 			// Ensure the specified channel exists for the given path
 			var srcChannel *chantypes.IdentifiedChannel
-			for _, channel := range channels {
+			for _, channel := range channels_s {
+				if channel.ChannelId == srcChannelID {
+					srcChannel = channel
+					break
+				}
+			}
+
+			if srcChannel == nil {
+				fmt.Errorf("could not find channel{%s} for chain{%s}@connection{%s}",
+					srcChannelID, src, path.Src.ConnectionID)
+			}
+
+			channels_d, err := src.ChainProvider.QueryConnectionChannels(cmd.Context(), srch, path.Dst.ConnectionID)
+			if err != nil {
+				return err
+			}
+
+			// Ensure the specified channel exists for the given path
+			for _, channel := range channels_d {
 				if channel.ChannelId == srcChannelID {
 					srcChannel = channel
 					break
@@ -914,7 +932,7 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 
 			if srcChannel == nil {
 				return fmt.Errorf("could not find channel{%s} for chain{%s}@connection{%s}",
-					srcChannelID, src, path.Src.ConnectionID)
+					srcChannelID, src, path.Dst.ConnectionID)
 			}
 
 			dts, err := src.ChainProvider.QueryDenomTraces(cmd.Context(), 0, 100, srch)


### PR DESCRIPTION
related issue:
https://github.com/cosmos/relayer/issues/804

description:
When sending a transaction with rly tx trnsfer, relayer must verify the
channel exists based off the path metadata's "src" and "dst" chain.

Signed-off-by: hwangjae lee <meetrick@gmail.com>