### PR TITLE
EventProcessor architecture - wire up with flag

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -119,7 +120,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 
 	t.Log("Starting relayer")
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, filter, 2*cmd.MB, 5)
+	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
 
 	t.Log("Waiting for relayer messages to reach both chains")
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 2))
@@ -269,7 +270,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, filter, 2*cmd.MB, 5)
+	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 1))
@@ -443,7 +444,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 
 	t.Log("Starting relayer")
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, filter, 2*cmd.MB, 5)
+	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
 
 	t.Log("Waiting for relayer message inclusion in both chains")
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 1))
@@ -619,7 +620,7 @@ func TestUnorderedChannelBlockHeightTimeout(t *testing.T) {
 
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, filter, 2*cmd.MB, 5)
+	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
 
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 5))
 
@@ -717,7 +718,7 @@ func TestUnorderedChannelTimestampTimeout(t *testing.T) {
 
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, filter, 2*cmd.MB, 5)
+	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
 
 	time.Sleep(time.Second * 10)
 

--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"testing"
 	"time"
 
@@ -120,7 +121,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 
 	t.Log("Starting relayer")
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
+	_ = relayer.StartRelayer(ctx, log, src, dst, bytes.NewReader(nil), io.Discard, filter, 2*cmd.MB, 5, relayer.ProcessorEvents, 20)
 
 	t.Log("Waiting for relayer messages to reach both chains")
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 2))
@@ -270,7 +271,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
+	_ = relayer.StartRelayer(ctx, log, src, dst, bytes.NewReader(nil), io.Discard, filter, 2*cmd.MB, 5, relayer.ProcessorEvents, 20)
 
 	// Wait for relay message inclusion in both chains
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 1))
@@ -444,7 +445,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 
 	t.Log("Starting relayer")
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
+	_ = relayer.StartRelayer(ctx, log, src, dst, bytes.NewReader(nil), io.Discard, filter, 2*cmd.MB, 5, relayer.ProcessorEvents, 20)
 
 	t.Log("Waiting for relayer message inclusion in both chains")
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 1))
@@ -620,7 +621,7 @@ func TestUnorderedChannelBlockHeightTimeout(t *testing.T) {
 
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
+	_ = relayer.StartRelayer(ctx, log, src, dst, bytes.NewReader(nil), io.Discard, filter, 2*cmd.MB, 5, relayer.ProcessorEvents, 20)
 
 	require.NoError(t, src.ChainProvider.WaitForNBlocks(ctx, 5))
 
@@ -718,7 +719,7 @@ func TestUnorderedChannelTimestampTimeout(t *testing.T) {
 
 	// start the relayer process in it's own goroutine
 	filter := relayer.ChannelFilter{}
-	_ = relayer.StartRelayer(ctx, log, src, dst, os.Stdin, os.Stdout, filter, 2*cmd.MB, 5, true, 20)
+	_ = relayer.StartRelayer(ctx, log, src, dst, bytes.NewReader(nil), io.Discard, filter, 2*cmd.MB, 5, relayer.ProcessorEvents, 20)
 
 	time.Sleep(time.Second * 10)
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -40,6 +40,8 @@ const (
 	flagPageKey                 = "page-key"
 	flagCountTotal              = "count-total"
 	flagReverse                 = "reverse"
+	flagEventProcessor          = "events"
+	flagInitialBlockHistory     = "block-history"
 )
 
 const (
@@ -282,6 +284,18 @@ func dstPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().String(flagDebugAddr, defaultDebugAddr, "address to use for debug server. Set empty to disable debug server.")
 	if err := v.BindPFlag(flagDebugAddr, cmd.Flags().Lookup(flagDebugAddr)); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func eventProcessorFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().BoolP(flagEventProcessor, "e", false, "relay using event processor")
+	if err := v.BindPFlag(flagEventProcessor, cmd.Flags().Lookup(flagEventProcessor)); err != nil {
+		panic(err)
+	}
+	cmd.Flags().Uint64P(flagInitialBlockHistory, "h", 20, "initial block history to query when using event processor relaying")
+	if err := v.BindPFlag(flagEventProcessor, cmd.Flags().Lookup(flagEventProcessor)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cosmos/relayer/v2/relayer"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,7 +42,7 @@ const (
 	flagPageKey                 = "page-key"
 	flagCountTotal              = "count-total"
 	flagReverse                 = "reverse"
-	flagEventProcessor          = "events"
+	flagProcessor               = "processor"
 	flagInitialBlockHistory     = "block-history"
 )
 
@@ -289,13 +291,13 @@ func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func eventProcessorFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().BoolP(flagEventProcessor, "e", false, "relay using event processor")
-	if err := v.BindPFlag(flagEventProcessor, cmd.Flags().Lookup(flagEventProcessor)); err != nil {
+func processorFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().StringP(flagProcessor, "p", relayer.ProcessorLegacy, "which relayer processor to use")
+	if err := v.BindPFlag(flagProcessor, cmd.Flags().Lookup(flagProcessor)); err != nil {
 		panic(err)
 	}
-	cmd.Flags().Uint64P(flagInitialBlockHistory, "h", 20, "initial block history to query when using event processor relaying")
-	if err := v.BindPFlag(flagEventProcessor, cmd.Flags().Lookup(flagEventProcessor)); err != nil {
+	cmd.Flags().Uint64P(flagInitialBlockHistory, "h", 20, "initial block history to query when using 'events' as the processor for relaying")
+	if err := v.BindPFlag(flagInitialBlockHistory, cmd.Flags().Lookup(flagInitialBlockHistory)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -82,7 +82,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 				relaydebug.StartDebugServer(cmd.Context(), log, ln)
 			}
 
-			useEventProcessor, err := cmd.Flags().GetBool(flagEventProcessor)
+			processorType, err := cmd.Flags().GetString(flagProcessor)
 			if err != nil {
 				return err
 			}
@@ -91,7 +91,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 				return err
 			}
 
-			rlyErrCh := relayer.StartRelayer(cmd.Context(), a.Log, c[src], c[dst], cmd.InOrStdin(), cmd.OutOrStdout(), filter, maxTxSize, maxMsgLength, useEventProcessor, initialBlockHistory)
+			rlyErrCh := relayer.StartRelayer(cmd.Context(), a.Log, c[src], c[dst], cmd.InOrStdin(), cmd.OutOrStdout(), filter, maxTxSize, maxMsgLength, processorType, initialBlockHistory)
 
 			// NOTE: This block of code is useful for ensuring that the clients tracking each chain do not expire
 			// when there are no packets flowing across the channels. It is currently a source of errors that have been
@@ -151,7 +151,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 	cmd = updateTimeFlags(a.Viper, cmd)
 	cmd = strategyFlag(a.Viper, cmd)
 	cmd = debugServerFlags(a.Viper, cmd)
-	cmd = eventProcessorFlags(a.Viper, cmd)
+	cmd = processorFlags(a.Viper, cmd)
 	return cmd
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -43,7 +43,7 @@ func startCmd(a *appState) *cobra.Command {
 		Short:   "Start the listening relayer on a given path",
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
-$ %s start demo-path -e # to use event processor
+$ %s start demo-path -p events # to use event processor
 $ %s start demo-path --max-msgs 3
 $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -43,8 +43,9 @@ func startCmd(a *appState) *cobra.Command {
 		Short:   "Start the listening relayer on a given path",
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
+$ %s start demo-path -e # to use event processor
 $ %s start demo-path --max-msgs 3
-$ %s start demo-path2 --max-tx-size 10`, appName, appName)),
+$ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, src, dst, err := a.Config.ChainsFromPath(args[0])
 			if err != nil {
@@ -81,7 +82,16 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 				relaydebug.StartDebugServer(cmd.Context(), log, ln)
 			}
 
-			rlyErrCh := relayer.StartRelayer(cmd.Context(), a.Log, c[src], c[dst], filter, maxTxSize, maxMsgLength)
+			useEventProcessor, err := cmd.Flags().GetBool(flagEventProcessor)
+			if err != nil {
+				return err
+			}
+			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
+			if err != nil {
+				return err
+			}
+
+			rlyErrCh := relayer.StartRelayer(cmd.Context(), a.Log, c[src], c[dst], cmd.InOrStdin(), cmd.OutOrStdout(), filter, maxTxSize, maxMsgLength, useEventProcessor, initialBlockHistory)
 
 			// NOTE: This block of code is useful for ensuring that the clients tracking each chain do not expire
 			// when there are no packets flowing across the channels. It is currently a source of errors that have been
@@ -138,7 +148,11 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName)),
 			return nil
 		},
 	}
-	return debugServerFlags(a.Viper, strategyFlag(a.Viper, updateTimeFlags(a.Viper, cmd)))
+	cmd = updateTimeFlags(a.Viper, cmd)
+	cmd = strategyFlag(a.Viper, cmd)
+	cmd = debugServerFlags(a.Viper, cmd)
+	cmd = eventProcessorFlags(a.Viper, cmd)
+	return cmd
 }
 
 // UpdateClientsFromChains takes src, dst chains, threshold time and update clients based on expiry time

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -51,7 +51,7 @@ type CosmosChainProcessor struct {
 	channelStateCache processor.ChannelStateCache
 }
 
-func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider, rpcAddress string, input io.Reader, output io.Writer, pathProcessors processor.PathProcessors) (*CosmosChainProcessor, error) {
+func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider, rpcAddress string, input io.Reader, output io.Writer) (*CosmosChainProcessor, error) {
 	chainID := provider.ChainId()
 	cc, err := getCosmosClient(rpcAddress, chainID, input, output)
 	if err != nil {
@@ -66,7 +66,6 @@ func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider, r
 		chainProvider:        provider,
 		cc:                   cc,
 		lightProvider:        lightProvider,
-		pathProcessors:       pathProcessors,
 		latestClientState:    make(latestClientState),
 		connectionStateCache: make(processor.ConnectionStateCache),
 		channelStateCache:    make(processor.ChannelStateCache),

--- a/relayer/chains/cosmos/msg_handlers_packet_test.go
+++ b/relayer/chains/cosmos/msg_handlers_packet_test.go
@@ -26,8 +26,10 @@ func mockCosmosChainProcessor(t *testing.T) *CosmosChainProcessor {
 		provider      = cosmos.CosmosProvider{PCfg: cosmos.CosmosProviderConfig{ChainID: chainID1}}
 	)
 
-	ccp, err := NewCosmosChainProcessor(log, &provider, "", os.Stdin, os.Stdout, []*processor.PathProcessor{pathProcessor})
+	ccp, err := NewCosmosChainProcessor(log, &provider, "", os.Stdin, os.Stdout)
 	require.NoError(t, err, "error constructing cosmos chain processor")
+
+	ccp.SetPathProcessors(processor.PathProcessors{pathProcessor})
 
 	applicable := pathProcessor.SetChainProviderIfApplicable(&provider)
 	require.True(t, applicable, "error setting path processor reference to chain processor")

--- a/relayer/chains/cosmos/msg_handlers_packet_test.go
+++ b/relayer/chains/cosmos/msg_handlers_packet_test.go
@@ -1,7 +1,8 @@
 package cosmos
 
 import (
-	"os"
+	"bytes"
+	"io"
 	"testing"
 
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
@@ -26,7 +27,7 @@ func mockCosmosChainProcessor(t *testing.T) *CosmosChainProcessor {
 		provider      = cosmos.CosmosProvider{PCfg: cosmos.CosmosProviderConfig{ChainID: chainID1}}
 	)
 
-	ccp, err := NewCosmosChainProcessor(log, &provider, "", os.Stdin, os.Stdout)
+	ccp, err := NewCosmosChainProcessor(log, &provider, "", bytes.NewReader(nil), io.Discard)
 	require.NoError(t, err, "error constructing cosmos chain processor")
 
 	ccp.SetPathProcessors(processor.PathProcessors{pathProcessor})

--- a/relayer/processor/event_processor.go
+++ b/relayer/processor/event_processor.go
@@ -25,9 +25,9 @@ func NewEventProcessor() EventProcessorBuilder {
 	return EventProcessorBuilder{}
 }
 
-// WithChainProcessors will set the ChainProcessors to be used.
+// WithChainProcessors will add to the list of ChainProcessors to be used.
 func (ep EventProcessorBuilder) WithChainProcessors(chainProcessors ...ChainProcessor) EventProcessorBuilder {
-	ep.chainProcessors = chainProcessors
+	ep.chainProcessors = append(ep.chainProcessors, chainProcessors...)
 	return ep
 }
 
@@ -37,9 +37,9 @@ func (ep EventProcessorBuilder) WithInitialBlockHistory(initialBlockHistory uint
 	return ep
 }
 
-// WithPathProcessors will set the PathProcessors to be used.
+// WithPathProcessors will add to the list of PathProcessors to be used.
 func (ep EventProcessorBuilder) WithPathProcessors(pathProcessors ...*PathProcessor) EventProcessorBuilder {
-	ep.pathProcessors = pathProcessors
+	ep.pathProcessors = append(ep.pathProcessors, pathProcessors...)
 	return ep
 }
 

--- a/relayer/processor/event_processor.go
+++ b/relayer/processor/event_processor.go
@@ -25,25 +25,34 @@ func NewEventProcessor() EventProcessorBuilder {
 	return EventProcessorBuilder{}
 }
 
-// WithChainProcessors will add to the list of ChainProcessors to be used.
+// WithChainProcessors adds to the list of ChainProcessors to be used
+// if the chain name has not already been added.
 func (ep EventProcessorBuilder) WithChainProcessors(chainProcessors ...ChainProcessor) EventProcessorBuilder {
-	ep.chainProcessors = append(ep.chainProcessors, chainProcessors...)
+ChainProcessorLoop:
+	for _, cp := range chainProcessors {
+		for _, existingCp := range ep.chainProcessors {
+			if existingCp.Provider().ChainName() == cp.Provider().ChainName() {
+				continue ChainProcessorLoop
+			}
+		}
+		ep.chainProcessors = append(ep.chainProcessors, cp)
+	}
 	return ep
 }
 
-// WithInitialBlockHistory will set the initial block history to query for the ChainProcessors.
+// WithInitialBlockHistory sets the initial block history to query for the ChainProcessors.
 func (ep EventProcessorBuilder) WithInitialBlockHistory(initialBlockHistory uint64) EventProcessorBuilder {
 	ep.initialBlockHistory = initialBlockHistory
 	return ep
 }
 
-// WithPathProcessors will add to the list of PathProcessors to be used.
+// WithPathProcessors adds to the list of PathProcessors to be used.
 func (ep EventProcessorBuilder) WithPathProcessors(pathProcessors ...*PathProcessor) EventProcessorBuilder {
 	ep.pathProcessors = append(ep.pathProcessors, pathProcessors...)
 	return ep
 }
 
-// Build will link the relevant ChainProcessors and PathProcessors, then return an EventProcessor that can be used to run the ChainProcessors and PathProcessors.
+// Build links the relevant ChainProcessors and PathProcessors, then returns an EventProcessor that can be used to run the ChainProcessors and PathProcessors.
 func (ep EventProcessorBuilder) Build() EventProcessor {
 	for _, chainProcessor := range ep.chainProcessors {
 		pathProcessorsForThisChain := PathProcessors{}

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -29,28 +29,23 @@ func StartRelayer(ctx context.Context, log *zap.Logger, src, dst *Chain, stdin i
 	errorChan := make(chan error, 1)
 
 	if useEventProcessor {
-		var allowedSrc, allowedDst, blockedSrc, blockedDst []processor.ChannelKey
+		var filterSrc, filterDst []processor.ChannelKey
 
 		for _, ch := range filter.ChannelList {
 			ruleSrc := processor.ChannelKey{ChannelID: ch}
 			ruleDst := processor.ChannelKey{CounterpartyChannelID: ch}
-			if filter.Rule == allowList {
-				allowedSrc = append(allowedSrc, ruleSrc)
-				allowedDst = append(allowedDst, ruleDst)
-			} else if filter.Rule == denyList {
-				blockedSrc = append(blockedSrc, ruleSrc)
-				blockedDst = append(blockedDst, ruleDst)
-			}
+			filterSrc = append(filterSrc, ruleSrc)
+			filterDst = append(filterDst, ruleDst)
 		}
-		paths := []path{path{
+		paths := []path{{
 			src: pathChain{
 				provider:   src.ChainProvider,
-				pathEnd:    processor.NewPathEnd(src.ChainProvider.ChainId(), src.ClientID(), allowedSrc, blockedSrc),
+				pathEnd:    processor.NewPathEnd(src.ChainProvider.ChainId(), src.ClientID(), filter.Rule, filterSrc),
 				rpcAddress: src.RPCAddr,
 			},
 			dst: pathChain{
 				provider:   dst.ChainProvider,
-				pathEnd:    processor.NewPathEnd(dst.ChainProvider.ChainId(), dst.ClientID(), allowedDst, blockedDst),
+				pathEnd:    processor.NewPathEnd(dst.ChainProvider.ChainId(), dst.ClientID(), filter.Rule, filterDst),
 				rpcAddress: dst.RPCAddr,
 			},
 		}}

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -45,12 +45,12 @@ func StartRelayer(ctx context.Context, log *zap.Logger, src, dst *Chain, stdin i
 		paths := []path{path{
 			src: pathChain{
 				provider:   src.ChainProvider,
-				pathEnd:    processor.NewPathEnd(src.ChainProvider.ChainId(), src.ClientID(), []string{src.ConnectionID()}, allowedSrc, blockedSrc),
+				pathEnd:    processor.NewPathEnd(src.ChainProvider.ChainId(), src.ClientID(), allowedSrc, blockedSrc),
 				rpcAddress: src.RPCAddr,
 			},
 			dst: pathChain{
 				provider:   dst.ChainProvider,
-				pathEnd:    processor.NewPathEnd(dst.ChainProvider.ChainId(), dst.ClientID(), []string{dst.ConnectionID()}, allowedDst, blockedDst),
+				pathEnd:    processor.NewPathEnd(dst.ChainProvider.ChainId(), dst.ClientID(), allowedDst, blockedDst),
 				rpcAddress: dst.RPCAddr,
 			},
 		}}


### PR DESCRIPTION
Add `--events`/`-e` flag for relaying using the event processor architecture. Initial block history to query can be configured using `--block-history`/`-h` flag.

Enables event processor architecture relaying in the chain tests.