### PR TITLE
PathProcessor - msg assembly optimization

### DIFF
--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"sync"
 	"time"
 
 	"github.com/cosmos/relayer/v2/relayer/provider"
@@ -176,90 +175,26 @@ func (pp *PathProcessor) HandleNewData(chainID string, cacheData ChainProcessorC
 func (pp *PathProcessor) assemblePacketIBCMessage(
 	ctx context.Context,
 	src, dst *pathEndRuntime,
-	channelKey ChannelKey,
-	action string,
-	sequence uint64,
-	partialMessage provider.RelayerMessage,
+	partialMessage packetIBCMessage,
 	assembleMessage func(ctx context.Context, msgRecvPacket provider.RelayerMessage, signer string, latest provider.LatestBlock) (provider.RelayerMessage, error),
-	messages *[]packetIBCMessage,
-) error {
-	packetMsg := packetIBCMessage{channelKey: channelKey, action: action, sequence: sequence, message: partialMessage}
-	// skip unneccessary message assembly queries if this message will not be sent this time anyways
-	if !dst.shouldSendPacketMessage(packetMsg, src) {
-		return nil
-	}
+) (provider.RelayerMessage, error) {
 	signer, err := dst.chainProvider.Address()
 	if err != nil {
-		return fmt.Errorf("error getting signer address for {%s}: %w", dst.info.ChainID, err)
+		return nil, fmt.Errorf("error getting signer address for {%s}: %w", dst.info.ChainID, err)
 	}
-	assembled, err := assembleMessage(ctx, partialMessage, signer, src.latestBlock)
+	assembled, err := assembleMessage(ctx, partialMessage.message, signer, src.latestBlock)
 	if err != nil {
-		return fmt.Errorf("error assembling %s for {%s}: %w", action, dst.info.ChainID, err)
+		return nil, fmt.Errorf("error assembling %s for {%s}: %w", partialMessage.action, dst.info.ChainID, err)
 	}
-	packetMsg.message = assembled
-	*messages = append(*messages, packetMsg)
-	return nil
+
+	return assembled, nil
 }
 
-func (pp *PathProcessor) appendPacketOrTimeout(ctx context.Context, src, dst *pathEndRuntime, channelKey ChannelKey, sequence uint64, msgRecvPacket provider.RelayerMessage, res *pathEndPacketFlowResponse) {
-	if err := dst.chainProvider.ValidatePacket(msgRecvPacket, dst.latestBlock); err != nil {
-		var timeoutHeightErr *provider.TimeoutHeightError
-		var timeoutTimestampErr *provider.TimeoutTimestampError
-		var timeoutOnCloseErr *provider.TimeoutOnCloseError
-
-		// if timeouts were detected, need to generate msgs for them for src
-		switch {
-		case errors.As(err, &timeoutHeightErr) || errors.As(err, &timeoutTimestampErr):
-			if err := pp.assemblePacketIBCMessage(ctx, dst, src, channelKey.Counterparty(), MsgTimeout, sequence, msgRecvPacket, dst.chainProvider.MsgTimeout, &res.SrcMessages); err != nil {
-				pp.log.Error("Error assembling MsgTimeout",
-					zap.Uint64("sequence", sequence),
-					zap.String("chain_id", src.info.ChainID),
-					zap.Error(err),
-				)
-			}
-		case errors.As(err, &timeoutOnCloseErr):
-			if err := pp.assemblePacketIBCMessage(ctx, dst, src, channelKey.Counterparty(), MsgTimeoutOnClose, sequence, msgRecvPacket, dst.chainProvider.MsgTimeoutOnClose, &res.SrcMessages); err != nil {
-				pp.log.Error("Error assembling MsgTimeoutOnClose",
-					zap.Uint64("sequence", sequence),
-					zap.String("chain_id", src.info.ChainID),
-					zap.Error(err),
-				)
-			}
-		default:
-			pp.log.Error("Packet is invalid",
-				zap.String("chain_id", src.info.ChainID),
-				zap.Error(err),
-			)
-		}
-		return
+func (pp *PathProcessor) getUnrelayedPacketsAndAcksAndToDelete(ctx context.Context, pathEndPacketFlowMessages pathEndPacketFlowMessages) pathEndPacketFlowResponse {
+	res := pathEndPacketFlowResponse{
+		ToDeleteSrc: make(map[string][]uint64),
+		ToDeleteDst: make(map[string][]uint64),
 	}
-	if err := pp.assemblePacketIBCMessage(ctx, src, dst, channelKey, MsgRecvPacket, sequence, msgRecvPacket, src.chainProvider.MsgRecvPacket, &res.DstMessages); err != nil {
-		pp.log.Error("Error assembling MsgRecvPacket",
-			zap.Uint64("sequence", sequence),
-			zap.String("src_chain_id", src.info.ChainID),
-			zap.String("dst_chain_id", dst.info.ChainID),
-			zap.Error(err),
-		)
-	}
-}
-
-func (pp *PathProcessor) appendAcknowledgement(ctx context.Context, src, dst *pathEndRuntime, channelKey ChannelKey, sequence uint64, msgAcknowledgement provider.RelayerMessage, messages *[]packetIBCMessage) {
-	if err := pp.assemblePacketIBCMessage(ctx, src, dst, channelKey, MsgAcknowledgement, sequence, msgAcknowledgement, src.chainProvider.MsgAcknowledgement, messages); err != nil {
-		pp.log.Error("Error assembling MsgAcknowledgement",
-			zap.Uint64("sequence", sequence),
-			zap.String("src_chain_id", src.info.ChainID),
-			zap.String("dst_chain_id", dst.info.ChainID),
-			zap.Error(err),
-		)
-	}
-}
-
-func (pp *PathProcessor) getUnrelayedPacketsAndAcksAndToDelete(ctx context.Context, pathEndPacketFlowMessages pathEndPacketFlowMessages, wg *sync.WaitGroup, res *pathEndPacketFlowResponse) {
-	defer wg.Done()
-	res.SrcMessages = nil
-	res.DstMessages = nil
-	res.ToDeleteSrc = make(map[string][]uint64)
-	res.ToDeleteDst = make(map[string][]uint64)
 
 MsgTransferLoop:
 	for transferSeq, msgTransfer := range pathEndPacketFlowMessages.SrcMsgTransfer {
@@ -294,12 +229,42 @@ MsgTransferLoop:
 		for msgRecvSeq, msgAcknowledgement := range pathEndPacketFlowMessages.DstMsgRecvPacket {
 			if transferSeq == msgRecvSeq {
 				// msg is received by dst chain, but no ack yet. Need to relay ack from dst to src!
-				pp.appendAcknowledgement(ctx, pathEndPacketFlowMessages.Dst, pathEndPacketFlowMessages.Src, pathEndPacketFlowMessages.ChannelKey, msgRecvSeq, msgAcknowledgement, &res.SrcMessages)
+				ackMsg := packetIBCMessage{channelKey: pathEndPacketFlowMessages.ChannelKey, action: MsgAcknowledgement, sequence: transferSeq, message: msgAcknowledgement}
+				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(ackMsg, pathEndPacketFlowMessages.Dst) {
+					res.SrcMessages = append(res.SrcMessages, ackMsg)
+				}
 				continue MsgTransferLoop
 			}
 		}
-		// Packet is not yet relayed! need to relay from src to dst
-		pp.appendPacketOrTimeout(ctx, pathEndPacketFlowMessages.Src, pathEndPacketFlowMessages.Dst, pathEndPacketFlowMessages.ChannelKey.Counterparty(), transferSeq, msgTransfer, res)
+		// Packet is not yet relayed! need to relay either MsgRecvPacket from src to dst, or MsgTimeout/MsgTimeoutOnClose from dst to src
+		if err := pathEndPacketFlowMessages.Dst.chainProvider.ValidatePacket(msgTransfer, pathEndPacketFlowMessages.Dst.latestBlock); err != nil {
+			var timeoutHeightErr *provider.TimeoutHeightError
+			var timeoutTimestampErr *provider.TimeoutTimestampError
+			var timeoutOnCloseErr *provider.TimeoutOnCloseError
+
+			switch {
+			case errors.As(err, &timeoutHeightErr) || errors.As(err, &timeoutTimestampErr):
+				timeoutMsg := packetIBCMessage{channelKey: pathEndPacketFlowMessages.ChannelKey, action: MsgTimeout, sequence: transferSeq, message: msgTransfer}
+				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(timeoutMsg, pathEndPacketFlowMessages.Dst) {
+					res.SrcMessages = append(res.SrcMessages, timeoutMsg)
+				}
+			case errors.As(err, &timeoutOnCloseErr):
+				timeoutOnCloseMsg := packetIBCMessage{channelKey: pathEndPacketFlowMessages.ChannelKey, action: MsgTimeoutOnClose, sequence: transferSeq, message: msgTransfer}
+				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(timeoutOnCloseMsg, pathEndPacketFlowMessages.Dst) {
+					res.SrcMessages = append(res.SrcMessages, timeoutOnCloseMsg)
+				}
+			default:
+				pp.log.Error("Packet is invalid",
+					zap.String("chain_id", pathEndPacketFlowMessages.Src.info.ChainID),
+					zap.Error(err),
+				)
+			}
+			continue MsgTransferLoop
+		}
+		recvPacketMsg := packetIBCMessage{channelKey: pathEndPacketFlowMessages.ChannelKey.Counterparty(), action: MsgRecvPacket, sequence: transferSeq, message: msgTransfer}
+		if pathEndPacketFlowMessages.Dst.shouldSendPacketMessage(recvPacketMsg, pathEndPacketFlowMessages.Src) {
+			res.DstMessages = append(res.DstMessages, recvPacketMsg)
+		}
 	}
 
 	// now iterate through packet-flow-complete messages and remove any leftover messages if the MsgTransfer or MsgRecvPacket was in a previous block that we did not query
@@ -316,17 +281,17 @@ MsgTransferLoop:
 		res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], timeoutOnCloseSeq)
 		res.ToDeleteSrc[MsgTimeoutOnClose] = append(res.ToDeleteSrc[MsgTimeoutOnClose], timeoutOnCloseSeq)
 	}
+	return res
 }
 
