### PR TITLE
Supports type any for panic arguments (Go SDK 1.18.3)

### DIFF
--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -136,8 +136,7 @@ func (c *Chain) CreateOpenChannels(
 			}
 		}
 	}
-
-	panic("unreachable")
+	panic(any("unreachable"))
 }
 
 // ExecuteChannelStep executes the next channel step based on the

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -388,7 +388,7 @@ func (c *Chain) UpgradeClients(ctx context.Context, dst *Chain, height int64) er
 func MustGetHeight(h ibcexported.Height) clienttypes.Height {
 	height, ok := h.(clienttypes.Height)
 	if !ok {
-		panic("height is not an instance of height!")
+		panic(any("height is not an instance of height!"))
 	}
 	return height
 }

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -121,7 +121,7 @@ func (c *Chain) CreateOpenConnections(
 		}
 	}
 
-	panic("unreachable")
+	panic(any("unreachable"))
 }
 
 // ExecuteConnectionStep executes the next connection step based on the


### PR DESCRIPTION
`type any` was introduced from Go 1.18. In the Go SDK 1.18.3, the panic argument must be of `type any` in order to compile.