### PR TITLE
CosmosChainProcessor - channel and connection message handlers

### DIFF
--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -51,13 +51,6 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(action string, ci provider
 	channelKey := processor.ChannelInfoChannelKey(ci)
 	switch action {
 	case processor.MsgChannelOpenInit:
-		// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
-		for k := range ccp.connectionStateCache {
-			if k.ConnectionID == ci.ConnID {
-				ci.CounterpartyConnID = k.CounterpartyConnID
-				break
-			}
-		}
 		ccp.channelStateCache[channelKey] = false
 	case processor.MsgChannelOpenTry:
 		ccp.channelStateCache[channelKey] = false

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -50,9 +50,7 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(action string, ci provider
 	ccp.channelConnections[ci.ChannelID] = ci.ConnID
 	channelKey := processor.ChannelInfoChannelKey(ci)
 	switch action {
-	case processor.MsgChannelOpenInit:
-		ccp.channelStateCache[channelKey] = false
-	case processor.MsgChannelOpenTry:
+	case processor.MsgChannelOpenInit, processor.MsgChannelOpenTry:
 		ccp.channelStateCache[channelKey] = false
 	case processor.MsgChannelOpenAck, processor.MsgChannelOpenConfirm:
 		ccp.channelStateCache[channelKey] = true
@@ -72,12 +70,8 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(action string, ci provider
 func (ccp *CosmosChainProcessor) handleConnectionMessage(action string, ci provider.ConnectionInfo, ibcMessagesCache processor.IBCMessagesCache) {
 	ccp.connectionClients[ci.ConnID] = ci.ClientID
 	connectionKey := processor.ConnectionInfoConnectionKey(ci)
-	switch action {
-	case processor.MsgConnectionOpenAck, processor.MsgConnectionOpenConfirm:
-		ccp.connectionStateCache[connectionKey] = true
-	default:
-		ccp.connectionStateCache[connectionKey] = false
-	}
+	open := (action == processor.MsgConnectionOpenAck || action == processor.MsgConnectionOpenConfirm)
+	ccp.connectionStateCache[connectionKey] = open
 	ibcMessagesCache.ConnectionHandshake.Retain(connectionKey, action, ci)
 
 	ccp.logConnectionMessage(action, ci)

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -12,6 +12,10 @@ func (ccp *CosmosChainProcessor) handleMessage(m ibcMessage, c processor.IBCMess
 	switch m.action {
 	case processor.MsgTransfer, processor.MsgRecvPacket, processor.MsgAcknowledgement, processor.MsgTimeout, processor.MsgTimeoutOnClose:
 		ccp.handlePacketMessage(m.action, provider.PacketInfo(*m.info.(*packetInfo)), c)
+	case processor.MsgChannelOpenInit, processor.MsgChannelOpenTry, processor.MsgChannelOpenAck, processor.MsgChannelOpenConfirm:
+		ccp.handleChannelMessage(m.action, provider.ChannelInfo(*m.info.(*channelInfo)), c)
+	case processor.MsgConnectionOpenInit, processor.MsgConnectionOpenTry, processor.MsgConnectionOpenAck, processor.MsgConnectionOpenConfirm:
+		ccp.handleConnectionMessage(m.action, provider.ConnectionInfo(*m.info.(*connectionInfo)), c)
 	case processor.MsgCreateClient, processor.MsgUpdateClient, processor.MsgUpgradeClient, processor.MsgSubmitMisbehaviour:
 		ccp.handleClientMessage(m.action, *m.info.(*clientInfo))
 	}
@@ -40,6 +44,50 @@ func (ccp *CosmosChainProcessor) handlePacketMessage(action string, pi provider.
 
 	c.PacketFlow.Retain(channelKey, action, pi)
 	ccp.logPacketMessage(action, pi)
+}
+
+func (ccp *CosmosChainProcessor) handleChannelMessage(action string, ci provider.ChannelInfo, ibcMessagesCache processor.IBCMessagesCache) {
+	ccp.channelConnections[ci.ChannelID] = ci.ConnID
+	channelKey := processor.ChannelInfoChannelKey(ci)
+	switch action {
+	case processor.MsgChannelOpenInit:
+		// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
+		for k := range ccp.connectionStateCache {
+			if k.ConnectionID == ci.ConnID {
+				ci.CounterpartyConnID = k.CounterpartyConnID
+				break
+			}
+		}
+		ccp.channelStateCache[channelKey] = false
+	case processor.MsgChannelOpenTry:
+		ccp.channelStateCache[channelKey] = false
+	case processor.MsgChannelOpenAck, processor.MsgChannelOpenConfirm:
+		ccp.channelStateCache[channelKey] = true
+	case processor.MsgChannelCloseInit, processor.MsgChannelCloseConfirm:
+		for k := range ccp.channelStateCache {
+			if k.PortID == ci.PortID && k.ChannelID == ci.ChannelID {
+				ccp.channelStateCache[k] = false
+				break
+			}
+		}
+	}
+	ibcMessagesCache.ChannelHandshake.Retain(channelKey, action, ci)
+
+	ccp.logChannelMessage(action, ci)
+}
+
+func (ccp *CosmosChainProcessor) handleConnectionMessage(action string, ci provider.ConnectionInfo, ibcMessagesCache processor.IBCMessagesCache) {
+	ccp.connectionClients[ci.ConnID] = ci.ClientID
+	connectionKey := processor.ConnectionInfoConnectionKey(ci)
+	switch action {
+	case processor.MsgConnectionOpenAck, processor.MsgConnectionOpenConfirm:
+		ccp.connectionStateCache[connectionKey] = true
+	default:
+		ccp.connectionStateCache[connectionKey] = false
+	}
+	ibcMessagesCache.ConnectionHandshake.Retain(connectionKey, action, ci)
+
+	ccp.logConnectionMessage(action, ci)
 }
 
 func (ccp *CosmosChainProcessor) handleClientMessage(action string, ci clientInfo) {
@@ -72,4 +120,23 @@ func (ccp *CosmosChainProcessor) logPacketMessage(message string, pi provider.Pa
 		fields = append(fields, zap.Uint64("timeout_timestamp", pi.TimeoutTimestamp))
 	}
 	ccp.logObservedIBCMessage(message, fields...)
+}
+
+func (ccp *CosmosChainProcessor) logChannelMessage(message string, ci provider.ChannelInfo) {
+	ccp.logObservedIBCMessage(message,
+		zap.String("channel_id", ci.ChannelID),
+		zap.String("port_id", ci.PortID),
+		zap.String("counterparty_channel_id", ci.CounterpartyChannelID),
+		zap.String("counterparty_port_id", ci.CounterpartyPortID),
+		zap.String("connection_id", ci.ConnID),
+	)
+}
+
+func (ccp *CosmosChainProcessor) logConnectionMessage(message string, ci provider.ConnectionInfo) {
+	ccp.logObservedIBCMessage(message,
+		zap.String("client_id", ci.ClientID),
+		zap.String("connection_id", ci.ConnID),
+		zap.String("counterparty_client_id", ci.CounterpartyClientID),
+		zap.String("counterparty_connection_id", ci.CounterpartyConnID),
+	)
 }

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -108,11 +108,22 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 	for action, cmc := range messageCache.ChannelHandshake {
 		newCmc := make(ChannelMessageCache)
 		for k, ci := range cmc {
-			if pathEnd.isRelevantChannel(k.ChannelID) {
-				// can complete channel handshakes on this client
-				// since PathProcessor holds reference to the counterparty chain pathEndRuntime.
-				newCmc[k] = ci
+			if !pathEnd.isRelevantChannel(k.ChannelID) {
+				continue
 			}
+			// can complete channel handshakes on this client
+			// since PathProcessor holds reference to the counterparty chain pathEndRuntime.
+
+			if action == MsgChannelOpenInit {
+				// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
+				for k := range pathEnd.connectionStateCache {
+					if k.ConnectionID == ci.ConnID {
+						ci.CounterpartyConnID = k.CounterpartyConnID
+						break
+					}
+				}
+			}
+			newCmc[k] = ci
 		}
 		if len(newCmc) == 0 {
 			continue


### PR DESCRIPTION
Brings the channel and connection message handlers back in the minimal format where a single handler is used for all actions.

`MsgChannelOpenTry` requires the counterparty connection ID, so adding this in the `pathEndRuntime` so that it does not need to be a `ChainProcessor` concern.