-func (pp *PathProcessor) getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEndConnectionHandshakeMessages pathEndConnectionHandshakeMessages, wg *sync.WaitGroup, res *pathEndConnectionHandshakeResponse) {
-	defer wg.Done()
-	res.SrcMessages = nil
-	res.DstMessages = nil
-	res.ToDeleteSrc = make(map[string][]ConnectionKey)
-	res.ToDeleteDst = make(map[string][]ConnectionKey)
+func (pp *PathProcessor) getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEndConnectionHandshakeMessages pathEndConnectionHandshakeMessages) pathEndConnectionHandshakeResponse {
+	res := pathEndConnectionHandshakeResponse{
+		ToDeleteSrc: make(map[string][]ConnectionKey),
+		ToDeleteDst: make(map[string][]ConnectionKey),
+	}
 
 ConnectionHandshakeLoop:
-	for openInitKey, _ := range pathEndConnectionHandshakeMessages.SrcMsgConnectionOpenInit {
+	for openInitKey, openInitMsg := range pathEndConnectionHandshakeMessages.SrcMsgConnectionOpenInit {
 		var foundOpenTry provider.RelayerMessage
 		for openTryKey, openTryMsg := range pathEndConnectionHandshakeMessages.DstMsgConnectionOpenTry {
 			if openInitKey == openTryKey {
@@ -335,7 +300,8 @@ ConnectionHandshakeLoop:
 			}
 		}
 		if foundOpenTry == nil {
-			// TODO need to send an open try to dst
+			// need to send an open try to dst
+			res.DstMessages = append(res.DstMessages, connectionIBCMessage{action: MsgConnectionOpenTry, connectionKey: openInitKey.Counterparty(), message: openInitMsg})
 			continue ConnectionHandshakeLoop
 		}
 		var foundOpenAck provider.RelayerMessage
@@ -346,7 +312,8 @@ ConnectionHandshakeLoop:
 			}
 		}
 		if foundOpenAck == nil {
-			// TODO need to send an open ack to src
+			// need to send an open ack to src
+			res.SrcMessages = append(res.SrcMessages, connectionIBCMessage{action: MsgConnectionOpenAck, connectionKey: openInitKey, message: foundOpenTry})
 			continue ConnectionHandshakeLoop
 		}
 		var foundOpenConfirm provider.RelayerMessage
@@ -357,7 +324,8 @@ ConnectionHandshakeLoop:
 			}
 		}
 		if foundOpenConfirm == nil {
-			// TODO need to send an open confirm to dst
+			// need to send an open confirm to dst
+			res.DstMessages = append(res.DstMessages, connectionIBCMessage{action: MsgConnectionOpenConfirm, connectionKey: openInitKey.Counterparty(), message: foundOpenAck})
 			continue ConnectionHandshakeLoop
 		}
 		// handshake is complete for this connection, remove all retention.
