### PR TITLE
refactor: Replace interface{} with any

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -166,7 +166,6 @@ $ %s cfg i`, appName, defaultHome, appName)),
 	return cmd
 }
 
-
 // addChainsFromDirectory finds all JSON-encoded config files in dir,
 // and optimistically adds them to a's chains.
 //
@@ -304,8 +303,8 @@ type ProviderConfigWrapper struct {
 
 // ProviderConfigYAMLWrapper is an intermediary type for parsing arbitrary ProviderConfigs from yaml files
 type ProviderConfigYAMLWrapper struct {
-	Type  string      `yaml:"type"`
-	Value interface{} `yaml:"-"`
+	Type  string `yaml:"type"`
+	Value any    `yaml:"-"`
 }
 
 // UnmarshalJSON adds support for unmarshalling data from an arbitrary ProviderConfig
@@ -324,8 +323,8 @@ func (pcw *ProviderConfigWrapper) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalJSONProviderConfig contains the custom unmarshalling logic for ProviderConfig structs
-func UnmarshalJSONProviderConfig(data []byte, customTypes map[string]reflect.Type) (interface{}, error) {
-	m := map[string]interface{}{}
+func UnmarshalJSONProviderConfig(data []byte, customTypes map[string]reflect.Type) (any, error) {
+	m := map[string]any{}
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -900,9 +900,9 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 			srcChannelID := args[4]
 
 			var pathConnectionID string
-			if src.ChainID()  == path.Src.ChainID {
+			if src.ChainID() == path.Src.ChainID {
 				pathConnectionID = path.Src.ConnectionID
-			} else if src.ChainID()  == path.Dst.ChainID {
+			} else if src.ChainID() == path.Dst.ChainID {
 				pathConnectionID = path.Dst.ConnectionID
 			} else {
 				return fmt.Errorf("no path configured using chain-id: %s", src.ChainID())

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -70,7 +70,7 @@ const (
 
 type msgHandlerParams struct {
 	// incoming IBC message
-	messageInfo interface{}
+	messageInfo any
 
 	// reference to the caches that will be assembled by the handlers in this file
 	ibcMessagesCache processor.IBCMessagesCache

--- a/relayer/provider/cosmos/msg.go
+++ b/relayer/provider/cosmos/msg.go
@@ -33,7 +33,7 @@ func CosmosMsg(rm provider.RelayerMessage) sdk.Msg {
 }
 
 // typedCosmosMsg does not accept nil. IBC Message must be of the requested type.
-func typedCosmosMsg[T *chantypes.MsgRecvPacket | *chantypes.MsgAcknowledgement](msg provider.RelayerMessage) T  {
+func typedCosmosMsg[T *chantypes.MsgRecvPacket | *chantypes.MsgAcknowledgement](msg provider.RelayerMessage) T {
 	if msg == nil {
 		panic("msg is nil")
 	}


### PR DESCRIPTION
```
gofmt -w -r 'interface{} -> any' .
```

Prefer use of `any` over `interface{}` in go 1.18+. It's shorter and clearer. 

We've been good about using `any`. The above command didn't find many to refactor. 