### PR TITLE
EventProcessor - message lifecycle mechanism

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/cosmos/relayer/v2/relayer/provider"
@@ -38,6 +39,12 @@ type CosmosChainProcessor struct {
 
 	// holds open state for known channels
 	channelStateCache processor.ChannelStateCache
+
+	// map of connection ID to client ID
+	connectionClients map[string]string
+
+	// map of channel ID to connection ID
+	channelConnections map[string]string
 }
 
 func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider) *CosmosChainProcessor {
@@ -47,6 +54,8 @@ func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider) *
 		latestClientState:    make(latestClientState),
 		connectionStateCache: make(processor.ConnectionStateCache),
 		channelStateCache:    make(processor.ChannelStateCache),
+		connectionClients:    make(map[string]string),
+		channelConnections:   make(map[string]string),
 	}
 }
 
@@ -172,7 +181,16 @@ func (ccp *CosmosChainProcessor) Run(ctx context.Context, initialBlockHistory ui
 
 	persistence.latestQueriedBlock = latestQueriedBlock
 
-	ccp.initializeChannelState(ctx)
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return ccp.initializeConnectionState(ctx)
+	})
+	eg.Go(func() error {
+		return ccp.initializeChannelState(ctx)
+	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 
 	ccp.log.Debug("Entering main query loop")
 
@@ -191,6 +209,26 @@ func (ccp *CosmosChainProcessor) Run(ctx context.Context, initialBlockHistory ui
 	}
 }
 
+// initializeConnectionState will bootstrap the connectionStateCache with the open connection state.
+func (ccp *CosmosChainProcessor) initializeConnectionState(ctx context.Context) error {
+	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, queryTimeout)
+	defer cancelQueryCtx()
+	connections, err := ccp.chainProvider.QueryConnections(queryCtx)
+	if err != nil {
+		return fmt.Errorf("error querying connections: %w", err)
+	}
+	for _, c := range connections {
+		ccp.connectionClients[c.Id] = c.ClientId
+		ccp.connectionStateCache[processor.ConnectionKey{
+			ConnectionID:         c.Id,
+			ClientID:             c.ClientId,
+			CounterpartyConnID:   c.Counterparty.ConnectionId,
+			CounterpartyClientID: c.Counterparty.ClientId,
+		}] = c.State == conntypes.OPEN
+	}
+	return nil
+}
+
 // initializeChannelState will bootstrap the channelStateCache with the open channel state.
 func (ccp *CosmosChainProcessor) initializeChannelState(ctx context.Context) error {
 	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, queryTimeout)