@@ -374,17 +342,17 @@ ConnectionHandshakeLoop:
 		res.ToDeleteSrc[MsgConnectionOpenAck] = append(res.ToDeleteSrc[MsgConnectionOpenAck], openConfirmKey)
 		res.ToDeleteDst[MsgConnectionOpenConfirm] = append(res.ToDeleteDst[MsgConnectionOpenConfirm], openConfirmKey)
 	}
+	return res
 }
 
-func (pp *PathProcessor) getUnrelayedChannelHandshakeMessagesAndToDelete(pathEndChannelHandshakeMessages pathEndChannelHandshakeMessages, wg *sync.WaitGroup, res *pathEndChannelHandshakeResponse) {
-	defer wg.Done()
-	res.SrcMessages = nil
-	res.DstMessages = nil
-	res.ToDeleteSrc = make(map[string][]ChannelKey)
-	res.ToDeleteDst = make(map[string][]ChannelKey)
+func (pp *PathProcessor) getUnrelayedChannelHandshakeMessagesAndToDelete(pathEndChannelHandshakeMessages pathEndChannelHandshakeMessages) pathEndChannelHandshakeResponse {
+	res := pathEndChannelHandshakeResponse{
+		ToDeleteSrc: make(map[string][]ChannelKey),
+		ToDeleteDst: make(map[string][]ChannelKey),
+	}
 
 ChannelHandshakeLoop:
-	for openInitKey, _ := range pathEndChannelHandshakeMessages.SrcMsgChannelOpenInit {
+	for openInitKey, openInitMsg := range pathEndChannelHandshakeMessages.SrcMsgChannelOpenInit {
 		var foundOpenTry provider.RelayerMessage
 		for openTryKey, openTryMsg := range pathEndChannelHandshakeMessages.DstMsgChannelOpenTry {
 			if openInitKey == openTryKey {
@@ -393,7 +361,8 @@ ChannelHandshakeLoop:
 			}
 		}
 		if foundOpenTry == nil {
-			// TODO need to send an open try to dst
+			// need to send an open try to dst
+			res.DstMessages = append(res.DstMessages, channelIBCMessage{action: MsgChannelOpenTry, channelKey: openInitKey.Counterparty(), message: openInitMsg})
 			continue ChannelHandshakeLoop
 		}
 		var foundOpenAck provider.RelayerMessage
@@ -404,7 +373,8 @@ ChannelHandshakeLoop:
 			}
 		}
 		if foundOpenAck == nil {
-			// TODO need to send an open ack to src
+			// need to send an open ack to src
+			res.SrcMessages = append(res.SrcMessages, channelIBCMessage{action: MsgChannelOpenAck, channelKey: openInitKey, message: foundOpenTry})
 			continue ChannelHandshakeLoop
 		}
 		var foundOpenConfirm provider.RelayerMessage
@@ -415,7 +385,8 @@ ChannelHandshakeLoop:
 			}
 		}
 		if foundOpenConfirm == nil {
-			// TODO need to send an open confirm to dst
+			// need to send an open confirm to dst
+			res.DstMessages = append(res.DstMessages, channelIBCMessage{action: MsgChannelOpenConfirm, channelKey: openInitKey.Counterparty(), message: foundOpenAck})
 			continue ChannelHandshakeLoop
 		}
 		// handshake is complete for this channel, remove all retention.
