### PR TITLE
EventProcessor bugfixes

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -361,5 +361,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		})
 	}
 
+	persistence.latestQueriedBlock = persistence.latestHeight
+
 	return nil
 }

--- a/relayer/chains/cosmos/msg_handlers_channel.go
+++ b/relayer/chains/cosmos/msg_handlers_channel.go
@@ -14,7 +14,7 @@ import (
 // a MsgChannelOpenTry will be sent to the counterparty chain using this information
 // with the channel open init proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgChannelOpenInit(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	k := ci.channelKey()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelOpenInit, cosmos.NewCosmosMessage(&chantypes.MsgChannelOpenTry{
 		PortId:            k.PortID,
@@ -39,7 +39,7 @@ func (ccp *CosmosChainProcessor) handleMsgChannelOpenInit(p msgHandlerParams) {
 // will be sent to the counterparty chain using this information with the
 // channel open try proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgChannelOpenTry(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	// using flipped counterparty since counterparty initialized this handshake
 	k := ci.channelKey().Counterparty()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelOpenTry, cosmos.NewCosmosMessage(&chantypes.MsgChannelOpenAck{
@@ -58,7 +58,7 @@ func (ccp *CosmosChainProcessor) handleMsgChannelOpenTry(p msgHandlerParams) {
 // a MsgChannelOpenConfirm will be sent to the counterparty chain
 // using this information with the channel open ack proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgChannelOpenAck(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	k := ci.channelKey()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelOpenAck, cosmos.NewCosmosMessage(&chantypes.MsgChannelOpenConfirm{
 		PortId:    k.PortID,
@@ -73,7 +73,7 @@ func (ccp *CosmosChainProcessor) handleMsgChannelOpenAck(p msgHandlerParams) {
 // for the counterparty chain after the MsgChannelOpenConfirm is observed, but we want to
 // tell the PathProcessor that the channel handshake is complete for this channel.
 func (ccp *CosmosChainProcessor) handleMsgChannelOpenConfirm(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	// using flipped counterparty since counterparty initialized this handshake
 	k := ci.channelKey().Counterparty()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelOpenConfirm, nil)
@@ -87,7 +87,7 @@ func (ccp *CosmosChainProcessor) handleMsgChannelOpenConfirm(p msgHandlerParams)
 // a MsgChannelCloseConfirm will be sent to the counterparty chain
 // using this information with the channel close init proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgChannelCloseInit(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	k := ci.channelKey()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelCloseInit, cosmos.NewCosmosMessage(&chantypes.MsgChannelCloseConfirm{
 		PortId:    k.PortID,
@@ -102,7 +102,7 @@ func (ccp *CosmosChainProcessor) handleMsgChannelCloseInit(p msgHandlerParams) {
 // for the counterparty chain after the MsgChannelCloseConfirm is observed, but we want to
 // tell the PathProcessor that the channel close is complete for this channel.
 func (ccp *CosmosChainProcessor) handleMsgChannelCloseConfirm(p msgHandlerParams) {
-	ci := p.messageInfo.(*channelInfo)
+	ci := p.messageInfo.(channelInfo)
 	// using flipped counterparty since counterparty initialized this channel close
 	k := ci.channelKey().Counterparty()
 	p.ibcMessagesCache.ChannelHandshake.Retain(k, processor.MsgChannelCloseConfirm, nil)
@@ -110,12 +110,12 @@ func (ccp *CosmosChainProcessor) handleMsgChannelCloseConfirm(p msgHandlerParams
 	ccp.logChannelMessage("MsgChannelCloseConfirm", ci)
 }
 
-func (ccp *CosmosChainProcessor) logChannelMessage(message string, channelInfo *channelInfo) {
+func (ccp *CosmosChainProcessor) logChannelMessage(message string, ci channelInfo) {
 	ccp.logObservedIBCMessage(message,
-		zap.String("channel_id", channelInfo.channelID),
-		zap.String("port_id", channelInfo.portID),
-		zap.String("counterparty_channel_id", channelInfo.counterpartyChannelID),
-		zap.String("counterparty_port_id", channelInfo.counterpartyPortID),
-		zap.String("connection_id", channelInfo.connectionID),
+		zap.String("channel_id", ci.channelID),
+		zap.String("port_id", ci.portID),
+		zap.String("counterparty_channel_id", ci.counterpartyChannelID),
+		zap.String("counterparty_port_id", ci.counterpartyPortID),
+		zap.String("connection_id", ci.connectionID),
 	)
 }

--- a/relayer/chains/cosmos/msg_handlers_channel_test.go
+++ b/relayer/chains/cosmos/msg_handlers_channel_test.go
@@ -17,7 +17,7 @@ func TestHandleChannelHandshake(t *testing.T) {
 
 	ccp := mockCosmosChainProcessor(t)
 
-	channelInfo := &channelInfo{
+	ci := channelInfo{
 		channelID:             srcChannel,
 		portID:                srcPort,
 		counterpartyChannelID: dstChannel,
@@ -26,9 +26,9 @@ func TestHandleChannelHandshake(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	ccp.handleMsgChannelOpenInit(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgChannelOpenInit(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
-	channelKey := channelInfo.channelKey()
+	channelKey := ci.channelKey()
 
 	channelOpen, ok := ccp.channelStateCache[channelKey]
 	require.True(t, ok, "unable to find channel state for channel key")
@@ -45,7 +45,7 @@ func TestHandleChannelHandshake(t *testing.T) {
 
 	require.NotNil(t, openInitMessage)
 
-	ccp.handleMsgChannelOpenAck(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgChannelOpenAck(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
 	channelOpen, ok = ccp.channelStateCache[channelKey]
 	require.True(t, ok, "unable to find channel state for channel key")
@@ -79,7 +79,7 @@ func TestHandleChannelHandshakeCounterparty(t *testing.T) {
 
 	ccp := mockCosmosChainProcessor(t)
 
-	channelInfo := &channelInfo{
+	ci := channelInfo{
 		channelID:             srcChannel,
 		portID:                srcPort,
 		counterpartyChannelID: dstChannel,
@@ -88,9 +88,9 @@ func TestHandleChannelHandshakeCounterparty(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	ccp.handleMsgChannelOpenTry(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgChannelOpenTry(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
-	channelKey := channelInfo.channelKey().Counterparty()
+	channelKey := ci.channelKey().Counterparty()
 
 	channelOpen, ok := ccp.channelStateCache[channelKey]
 	require.True(t, ok, "unable to find channel state for channel key")
@@ -107,7 +107,7 @@ func TestHandleChannelHandshakeCounterparty(t *testing.T) {
 
 	require.NotNil(t, openTryMessage)
 
-	ccp.handleMsgChannelOpenConfirm(msgHandlerParams{messageInfo: channelInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgChannelOpenConfirm(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
 	channelOpen, ok = ccp.channelStateCache[channelKey]
 	require.True(t, ok, "unable to find channel state for channel key")

--- a/relayer/chains/cosmos/msg_handlers_client.go
+++ b/relayer/chains/cosmos/msg_handlers_client.go
@@ -5,29 +5,29 @@ import (
 )
 
 func (ccp *CosmosChainProcessor) handleMsgCreateClient(p msgHandlerParams) {
-	clientInfo := p.messageInfo.(*clientInfo)
+	clientInfo := p.messageInfo.(clientInfo)
 	// save the latest consensus height and header for this client
-	ccp.latestClientState.UpdateLatestClientState(*clientInfo)
+	ccp.latestClientState.UpdateLatestClientState(clientInfo)
 	ccp.logObservedIBCMessage("MsgCreateClient", zap.String("client_id", clientInfo.clientID))
 }
 
 func (ccp *CosmosChainProcessor) handleMsgUpdateClient(p msgHandlerParams) {
-	clientInfo := p.messageInfo.(*clientInfo)
+	clientInfo := p.messageInfo.(clientInfo)
 	// save the latest consensus height and header for this client
-	ccp.latestClientState.UpdateLatestClientState(*clientInfo)
+	ccp.latestClientState.UpdateLatestClientState(clientInfo)
 	ccp.logObservedIBCMessage("MsgUpdateClient", zap.String("client_id", clientInfo.clientID))
 }
 
 func (ccp *CosmosChainProcessor) handleMsgUpgradeClient(p msgHandlerParams) {
-	clientInfo := p.messageInfo.(*clientInfo)
+	clientInfo := p.messageInfo.(clientInfo)
 	// save the latest consensus height and header for this client
-	ccp.latestClientState.UpdateLatestClientState(*clientInfo)
+	ccp.latestClientState.UpdateLatestClientState(clientInfo)
 	ccp.logObservedIBCMessage("MsgUpgradeClient", zap.String("client_id", clientInfo.clientID))
 }
 
 func (ccp *CosmosChainProcessor) handleMsgSubmitMisbehaviour(p msgHandlerParams) {
-	clientInfo := p.messageInfo.(*clientInfo)
+	clientInfo := p.messageInfo.(clientInfo)
 	// save the latest consensus height and header for this client
-	ccp.latestClientState.UpdateLatestClientState(*clientInfo)
+	ccp.latestClientState.UpdateLatestClientState(clientInfo)
 	ccp.logObservedIBCMessage("MsgSubmitMisbehaviour", zap.String("client_id", clientInfo.clientID))
 }

--- a/relayer/chains/cosmos/msg_handlers_connection.go
+++ b/relayer/chains/cosmos/msg_handlers_connection.go
@@ -14,7 +14,7 @@ import (
 // yet on this chain, a MsgConnectionOpenTry will be sent to the counterparty chain
 // using this information with the connection init proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgConnectionOpenInit(p msgHandlerParams) {
-	ci := p.messageInfo.(*connectionInfo)
+	ci := p.messageInfo.(connectionInfo)
 	k := ci.connectionKey()
 	p.ibcMessagesCache.ConnectionHandshake.Retain(k, processor.MsgConnectionOpenInit, cosmos.NewCosmosMessage(&conntypes.MsgConnectionOpenTry{
 		ClientId:             k.ClientID,
@@ -35,7 +35,7 @@ func (ccp *CosmosChainProcessor) handleMsgConnectionOpenInit(p msgHandlerParams)
 // a MsgConnectionOpenAck will be sent to the counterparty chain
 // using this information with the connection try proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgConnectionOpenTry(p msgHandlerParams) {
-	ci := p.messageInfo.(*connectionInfo)
+	ci := p.messageInfo.(connectionInfo)
 	k := ci.connectionKey().Counterparty()
 	p.ibcMessagesCache.ConnectionHandshake.Retain(k, processor.MsgConnectionOpenTry, cosmos.NewCosmosMessage(&conntypes.MsgConnectionOpenAck{
 		ConnectionId:             k.ConnectionID,
@@ -51,7 +51,7 @@ func (ccp *CosmosChainProcessor) handleMsgConnectionOpenTry(p msgHandlerParams) 
 // a MsgConnectionOpenConfirm will be sent to the counterparty chain
 // using this information with the connection ack proof from this chain added.
 func (ccp *CosmosChainProcessor) handleMsgConnectionOpenAck(p msgHandlerParams) {
-	ci := p.messageInfo.(*connectionInfo)
+	ci := p.messageInfo.(connectionInfo)
 	k := ci.connectionKey()
 	p.ibcMessagesCache.ConnectionHandshake.Retain(k, processor.MsgConnectionOpenAck, cosmos.NewCosmosMessage(&conntypes.MsgConnectionOpenConfirm{
 		ConnectionId: k.ConnectionID,
@@ -65,16 +65,18 @@ func (ccp *CosmosChainProcessor) handleMsgConnectionOpenAck(p msgHandlerParams) 
 // A message does not need to be constructed for the counterparty chain after the MsgConnectionOpenConfirm is observed,
 // but we want to tell the PathProcessor that the connection handshake is complete for this sequence.
 func (ccp *CosmosChainProcessor) handleMsgConnectionOpenConfirm(p msgHandlerParams) {
-	ci := p.messageInfo.(*connectionInfo)
+	ci := p.messageInfo.(connectionInfo)
 	k := ci.connectionKey().Counterparty()
 	p.ibcMessagesCache.ConnectionHandshake.Retain(k, processor.MsgConnectionOpenConfirm, nil)
 	ccp.connectionStateCache[k] = true
 	ccp.logConnectionMessage("MsgConnectionOpenConfirm", ci)
 }
 
-func (ccp *CosmosChainProcessor) logConnectionMessage(message string, connectionInfo *connectionInfo) {
-	ccp.logObservedIBCMessage(message, zap.String("client_id", connectionInfo.clientID),
-		zap.String("connection_id", connectionInfo.connectionID),
-		zap.String("counterparty_client_id", connectionInfo.counterpartyClientID),
-		zap.String("counterparty_connection_id", connectionInfo.counterpartyConnectionID))
+func (ccp *CosmosChainProcessor) logConnectionMessage(message string, ci connectionInfo) {
+	ccp.logObservedIBCMessage(message,
+		zap.String("client_id", ci.clientID),
+		zap.String("connection_id", ci.connectionID),
+		zap.String("counterparty_client_id", ci.counterpartyClientID),
+		zap.String("counterparty_connection_id", ci.counterpartyConnectionID),
+	)
 }

--- a/relayer/chains/cosmos/msg_handlers_connection_test.go
+++ b/relayer/chains/cosmos/msg_handlers_connection_test.go
@@ -17,7 +17,7 @@ func TestHandleConnectionHandshake(t *testing.T) {
 
 	ccp := mockCosmosChainProcessor(t)
 
-	connectionInfo := &connectionInfo{
+	ci := connectionInfo{
 		connectionID:             srcConnection,
 		clientID:                 srcClient,
 		counterpartyClientID:     dstClient,
@@ -26,9 +26,9 @@ func TestHandleConnectionHandshake(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	ccp.handleMsgConnectionOpenInit(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgConnectionOpenInit(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
-	connectionKey := connectionInfo.connectionKey()
+	connectionKey := ci.connectionKey()
 
 	connectionOpen, ok := ccp.connectionStateCache[connectionKey]
 	require.True(t, ok, "unable to find connection state for connection key")
@@ -45,7 +45,7 @@ func TestHandleConnectionHandshake(t *testing.T) {
 
 	require.NotNil(t, openInitMessage)
 
-	ccp.handleMsgConnectionOpenAck(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgConnectionOpenAck(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
 	connectionOpen, ok = ccp.connectionStateCache[connectionKey]
 	require.True(t, ok, "unable to find connection state for connection key")
@@ -80,7 +80,7 @@ func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
 
 	ccp := mockCosmosChainProcessor(t)
 
-	connectionInfo := &connectionInfo{
+	ci := connectionInfo{
 		connectionID:             srcConnection,
 		clientID:                 srcClient,
 		counterpartyClientID:     dstClient,
@@ -89,9 +89,9 @@ func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	ccp.handleMsgConnectionOpenTry(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgConnectionOpenTry(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
-	connectionKey := connectionInfo.connectionKey().Counterparty()
+	connectionKey := ci.connectionKey().Counterparty()
 
 	connectionOpen, ok := ccp.connectionStateCache[connectionKey]
 	require.True(t, ok, "unable to find connection state for connection key")
@@ -108,7 +108,7 @@ func TestHandleConnectionHandshakeCounterparty(t *testing.T) {
 
 	require.NotNil(t, openTryMessage)
 
-	ccp.handleMsgConnectionOpenConfirm(msgHandlerParams{messageInfo: connectionInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgConnectionOpenConfirm(msgHandlerParams{messageInfo: ci, ibcMessagesCache: ibcMessagesCache})
 
 	connectionOpen, ok = ccp.connectionStateCache[connectionKey]
 	require.True(t, ok, "unable to find connection state for connection key")

--- a/relayer/chains/cosmos/msg_handlers_packet.go
+++ b/relayer/chains/cosmos/msg_handlers_packet.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ccp *CosmosChainProcessor) handleMsgTransfer(p msgHandlerParams) {
-	pi := p.messageInfo.(*packetInfo)
+	pi := p.messageInfo.(packetInfo)
 	// source chain processor will call this handler
 	// source channel used as key because MsgTransfer is sent to source chain
 	channelKey := pi.channelKey()
@@ -41,7 +41,7 @@ func (ccp *CosmosChainProcessor) handleMsgTransfer(p msgHandlerParams) {
 }
 
 func (ccp *CosmosChainProcessor) handleMsgRecvPacket(p msgHandlerParams) {
-	pi := p.messageInfo.(*packetInfo)
+	pi := p.messageInfo.(packetInfo)
 	// destination chain processor will call this handler
 	// destination channel used because MsgRecvPacket is sent to destination chain
 	channelKey := pi.channelKey().Counterparty()
@@ -70,7 +70,7 @@ func (ccp *CosmosChainProcessor) handleMsgRecvPacket(p msgHandlerParams) {
 }
 
 func (ccp *CosmosChainProcessor) handleMsgAcknowledgement(p msgHandlerParams) {
-	pi := p.messageInfo.(*packetInfo)
+	pi := p.messageInfo.(packetInfo)
 	// source chain processor will call this handler
 	// source channel used as key because MsgAcknowledgement is sent to source chain
 	channelKey := pi.channelKey()
@@ -85,7 +85,7 @@ func (ccp *CosmosChainProcessor) handleMsgAcknowledgement(p msgHandlerParams) {
 }
 
 func (ccp *CosmosChainProcessor) handleMsgTimeout(p msgHandlerParams) {
-	pi := p.messageInfo.(*packetInfo)
+	pi := p.messageInfo.(packetInfo)
 	// source chain processor will call this handler
 	// source channel used as key because MsgTimeout is sent to source chain
 	channelKey := pi.channelKey()
@@ -100,7 +100,7 @@ func (ccp *CosmosChainProcessor) handleMsgTimeout(p msgHandlerParams) {
 }
 
 func (ccp *CosmosChainProcessor) handleMsgTimeoutOnClose(p msgHandlerParams) {
-	pi := p.messageInfo.(*packetInfo)
+	pi := p.messageInfo.(packetInfo)
 	// source channel used because timeout is sent to source chain
 	channelKey := pi.channelKey()
 	if !p.ibcMessagesCache.PacketFlow.ShouldRetainSequence(ccp.pathProcessors, channelKey, ccp.chainProvider.ChainId(), processor.MsgTimeoutOnClose, pi.packet.Sequence) {
@@ -113,7 +113,7 @@ func (ccp *CosmosChainProcessor) handleMsgTimeoutOnClose(p msgHandlerParams) {
 	ccp.logPacketMessage("MsgTimeoutOnClose", pi)
 }
 
-func (ccp *CosmosChainProcessor) logPacketMessage(message string, pi *packetInfo, additionalFields ...zap.Field) {
+func (ccp *CosmosChainProcessor) logPacketMessage(message string, pi packetInfo, additionalFields ...zap.Field) {
 	fields := []zap.Field{
 		zap.Uint64("sequence", pi.packet.Sequence),
 		zap.String("src_channel", pi.packet.SourceChannel),

--- a/relayer/chains/cosmos/msg_handlers_packet_test.go
+++ b/relayer/chains/cosmos/msg_handlers_packet_test.go
@@ -53,7 +53,7 @@ func TestHandleMsgTransfer(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	packetInfo := &packetInfo{
+	pi := packetInfo{
 		packet: chantypes.Packet{
 			Data:               packetData,
 			Sequence:           sequence,
@@ -69,11 +69,11 @@ func TestHandleMsgTransfer(t *testing.T) {
 		},
 	}
 
-	ccp.handleMsgTransfer(msgHandlerParams{messageInfo: packetInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgTransfer(msgHandlerParams{messageInfo: pi, ibcMessagesCache: ibcMessagesCache})
 
 	require.Len(t, ibcMessagesCache.PacketFlow, 1)
 
-	channelKey := packetInfo.channelKey()
+	channelKey := pi.channelKey()
 
 	channelMessages, ok := ibcMessagesCache.PacketFlow[channelKey]
 	require.True(t, ok, "unable to find messages for channel key")
@@ -94,7 +94,7 @@ func TestHandleMsgTransfer(t *testing.T) {
 	msgRecvPacket, ok := cosmosMsg.(*chantypes.MsgRecvPacket)
 	require.True(t, ok, "unable to read message as MsgRecvPacket")
 
-	require.Empty(t, cmp.Diff(packetInfo.packet, msgRecvPacket.Packet), "MsgRecvPacket data does not match MsgTransfer data")
+	require.Empty(t, cmp.Diff(pi.packet, msgRecvPacket.Packet), "MsgRecvPacket data does not match MsgTransfer data")
 }
 
 func TestHandleMsgRecvPacket(t *testing.T) {
@@ -113,7 +113,7 @@ func TestHandleMsgRecvPacket(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	packetInfo := &packetInfo{
+	pi := packetInfo{
 		packet: chantypes.Packet{
 			Data:               packetData,
 			Sequence:           sequence,
@@ -125,12 +125,12 @@ func TestHandleMsgRecvPacket(t *testing.T) {
 		ack: packetAck,
 	}
 
-	ccp.handleMsgRecvPacket(msgHandlerParams{messageInfo: packetInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgRecvPacket(msgHandlerParams{messageInfo: pi, ibcMessagesCache: ibcMessagesCache})
 
 	require.Len(t, ibcMessagesCache.PacketFlow, 1)
 
 	// flipped on purpose since MsgRecvPacket is committed on counterparty chain
-	channelKey := packetInfo.channelKey().Counterparty()
+	channelKey := pi.channelKey().Counterparty()
 
 	channelMessages, ok := ibcMessagesCache.PacketFlow[channelKey]
 	require.True(t, ok, "unable to find messages for channel key")
@@ -151,7 +151,7 @@ func TestHandleMsgRecvPacket(t *testing.T) {
 	msgRecvPacket, ok := cosmosMsg.(*chantypes.MsgAcknowledgement)
 	require.True(t, ok, "unable to read message as MsgAcknowledgement")
 
-	require.Empty(t, cmp.Diff(packetInfo.packet, msgRecvPacket.Packet), "MsgAcknowledgement data does not match MsgRecvPacket data")
+	require.Empty(t, cmp.Diff(pi.packet, msgRecvPacket.Packet), "MsgAcknowledgement data does not match MsgRecvPacket data")
 }
 
 func TestHandleMsgAcknowledgement(t *testing.T) {
@@ -169,7 +169,7 @@ func TestHandleMsgAcknowledgement(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	packetInfo := &packetInfo{
+	pi := packetInfo{
 		packet: chantypes.Packet{
 			Data:               packetData,
 			Sequence:           sequence,
@@ -180,11 +180,11 @@ func TestHandleMsgAcknowledgement(t *testing.T) {
 		},
 	}
 
-	ccp.handleMsgAcknowledgement(msgHandlerParams{messageInfo: packetInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgAcknowledgement(msgHandlerParams{messageInfo: pi, ibcMessagesCache: ibcMessagesCache})
 
 	require.Len(t, ibcMessagesCache.PacketFlow, 1)
 
-	channelKey := packetInfo.channelKey()
+	channelKey := pi.channelKey()
 
 	channelMessages, ok := ibcMessagesCache.PacketFlow[channelKey]
 	require.True(t, ok, "unable to find messages for channel key")
@@ -217,7 +217,7 @@ func TestHandleMsgTimeout(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	packetInfo := &packetInfo{
+	pi := packetInfo{
 		packet: chantypes.Packet{
 			Data:               packetData,
 			Sequence:           sequence,
@@ -228,11 +228,11 @@ func TestHandleMsgTimeout(t *testing.T) {
 		},
 	}
 
-	ccp.handleMsgTimeout(msgHandlerParams{messageInfo: packetInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgTimeout(msgHandlerParams{messageInfo: pi, ibcMessagesCache: ibcMessagesCache})
 
 	require.Len(t, ibcMessagesCache.PacketFlow, 1)
 
-	channelKey := packetInfo.channelKey()
+	channelKey := pi.channelKey()
 
 	channelMessages, ok := ibcMessagesCache.PacketFlow[channelKey]
 	require.True(t, ok, "unable to find messages for channel key")
@@ -265,7 +265,7 @@ func TestHandleMsgTimeoutOnClose(t *testing.T) {
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 
-	packetInfo := &packetInfo{
+	pi := packetInfo{
 		packet: chantypes.Packet{
 			Data:               packetData,
 			Sequence:           sequence,
@@ -276,11 +276,11 @@ func TestHandleMsgTimeoutOnClose(t *testing.T) {
 		},
 	}
 
-	ccp.handleMsgTimeoutOnClose(msgHandlerParams{messageInfo: packetInfo, ibcMessagesCache: ibcMessagesCache})
+	ccp.handleMsgTimeoutOnClose(msgHandlerParams{messageInfo: pi, ibcMessagesCache: ibcMessagesCache})
 
 	require.Len(t, ibcMessagesCache.PacketFlow, 1)
 
-	channelKey := packetInfo.channelKey()
+	channelKey := pi.channelKey()
 
 	channelMessages, ok := ibcMessagesCache.PacketFlow[channelKey]
 	require.True(t, ok, "unable to find messages for channel key")

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -49,6 +49,9 @@ func newPathEndRuntime(pathEnd PathEnd) *pathEndRuntime {
 		channelStateCache:    make(ChannelStateCache),
 		messageCache:         NewIBCMessagesCache(),
 		ibcHeaderCache:       make(IBCHeaderCache),
+		packetSendCache:      make(packetSendCache),
+		connectionSendCache:  make(connectionSendCache),
+		channelSendCache:     make(channelSendCache),
 	}
 }
 
@@ -68,7 +71,7 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 	channelHandshakeMessages := make(ChannelMessagesCache)
 
 	for ch, pmc := range messageCache.PacketFlow {
-		if !pathEnd.info.ShouldRelayChannel(ch) {
+		if pathEnd.info.ShouldRelayChannel(ch) {
 			packetMessages[ch] = pmc
 		}
 	}

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/cosmos/relayer/v2/relayer/provider"
-	"go.uber.org/zap"
 )
 
 // shouldSendPacketMessage determines if the packet flow message should be sent now.

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/relayer/v2/relayer/provider"
+	"go.uber.org/zap"
 )
 
 // shouldSendPacketMessage determines if the packet flow message should be sent now.
@@ -145,11 +146,13 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 func (pathEnd *pathEndRuntime) trackSentPacketMessage(message packetIBCMessage) {
 	msgSendCache, ok := pathEnd.packetSendCache[message.channelKey]
 	if !ok {
-		pathEnd.packetSendCache[message.channelKey] = make(packetChannelMessageCache)
+		msgSendCache = make(packetChannelMessageCache)
+		pathEnd.packetSendCache[message.channelKey] = msgSendCache
 	}
 	channelSendCache, ok := msgSendCache[message.action]
 	if !ok {
-		msgSendCache[message.action] = make(packetMessageSendCache)
+		channelSendCache = make(packetMessageSendCache)
+		msgSendCache[message.action] = channelSendCache
 	}
 
 	retryCount := uint64(0)
@@ -168,7 +171,8 @@ func (pathEnd *pathEndRuntime) trackSentPacketMessage(message packetIBCMessage) 
 func (pathEnd *pathEndRuntime) trackSentConnectionMessage(message connectionIBCMessage) {
 	msgSendCache, ok := pathEnd.connectionSendCache[message.action]
 	if !ok {
-		pathEnd.connectionSendCache[message.action] = make(connectionKeySendCache)
+		msgSendCache = make(connectionKeySendCache)
+		pathEnd.connectionSendCache[message.action] = msgSendCache
 	}
 
 	retryCount := uint64(0)
@@ -187,7 +191,8 @@ func (pathEnd *pathEndRuntime) trackSentConnectionMessage(message connectionIBCM
 func (pathEnd *pathEndRuntime) trackSentChannelMessage(message channelIBCMessage) {
 	msgSendCache, ok := pathEnd.channelSendCache[message.action]
 	if !ok {
-		pathEnd.channelSendCache[message.action] = make(channelKeySendCache)
+		msgSendCache = make(channelKeySendCache)
+		pathEnd.channelSendCache[message.action] = msgSendCache
 	}
 
 	retryCount := uint64(0)


### PR DESCRIPTION
When hooking up the EventProcessor architecture behind a flag after the chunked review/merge, I found a few bugs such as not instantiating maps, casting to pointer types on accident, and not updating the latestQueried.