### PR TITLE
Remove duplicate command: `rly config add-chains`

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -332,10 +332,12 @@ func chainsAddDirCmd(a *appState) *cobra.Command {
 		Use:     "add-dir dir",
 		Aliases: []string{"ad"},
 		Args:    withUsage(cobra.ExactArgs(1)),
-		Short: `Add new chains to the configuration file from a directory 
-		full of chain configuration, useful for adding testnet configurations`,
+		Short:   `Add chain configuration data in bulk from a directory. Example dir: 'configs/demo/chains'`,
+		Long: `Add chain configuration data in bulk from a directory housing individual chain config files. 
+		
+		See 'configs/demo/chains' for an example of individual chain config files.`,
 		Example: strings.TrimSpace(fmt.Sprintf(`
-$ %s chains add-dir testnet/chains/
+$ %s chains add-dir configs/demo/chains
 $ %s ch ad testnet/chains/`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := addChainsFromDirectory(cmd.ErrOrStderr(), a, args[0]); err != nil {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -333,7 +333,7 @@ func chainsAddDirCmd(a *appState) *cobra.Command {
 		Aliases: []string{"ad"},
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Short:   `Add chain configuration data in bulk from a directory. Example dir: 'configs/demo/chains'`,
-		Long: `Add chain configuration data in bulk from a directory housing individual chain config files. 
+		Long: `Add chain configuration data in bulk from a directory housing individual chain config files. This is useful for spinning up testnets.
 		
 		See 'configs/demo/chains' for an example of individual chain config files.`,
 		Example: strings.TrimSpace(fmt.Sprintf(`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -47,7 +47,6 @@ func configCmd(a *appState) *cobra.Command {
 	cmd.AddCommand(
 		configShowCmd(a),
 		configInitCmd(),
-		configAddChainsCmd(a),
 		configAddPathsCmd(a),
 	)
 
@@ -166,25 +165,6 @@ $ %s cfg i`, appName, defaultHome, appName)),
 			return fmt.Errorf("config already exists: %s", cfgPath)
 		},
 	}
-	return cmd
-}
-
-func configAddChainsCmd(a *appState) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:  "add-chains path_to_chains",
-		Args: withUsage(cobra.ExactArgs(1)),
-		Short: `Add new chains to the configuration file from a directory full of chain 
-              configurations, useful for adding testnet configurations`,
-		Example: strings.TrimSpace(fmt.Sprintf(`
-$ %s config add-chains configs/chains`, appName)),
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if err := addChainsFromDirectory(cmd.ErrOrStderr(), a, args[0]); err != nil {
-				return err
-			}
-			return a.OverwriteConfig(a.Config)
-		},
-	}
-
 	return cmd
 }
 

--- a/scripts/nchainz
+++ b/scripts/nchainz
@@ -446,7 +446,7 @@ clients)
 
   echo "Generating rly configurations..."
   rly config init
-  rly config add-chains "$BASEDIR/config/chains"
+  rly chains add-dir "$BASEDIR/config/chains"
 
   sleep 2
 

--- a/scripts/three-chainz
+++ b/scripts/three-chainz
@@ -63,7 +63,7 @@ make install
 
 echo "Generating rly configurations..."
 rly config init
-rly config add-chains configs/three/chains
+rly chains add-dir configs/three/chains
 
 SEED0=$(jq -r '.mnemonic' $GAIA_DATA/ibc-0/key_seed.json)
 SEED1=$(jq -r '.mnemonic' $GAIA_DATA/ibc-1/key_seed.json)

--- a/scripts/two-chainz
+++ b/scripts/two-chainz
@@ -60,7 +60,7 @@ make install
 
 echo "Generating rly configurations..."
 rly config init
-rly config add-chains configs/demo/chains
+rly chains add-dir configs/demo/chains
 
 SEED0=$(jq -r '.mnemonic' $GAIA_DATA/ibc-0/key_seed.json)
 SEED1=$(jq -r '.mnemonic' $GAIA_DATA/ibc-1/key_seed.json)

--- a/scripts/two-chainz-akash
+++ b/scripts/two-chainz-akash
@@ -69,7 +69,7 @@ make install
 
 echo "Generating rly configurations..."
 rly config init
-rly config add-chains configs/akash/chains
+rly chains add-dir configs/akash/chains
 
 SEED0=$(jq -r '.mnemonic' $GAIA_DATA/ibc-0/key_seed.json)
 SEED1=$(jq -r '.mnemonic' $GAIA_DATA/ibc-1/key_seed.json)

--- a/scripts/two-chainz-wasmd
+++ b/scripts/two-chainz-wasmd
@@ -59,7 +59,7 @@ make install
 
 echo "Generating rly configurations..."
 rly config init
-rly config add-chains configs/wasmd/chains
+rly chains add-dir configs/wasmd/chains
 
 SEED0=$(jq -r '.mnemonic' $WASMD_DATA/ibc-0/key_seed.json)
 SEED1=$(jq -r '.mnemonic' $WASMD_DATA/ibc-1/key_seed.json)


### PR DESCRIPTION
I don't see a reason why there needs to be two commands that do the same thing.

Removing: `rly config add-chains`
In favor of: `rly chains add-dir`

*This should not effect IBCtest. IBCtest uses: `rly chains add`

Related to issue: https://github.com/cosmos/relayer/issues/560

The scripts that utilize the removed command have been updated. 

I could be convinced if this is not necessary, but I think this is a nice client cleanup.

PR to move the `rly config add-paths` to `rly paths add-dir` is in the works...