@@ -432,6 +403,7 @@ ChannelHandshakeLoop:
 		res.ToDeleteSrc[MsgChannelOpenAck] = append(res.ToDeleteSrc[MsgChannelOpenAck], openConfirmKey)
 		res.ToDeleteDst[MsgChannelOpenConfirm] = append(res.ToDeleteDst[MsgChannelOpenConfirm], openConfirmKey)
 	}
+	return res
 }
 
 // assembleMsgUpdateClient uses the ChainProvider from both pathEnds to assemble the client update header
@@ -517,15 +489,6 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context) error {
 
 	channelPairs := pp.channelPairs()
 
-	// process the packet flows for both packends to determine what needs to be relayed
-	pathEnd1ProcessRes := make([]*pathEndPacketFlowResponse, len(channelPairs))
-	pathEnd2ProcessRes := make([]*pathEndPacketFlowResponse, len(channelPairs))
-
-	var pathEnd1ConnectionHandshakeRes, pathEnd2ConnectionHandshakeRes pathEndConnectionHandshakeResponse
-	var pathEnd1ChannelHandshakeRes, pathEnd2ChannelHandshakeRes pathEndChannelHandshakeResponse
-
-	var wg sync.WaitGroup
-
 	pathEnd1ConnectionHandshakeMessages := pathEndConnectionHandshakeMessages{
 		Src:                         pp.pathEnd1,
 		Dst:                         pp.pathEnd2,
@@ -542,9 +505,8 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context) error {
 		SrcMsgConnectionOpenAck:     pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenAck],
 		DstMsgConnectionOpenConfirm: pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenConfirm],
 	}
