### PR TITLE
PathProcessor/Provider - separate proof queries from message assembly

### DIFF
--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -616,8 +615,6 @@ func (pp *PathProcessor) assembleAndSendMessages(
 			pp.log.Error("Error assembling packet message", zap.Error(err))
 			continue
 		}
-		outgoingMessages = append(outgoingMessages, message)
-	}
 		outgoingMessages = append(outgoingMessages, message)
 	}
 

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -173,28 +173,36 @@ type ChainProvider interface {
 
 	// [Begin] Packet flow IBC message assembly functions
 
-	// These functions query the proof of the packet state on the source chain. The message
-	// indicated by the function name is assembled and returned to be written to the destination chain.
+	// These functions query the proof of the packet state on the chain.
 
-	// MsgRecvPacket takes a partial MsgRecvPacket, queries the packet commitment,
-	// and assembles a full MsgRecvPacket ready to write to the counterparty chain.
-	MsgRecvPacket(ctx context.Context, msgTransfer PacketInfo, signer string, latest LatestBlock) (RelayerMessage, error)
+	// PacketCommitment queries for proof that a MsgTransfer has been committed on the chain.
+	PacketCommitment(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
 
-	// MsgAcknowledgement takes a partial MsgAcknowledgement, queries the packet acknowledgement,
-	// and assembles a full MsgAcknowledgement ready to write to the counterparty chain.
-	MsgAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, signer string, latest LatestBlock) (RelayerMessage, error)
+	// PacketAcknowledgement queries for proof that a MsgRecvPacket has been committed on the chain.
+	PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
 
-	// MsgTimeout takes a partial MsgRecvPacket, queries the packet receipt to prove that the packet was never relayed,
-	// i.e. that the MsgRecvPacket was never written to the chain,
-	// and assembles a full MsgTimeout ready to write to the counterparty chain,
+	// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
+	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
+
+	// MsgRecvPacket takes takes the packet infromation from a MsgTransfer along with the packet commitment,
+	// and assembles a full MsgRecvPacket ready to write to the chain.
+	MsgRecvPacket(msgTransfer PacketInfo, proof []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+
+	// MsgAcknowledgement takes the packet infromation from a MsgRecvPacket along with the packet acknowledgement,
+	// and assembles a full MsgAcknowledgement ready to write to the chain.
+	MsgAcknowledgement(msgRecvPacket PacketInfo, proofAcked []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+
+	// MsgTimeout takes the packet information from a MsgTransfer along with the packet receipt to prove that the packet was never relayed,
+	// i.e. that the MsgRecvPacket was never written to the counterparty chain,
+	// and assembles a full MsgTimeout ready to write to the chain,
 	// i.e. the chain where the MsgTransfer was committed.
-	MsgTimeout(ctx context.Context, msgTransfer PacketInfo, signer string, latest LatestBlock) (RelayerMessage, error)
+	MsgTimeout(msgTransfer PacketInfo, proofUnreceived []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
 
-	// MsgTimeoutOnClose takes a partial MsgRecvPacket, queries the packet receipt to prove that the packet was never relayed,
-	// i.e. that the MsgRecvPacket was never written to the chain,
-	// and assembles a full MsgTimeoutOnClose ready to write to the counterparty chain,
+	// MsgTimeoutOnClose takes the packet information from a MsgTransfer along with the packet receipt to prove that the packet was never relayed,
+	// i.e. that the MsgRecvPacket was never written to the counterparty chain,
+	// and assembles a full MsgTimeoutOnClose ready to write to the chain,
 	// i.e. the chain where the MsgTransfer was committed.
-	MsgTimeoutOnClose(ctx context.Context, msgTransfer PacketInfo, signer string, latest LatestBlock) (RelayerMessage, error)
+	MsgTimeoutOnClose(msgTransfer PacketInfo, proofUnreceived []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
 
 	// [End] Packet flow IBC message assembly
 

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -105,6 +105,12 @@ type ChannelInfo struct {
 	Version string
 }
 
+// PacketProof includes all of the proof parameters needed for packet flows.
+type PacketProof struct {
+	Proof       []byte
+	ProofHeight clienttypes.Height
+}
+
 // loggableEvents is an unexported wrapper type for a slice of RelayerEvent,
 // to satisfy the zapcore.ArrayMarshaler interface.
 type loggableEvents []RelayerEvent
@@ -176,33 +182,33 @@ type ChainProvider interface {
 	// These functions query the proof of the packet state on the chain.
 
 	// PacketCommitment queries for proof that a MsgTransfer has been committed on the chain.
-	PacketCommitment(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
+	PacketCommitment(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
 
 	// PacketAcknowledgement queries for proof that a MsgRecvPacket has been committed on the chain.
-	PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
+	PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, latest LatestBlock) (PacketProof, error)
 
 	// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
-	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) ([]byte, clienttypes.Height, error)
+	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
 
 	// MsgRecvPacket takes takes the packet infromation from a MsgTransfer along with the packet commitment,
 	// and assembles a full MsgRecvPacket ready to write to the chain.
-	MsgRecvPacket(msgTransfer PacketInfo, proof []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+	MsgRecvPacket(msgTransfer PacketInfo, proof PacketProof) (RelayerMessage, error)
 
 	// MsgAcknowledgement takes the packet infromation from a MsgRecvPacket along with the packet acknowledgement,
 	// and assembles a full MsgAcknowledgement ready to write to the chain.
-	MsgAcknowledgement(msgRecvPacket PacketInfo, proofAcked []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+	MsgAcknowledgement(msgRecvPacket PacketInfo, proofAcked PacketProof) (RelayerMessage, error)
 
 	// MsgTimeout takes the packet information from a MsgTransfer along with the packet receipt to prove that the packet was never relayed,
 	// i.e. that the MsgRecvPacket was never written to the counterparty chain,
 	// and assembles a full MsgTimeout ready to write to the chain,
 	// i.e. the chain where the MsgTransfer was committed.
-	MsgTimeout(msgTransfer PacketInfo, proofUnreceived []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+	MsgTimeout(msgTransfer PacketInfo, proofUnreceived PacketProof) (RelayerMessage, error)
 
 	// MsgTimeoutOnClose takes the packet information from a MsgTransfer along with the packet receipt to prove that the packet was never relayed,
 	// i.e. that the MsgRecvPacket was never written to the counterparty chain,
 	// and assembles a full MsgTimeoutOnClose ready to write to the chain,
 	// i.e. the chain where the MsgTransfer was committed.
-	MsgTimeoutOnClose(msgTransfer PacketInfo, proofUnreceived []byte, proofHeight clienttypes.Height) (RelayerMessage, error)
+	MsgTimeoutOnClose(msgTransfer PacketInfo, proofUnreceived PacketProof) (RelayerMessage, error)
 
 	// [End] Packet flow IBC message assembly
 

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -190,11 +190,11 @@ type ChainProvider interface {
 	// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
 	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
 
-	// MsgRecvPacket takes takes the packet infromation from a MsgTransfer along with the packet commitment,
+	// MsgRecvPacket takes the packet information from a MsgTransfer along with the packet commitment,
 	// and assembles a full MsgRecvPacket ready to write to the chain.
 	MsgRecvPacket(msgTransfer PacketInfo, proof PacketProof) (RelayerMessage, error)
 
-	// MsgAcknowledgement takes the packet infromation from a MsgRecvPacket along with the packet acknowledgement,
+	// MsgAcknowledgement takes the packet information from a MsgRecvPacket along with the packet acknowledgement,
 	// and assembles a full MsgAcknowledgement ready to write to the chain.
 	MsgAcknowledgement(msgRecvPacket PacketInfo, proofAcked PacketProof) (RelayerMessage, error)
 


### PR DESCRIPTION
Previously, methods such as `MsgRecvPacket` in the `CosmosChainProvider` would both query for the tendermint proof and assemble the message for the counterparty. This will only work if the counterparty is a cosmos chain. In preparation for third party chains, this separates the proof queries into the following methods:

```go
// PacketCommitment queries for proof that a MsgTransfer has been committed on the chain.
PacketCommitment(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)

// PacketAcknowledgement queries for proof that a MsgRecvPacket has been committed on the chain.
PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, latest LatestBlock) (PacketProof, error)

// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
```

They all have a common signature, returning the proof as `[]byte` and the height as `clienttypes.Height` ibc-go type. This information can then be passed into the message assembly function _for the destination chain_ instead of the source chain, which can construct the message as needed for the destination chain.