@@ -200,6 +238,15 @@ func (ccp *CosmosChainProcessor) initializeChannelState(ctx context.Context) err
 		return fmt.Errorf("error querying channels: %w", err)
 	}
 	for _, ch := range channels {
+		if len(ch.ConnectionHops) != 1 {
+			ccp.log.Error("Found channel using multiple connection hops. Not currently supported, ignoring.",
+				zap.String("channel_id", ch.ChannelId),
+				zap.String("port_id", ch.PortId),
+				zap.Any("connection_hops", ch.ConnectionHops),
+			)
+			continue
+		}
+		ccp.channelConnections[ch.ChannelId] = ch.ConnectionHops[0]
 		ccp.channelStateCache[processor.ChannelKey{
 			ChannelID:             ch.ChannelId,
 			PortID:                ch.PortId,
@@ -328,8 +375,8 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 			IBCMessagesCache:     ibcMessagesCache,
 			InSync:               ccp.inSync,
 			ClientState:          clientState,
-			ConnectionStateCache: ccp.connectionStateCache.Clone(),
-			ChannelStateCache:    ccp.channelStateCache.Clone(),
+			ConnectionStateCache: ccp.connectionStateCache.Filter(clientID),
+			ChannelStateCache:    ccp.channelStateCache.Filter(clientID, ccp.channelConnections, ccp.connectionClients),
 			IBCHeaderCache:       ibcHeaderCache,
 		})
 	}

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -211,9 +211,9 @@ func (ccp *CosmosChainProcessor) Run(ctx context.Context, initialBlockHistory ui
 
 // initializeConnectionState will bootstrap the connectionStateCache with the open connection state.
 func (ccp *CosmosChainProcessor) initializeConnectionState(ctx context.Context) error {
-	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, queryTimeout)
-	defer cancelQueryCtx()
-	connections, err := ccp.chainProvider.QueryConnections(queryCtx)
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+	connections, err := ccp.chainProvider.QueryConnections(ctx)
 	if err != nil {
 		return fmt.Errorf("error querying connections: %w", err)
 	}
@@ -231,9 +231,9 @@ func (ccp *CosmosChainProcessor) initializeConnectionState(ctx context.Context) 
 
 // initializeChannelState will bootstrap the channelStateCache with the open channel state.
 func (ccp *CosmosChainProcessor) initializeChannelState(ctx context.Context) error {
-	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, queryTimeout)
-	defer cancelQueryCtx()
-	channels, err := ccp.chainProvider.QueryChannels(queryCtx)
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+	channels, err := ccp.chainProvider.QueryChannels(ctx)
 	if err != nil {
 		return fmt.Errorf("error querying channels: %w", err)
 	}
@@ -375,8 +375,8 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 			IBCMessagesCache:     ibcMessagesCache,
 			InSync:               ccp.inSync,
 			ClientState:          clientState,
-			ConnectionStateCache: ccp.connectionStateCache.Filter(clientID),
-			ChannelStateCache:    ccp.channelStateCache.Filter(clientID, ccp.channelConnections, ccp.connectionClients),
+			ConnectionStateCache: ccp.connectionStateCache.FilterForClient(clientID),
+			ChannelStateCache:    ccp.channelStateCache.FilterForClient(clientID, ccp.channelConnections, ccp.connectionClients),
 			IBCHeaderCache:       ibcHeaderCache,
 		})
 	}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -128,7 +128,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 	}
 	switch m := messageLifecycle.(type) {
 	case *PacketMessageLifecycle:
-		if m.Termination.ChainID != pathEnd.info.ChainID {
+		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
 		channelKey, err := PacketInfoChannelKey(m.Termination.Action, m.Termination.Info)
@@ -156,7 +156,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		pathEnd.log.Info("Found termination condition for packet flow")
 		return true
 	case *ChannelMessageLifecycle:
-		if m.Termination.ChainID != pathEnd.info.ChainID {
+		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
 		cache, ok := ibcMessagesCache.ChannelHandshake[m.Termination.Action]
@@ -187,7 +187,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 			return true
 		}
 	case *ConnectionMessageLifecycle:
-		if m.Termination.ChainID != pathEnd.info.ChainID {
+		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
 		cache, ok := ibcMessagesCache.ConnectionHandshake[m.Termination.Action]

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -169,16 +169,16 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		foundCounterpartyChannelID := m.Termination.Info.CounterpartyChannelID == ""
 		foundCounterpartyPortID := m.Termination.Info.CounterpartyPortID == ""
 		for _, ci := range cache {
-			if !foundChannelID && ci.ChannelID == m.Termination.Info.ChannelID {
+			if ci.ChannelID == m.Termination.Info.ChannelID {
 				foundChannelID = true
 			}
-			if !foundPortID && ci.PortID == m.Termination.Info.PortID {
+			if ci.PortID == m.Termination.Info.PortID {
 				foundPortID = true
 			}
-			if !foundCounterpartyChannelID && ci.CounterpartyChannelID == m.Termination.Info.CounterpartyChannelID {
+			if ci.CounterpartyChannelID == m.Termination.Info.CounterpartyChannelID {
 				foundCounterpartyChannelID = true
 			}
-			if !foundCounterpartyPortID && ci.CounterpartyPortID == m.Termination.Info.CounterpartyPortID {
+			if ci.CounterpartyPortID == m.Termination.Info.CounterpartyPortID {
 				foundCounterpartyPortID = true
 			}
 		}
@@ -206,29 +206,22 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 				zap.String("termination_counterparty_client_id", m.Termination.Info.CounterpartyClientID),
 				zap.String("observed_counterparty_client_id", ci.CounterpartyClientID),
 			)
-			if !foundClientID && ci.ClientID == m.Termination.Info.ClientID {
+			if ci.ClientID == m.Termination.Info.ClientID {
 				foundClientID = true
 			}
-			if !foundConnectionID && ci.ConnID == m.Termination.Info.ConnID {
+			if ci.ConnID == m.Termination.Info.ConnID {
 				foundConnectionID = true
 			}
-			if !foundCounterpartyClientID && ci.CounterpartyClientID == m.Termination.Info.CounterpartyClientID {
+			if ci.CounterpartyClientID == m.Termination.Info.CounterpartyClientID {
 				foundCounterpartyClientID = true
 			}
-			if !foundCounterpartyConnectionID && ci.CounterpartyConnID == m.Termination.Info.CounterpartyConnID {
+			if ci.CounterpartyConnID == m.Termination.Info.CounterpartyConnID {
 				foundCounterpartyConnectionID = true
 			}
 		}
 		if foundClientID && foundConnectionID && foundCounterpartyClientID && foundCounterpartyConnectionID {
 			pathEnd.log.Info("Found termination condition for connection handshake")
 			return true
-		} else {
-			pathEnd.log.Info("Did not find termination condition for connection handshake",
-				zap.Bool("foundClientID", foundClientID),
-				zap.Bool("foundConnectionID", foundConnectionID),
-				zap.Bool("foundCounterpartyClientID", foundCounterpartyClientID),
-				zap.Bool("foundCounterpartyConnectionID", foundCounterpartyConnectionID),
-			)
 		}
 	}
 	return false

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -227,14 +227,14 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 	return false
 }
 
-func (pathEnd *pathEndRuntime) MergeCacheData(ctx context.Context, ctxCancel func(), d ChainProcessorCacheData, messageLifecycle MessageLifecycle) {
+func (pathEnd *pathEndRuntime) MergeCacheData(ctx context.Context, cancel func(), d ChainProcessorCacheData, messageLifecycle MessageLifecycle) {
 	pathEnd.inSync = d.InSync
 	pathEnd.latestBlock = d.LatestBlock
 	pathEnd.latestHeader = d.LatestHeader
 	pathEnd.clientState = d.ClientState
 
 	if pathEnd.shouldTerminate(d.IBCMessagesCache, messageLifecycle) {
-		ctxCancel()
+		cancel()
 		return
 	}
 

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -51,7 +51,7 @@ func NewPathProcessor(log *zap.Logger, pathEnd1 PathEnd, pathEnd2 PathEnd) *Path
 		log:          log,
 		pathEnd1:     newPathEndRuntime(log, pathEnd1),
 		pathEnd2:     newPathEndRuntime(log, pathEnd2),
-		retryProcess: make(chan struct{}, 8),
+		retryProcess: make(chan struct{}, 2),
 	}
 }
 
@@ -166,7 +166,7 @@ func (pp *PathProcessor) ProcessBacklogIfReady() {
 	default:
 		// Log that the channel is saturated;
 		// something is wrong if we are retrying this quickly.
-		pp.log.Info("Failed to enqueue path processor retry")
+		pp.log.Error("Failed to enqueue path processor retry, retries already scheduled")
 	}
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -453,6 +453,9 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 	if messageLifecycle != nil && !pp.sentInitialMsg {
 		switch m := messageLifecycle.(type) {
 		case *PacketMessageLifecycle:
+			if m.Initial == nil {
+				break
+			}
 			channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
 			if err != nil {
 				pp.log.Error("Unexpected error checking packet message",
@@ -477,6 +480,9 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 				})
 			}
 		case *ConnectionMessageLifecycle:
+			if m.Initial == nil {
+				break
+			}
 			if !pp.IsRelevantConnection(m.Initial.ChainID, m.Initial.Info.ConnID) {
 				break
 			}
@@ -492,6 +498,9 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 				})
 			}
 		case *ChannelMessageLifecycle:
+			if m.Initial == nil {
+				break
+			}
 			if !pp.IsRelevantChannel(m.Initial.ChainID, m.Initial.Info.ChannelID) {
 				break
 			}

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -373,10 +373,11 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 	if msg == nil || pp.sentInitialMsg {
 		return
 	}
+	pp.sentInitialMsg = true
 	switch m := msg.(type) {
 	case *PacketMessageLifecycle:
 		if m.Initial == nil {
-			break
+			return
 		}
 		channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
 		if err != nil {
@@ -385,10 +386,10 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 				zap.Any("channel", channelKey),
 				zap.Error(err),
 			)
-			break
+			return
 		}
 		if !pp.IsRelayedChannel(m.Initial.ChainID, channelKey) {
-			break
+			return
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.packetMessages = append(pathEnd1Messages.packetMessages, packetIBCMessage{
@@ -403,10 +404,10 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 	case *ConnectionMessageLifecycle:
 		if m.Initial == nil {
-			break
+			return
 		}
 		if !pp.IsRelevantConnection(m.Initial.ChainID, m.Initial.Info.ConnID) {
-			break
+			return
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.connectionMessages = append(pathEnd1Messages.connectionMessages, connectionIBCMessage{
@@ -421,10 +422,10 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 	case *ChannelMessageLifecycle:
 		if m.Initial == nil {
-			break
+			return
 		}
 		if !pp.IsRelevantChannel(m.Initial.ChainID, m.Initial.Info.ChannelID) {
-			break
+			return
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.channelMessages = append(pathEnd1Messages.channelMessages, channelIBCMessage{
@@ -438,8 +439,6 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 			})
 		}
 	}
-
-	pp.sentInitialMsg = true
 }
 
 // messages from both pathEnds are needed in order to determine what needs to be relayed for a single pathEnd

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -369,6 +369,79 @@ func (pp *PathProcessor) updateClientTrustedState(src *pathEndRuntime, dst *path
 	}
 }
 
+func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, pathEnd1Messages, pathEnd2Messages *pathEndMessages) {
+	if msg == nil || pp.sentInitialMsg {
+		return
+	}
+	switch m := msg.(type) {
+	case *PacketMessageLifecycle:
+		if m.Initial == nil {
+			break
+		}
+		channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
+		if err != nil {
+			pp.log.Error("Unexpected error checking packet message",
+				zap.String("action", m.Termination.Action),
+				zap.Any("channel", channelKey),
+				zap.Error(err),
+			)
+			break
+		}
+		if !pp.IsRelayedChannel(m.Initial.ChainID, channelKey) {
+			break
+		}
+		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
+			pathEnd1Messages.packetMessages = append(pathEnd1Messages.packetMessages, packetIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
+			pathEnd2Messages.packetMessages = append(pathEnd2Messages.packetMessages, packetIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		}
+	case *ConnectionMessageLifecycle:
+		if m.Initial == nil {
+			break
+		}
+		if !pp.IsRelevantConnection(m.Initial.ChainID, m.Initial.Info.ConnID) {
+			break
+		}
+		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
+			pathEnd1Messages.connectionMessages = append(pathEnd1Messages.connectionMessages, connectionIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
+			pathEnd2Messages.connectionMessages = append(pathEnd2Messages.connectionMessages, connectionIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		}
+	case *ChannelMessageLifecycle:
+		if m.Initial == nil {
+			break
+		}
+		if !pp.IsRelevantChannel(m.Initial.ChainID, m.Initial.Info.ChannelID) {
+			break
+		}
+		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
+			pathEnd1Messages.channelMessages = append(pathEnd1Messages.channelMessages, channelIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
+			pathEnd2Messages.channelMessages = append(pathEnd2Messages.channelMessages, channelIBCMessage{
+				action: m.Initial.Action,
+				info:   m.Initial.Info,
+			})
+		}
+	}
+
+	pp.sentInitialMsg = true
+}
+
 // messages from both pathEnds are needed in order to determine what needs to be relayed for a single pathEnd
 func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifecycle MessageLifecycle) error {
 	// Update trusted client state for both pathends
@@ -450,81 +523,25 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 	pathEnd1ChannelMessages, pathEnd2ChannelMessages := pp.channelMessagesToSend(pathEnd1ChannelHandshakeRes, pathEnd2ChannelHandshakeRes)
 	pathEnd1PacketMessages, pathEnd2PacketMessages := pp.packetMessagesToSend(channelPairs, pathEnd1ProcessRes, pathEnd2ProcessRes)
 
-	if messageLifecycle != nil && !pp.sentInitialMsg {
-		switch m := messageLifecycle.(type) {
-		case *PacketMessageLifecycle:
-			if m.Initial == nil {
-				break
-			}
-			channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
-			if err != nil {
-				pp.log.Error("Unexpected error checking packet message",
-					zap.String("action", m.Termination.Action),
-					zap.Any("channel", channelKey),
-					zap.Error(err),
-				)
-				break
-			}
-			if !pp.IsRelayedChannel(m.Initial.ChainID, channelKey) {
-				break
-			}
-			if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
-				pathEnd1PacketMessages = append(pathEnd1PacketMessages, packetIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
-				pathEnd2PacketMessages = append(pathEnd2PacketMessages, packetIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			}
-		case *ConnectionMessageLifecycle:
-			if m.Initial == nil {
-				break
-			}
-			if !pp.IsRelevantConnection(m.Initial.ChainID, m.Initial.Info.ConnID) {
-				break
-			}
-			if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
-				pathEnd1ConnectionMessages = append(pathEnd1ConnectionMessages, connectionIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
-				pathEnd2ConnectionMessages = append(pathEnd2ConnectionMessages, connectionIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			}
-		case *ChannelMessageLifecycle:
-			if m.Initial == nil {
-				break
-			}
-			if !pp.IsRelevantChannel(m.Initial.ChainID, m.Initial.Info.ChannelID) {
-				break
-			}
-			if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
-				pathEnd1ChannelMessages = append(pathEnd1ChannelMessages, channelIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
-				pathEnd2ChannelMessages = append(pathEnd2ChannelMessages, channelIBCMessage{
-					action: m.Initial.Action,
-					info:   m.Initial.Info,
-				})
-			}
-		}
-
-		pp.sentInitialMsg = true
+	pathEnd1Messages := pathEndMessages{
+		connectionMessages: pathEnd1ConnectionMessages,
+		channelMessages:    pathEnd1ChannelMessages,
+		packetMessages:     pathEnd1PacketMessages,
 	}
+
+	pathEnd2Messages := pathEndMessages{
+		connectionMessages: pathEnd2ConnectionMessages,
+		channelMessages:    pathEnd2ChannelMessages,
+		packetMessages:     pathEnd2PacketMessages,
+	}
+
+	pp.appendInitialMessageIfNecessary(messageLifecycle, &pathEnd1Messages, &pathEnd2Messages)
 
 	// now assemble and send messages in parallel
 	// if sending messages fails to one pathEnd, we don't need to halt sending to the other pathEnd.
 	var eg errgroup.Group
 	eg.Go(func() error {
-		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1PacketMessages, pathEnd1ConnectionMessages, pathEnd1ChannelMessages); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1Messages); err != nil {
 			pp.log.Error("Error sending messages",
 				zap.String("src_chain_id", pp.pathEnd1.info.ChainID),
 				zap.String("dst_chain_id", pp.pathEnd2.info.ChainID),
@@ -536,7 +553,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		return nil
 	})
 	eg.Go(func() error {
-		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2PacketMessages, pathEnd2ConnectionMessages, pathEnd2ChannelMessages); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2Messages); err != nil {
 			pp.log.Error("Error sending messages",
 				zap.String("src_chain_id", pp.pathEnd2.info.ChainID),
 				zap.String("dst_chain_id", pp.pathEnd1.info.ChainID),
@@ -553,11 +570,9 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 func (pp *PathProcessor) assembleAndSendMessages(
 	ctx context.Context,
 	src, dst *pathEndRuntime,
-	packetMessages []packetIBCMessage,
-	connectionMessages []connectionIBCMessage,
-	channelMessages []channelIBCMessage,
+	messages pathEndMessages,
 ) error {
-	if len(packetMessages) == 0 && len(connectionMessages) == 0 && len(channelMessages) == 0 {
+	if len(messages.packetMessages) == 0 && len(messages.connectionMessages) == 0 && len(messages.channelMessages) == 0 {
 		return nil
 	}
 	var outgoingMessages []provider.RelayerMessage
@@ -569,7 +584,7 @@ func (pp *PathProcessor) assembleAndSendMessages(
 
 	var sentPackageMessages []packetIBCMessage
 
-	for _, msg := range packetMessages {
+	for _, msg := range messages.packetMessages {
 		var assembleMessage func(context.Context, provider.PacketInfo, string, provider.LatestBlock) (provider.RelayerMessage, error)
 		switch msg.action {
 		case MsgRecvPacket:

--- a/relayer/processor/types.go
+++ b/relayer/processor/types.go
@@ -219,7 +219,7 @@ func (c ChannelStateCache) Merge(other ChannelStateCache) {
 	}
 }
 
-// FilterForClient returns a filtered map of channels on top of an underlying clientID
+// FilterForClient returns a filtered copy of channels on top of an underlying clientID so it can be used by other goroutines.
 func (c ChannelStateCache) FilterForClient(clientID string, channelConnections map[string]string, connectionClients map[string]string) ChannelStateCache {
 	n := make(ChannelStateCache)
 	for k, v := range c {
@@ -249,7 +249,7 @@ func (c ConnectionStateCache) Merge(other ConnectionStateCache) {
 }
 
 // FilterForClient makes a filtered copy of the ConnectionStateCache
-// for a single client ID so it can be used by other threads.
+// for a single client ID so it can be used by other goroutines.
 func (c ConnectionStateCache) FilterForClient(clientID string) ConnectionStateCache {
 	n := make(ConnectionStateCache)
 	for k, v := range c {

--- a/relayer/processor/types.go
+++ b/relayer/processor/types.go
@@ -219,8 +219,8 @@ func (c ChannelStateCache) Merge(other ChannelStateCache) {
 	}
 }
 
-// Filter returns a filtered map of channels on top of an underlying clientID
-func (c ChannelStateCache) Filter(clientID string, channelConnections map[string]string, connectionClients map[string]string) ChannelStateCache {
+// FilterForClient returns a filtered map of channels on top of an underlying clientID
+func (c ChannelStateCache) FilterForClient(clientID string, channelConnections map[string]string, connectionClients map[string]string) ChannelStateCache {
 	n := make(ChannelStateCache)
 	for k, v := range c {
 		connection, ok := channelConnections[k.ChannelID]
@@ -248,13 +248,13 @@ func (c ConnectionStateCache) Merge(other ConnectionStateCache) {
 	}
 }
 
-// Filter makes a filtered copy of the ConnectionStateCache so it can be used by other threads.
-func (c ConnectionStateCache) Filter(clientID string) ConnectionStateCache {
+// FilterForClient makes a filtered copy of the ConnectionStateCache
+// for a single client ID so it can be used by other threads.
+func (c ConnectionStateCache) FilterForClient(clientID string) ConnectionStateCache {
 	n := make(ConnectionStateCache)
 	for k, v := range c {
 		if k.ClientID == clientID {
 			n[k] = v
-			break
 		}
 	}
 	return n

--- a/relayer/processor/types_internal.go
+++ b/relayer/processor/types_internal.go
@@ -2,6 +2,14 @@ package processor
 
 import "github.com/cosmos/relayer/v2/relayer/provider"
 
+// pathEndMessages holds the different IBC messages that
+// will attempt to be sent to the pathEnd.
+type pathEndMessages struct {
+	connectionMessages []connectionIBCMessage
+	channelMessages    []channelIBCMessage
+	packetMessages     []packetIBCMessage
+}
+
 // packetIBCMessage holds a packet message's action and sequence along with it,
 // useful for sending packets around internal to the PathProcessor.
 type packetIBCMessage struct {


### PR DESCRIPTION
Adds ability to send an IBC message once `PathProcessor` starts and both chains are in sync, then waits for a completion message, using `EventProcessor.WithMessageLifecycle`. This enables a short lifecycle of the `EventProcessor` for connection/channel handshakes and packet flows. This can be used in the CLI methods `CreateOpenConnections` and `CreateOpenChannels` to perform a single task and then shutdown. 

Changes `connectionStateCache` and `channelStateCache` `Clone` methods to `Filter` methods, and now `ChainProcessor` only passes relevant connection and channel states to each `PathProcessor`. The `PathProcessor` can then use these to determine relevance internally.