-	wg.Add(2)
-	go pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd1ConnectionHandshakeMessages, &wg, &pathEnd1ConnectionHandshakeRes)
-	go pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd2ConnectionHandshakeMessages, &wg, &pathEnd2ConnectionHandshakeRes)
+	pathEnd1ConnectionHandshakeRes := pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd1ConnectionHandshakeMessages)
+	pathEnd2ConnectionHandshakeRes := pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd2ConnectionHandshakeMessages)
 
 	pathEnd1ChannelHandshakeMessages := pathEndChannelHandshakeMessages{
 		Src:                      pp.pathEnd1,
@@ -562,9 +524,12 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context) error {
 		SrcMsgChannelOpenAck:     pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenAck],
 		DstMsgChannelOpenConfirm: pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenConfirm],
 	}
-	wg.Add(2)
-	go pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd1ChannelHandshakeMessages, &wg, &pathEnd1ChannelHandshakeRes)
-	go pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd2ChannelHandshakeMessages, &wg, &pathEnd2ChannelHandshakeRes)
+	pathEnd1ChannelHandshakeRes := pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd1ChannelHandshakeMessages)
+	pathEnd2ChannelHandshakeRes := pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd2ChannelHandshakeMessages)
+
+	// process the packet flows for both packends to determine what needs to be relayed
+	pathEnd1ProcessRes := make([]pathEndPacketFlowResponse, len(channelPairs))
+	pathEnd2ProcessRes := make([]pathEndPacketFlowResponse, len(channelPairs))
 
 	for i, pair := range channelPairs {
 		pathEnd1PacketFlowMessages := pathEndPacketFlowMessages{
@@ -588,25 +553,20 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context) error {
 			SrcMsgTimeoutOnClose:  pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgTimeoutOnClose],
 		}
 
-		pathEnd1ProcessRes[i] = new(pathEndPacketFlowResponse)
-		pathEnd2ProcessRes[i] = new(pathEndPacketFlowResponse)
-
-		wg.Add(2)
-		go pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages, &wg, pathEnd1ProcessRes[i])
-		go pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd2PacketFlowMessages, &wg, pathEnd2ProcessRes[i])
+		pathEnd1ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages)
+		pathEnd2ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd2PacketFlowMessages)
 	}
-	wg.Wait()
 
 	// concatenate applicable messages for pathend
 	pathEnd1ConnectionMessages, pathEnd2ConnectionMessages := pp.connectionMessagesToSend(pathEnd1ConnectionHandshakeRes, pathEnd2ConnectionHandshakeRes)
 	pathEnd1ChannelMessages, pathEnd2ChannelMessages := pp.channelMessagesToSend(pathEnd1ChannelHandshakeRes, pathEnd2ChannelHandshakeRes)
 	pathEnd1PacketMessages, pathEnd2PacketMessages := pp.packetMessagesToSend(channelPairs, pathEnd1ProcessRes, pathEnd2ProcessRes)
 
-	// now send messages in parallel
+	// now assemble and send messages in parallel
 	// if sending messages fails to one pathEnd, we don't need to halt sending to the other pathEnd.
 	var eg errgroup.Group
 	eg.Go(func() error {
-		if err := pp.sendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2PacketMessages, pathEnd2ConnectionMessages, pathEnd2ChannelMessages); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1PacketMessages, pathEnd1ConnectionMessages, pathEnd1ChannelMessages); err != nil {
 			pp.log.Error("Error sending messages",
 				zap.String("src_chain_id", pp.pathEnd1.info.ChainID),
 				zap.String("dst_chain_id", pp.pathEnd2.info.ChainID),
@@ -618,7 +578,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context) error {
 		return nil
 	})
 	eg.Go(func() error {
-		if err := pp.sendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1PacketMessages, pathEnd1ConnectionMessages, pathEnd1ChannelMessages); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2PacketMessages, pathEnd2ConnectionMessages, pathEnd2ChannelMessages); err != nil {
 			pp.log.Error("Error sending messages",
 				zap.String("src_chain_id", pp.pathEnd2.info.ChainID),
 				zap.String("dst_chain_id", pp.pathEnd1.info.ChainID),

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -223,12 +223,12 @@ func (pp *PathProcessor) assembleAndSendMessages(
 	if len(packetMessages) == 0 && len(connectionMessages) == 0 && len(channelMessages) == 0 {
 		return nil
 	}
-	var messages []provider.RelayerMessage
+	var outgoingMessages []provider.RelayerMessage
 	msgUpdateClient, err := pp.assembleMsgUpdateClient(ctx, src, dst)
 	if err != nil {
 		return err
 	}
-	messages = append(messages, msgUpdateClient)
+	outgoingMessages = append(outgoingMessages, msgUpdateClient)
 
 	var sentPackageMessages []packetIBCMessage
 	var sentConnectionMessages []connectionIBCMessage
@@ -246,7 +246,7 @@ func (pp *PathProcessor) assembleAndSendMessages(
 		case MsgTimeoutOnClose:
 			assembleMessage = src.chainProvider.MsgTimeoutOnClose
 		default:
-			pp.log.Error("unexepected packet message action for message assembly",
+			pp.log.Error("Unexepected packet message action for message assembly",
 				zap.String("action", msg.action),
 			)
 			continue
@@ -258,12 +258,12 @@ func (pp *PathProcessor) assembleAndSendMessages(
 			continue
 		}
 		sentPackageMessages = append(sentPackageMessages, msg)
-		messages = append(messages, message)
+		outgoingMessages = append(outgoingMessages, message)
 	}
 
 	// TODO handle connection and channel handshake messages
 
-	_, txSuccess, err := dst.chainProvider.SendMessages(ctx, messages)
+	_, txSuccess, err := dst.chainProvider.SendMessages(ctx, outgoingMessages)
 	if err != nil {
 		return fmt.Errorf("error sending messages: %w", err)
 	}


### PR DESCRIPTION
Don't assemble messages if they aren't going to be sent.

`PathProcessor` was unnecessarily assembling packet messages when they weren't going to be sent during the current `processLatestMessages` iteration, e.g. filtered out due to sending already in progress. This caused unnecessary tendermint proof queries.

We can filter messages out before they are assembled to avoid the unnecessary queries.

In addition to that, this separates constructing the list of messages to be sent from the message assembly, so that something can be done in between those steps: making sure the `MsgUpdateClient` can be assembled before proceeding to assemble the other messages. This also removes unnecessary tendermint proof queries in case the client is not ready to be updated.