### PR TITLE
CLI - channel handshakes

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -88,7 +88,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	testConnectionPair(ctx, t, src, dst)
 
 	t.Log("Creating channels")
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	t.Log("Querying open channels to ensure successful creation")
@@ -175,7 +175,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -202,7 +202,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 	testChannelPair(ctx, t, src, dst, channel.ChannelId, channel.PortId)
 
@@ -256,7 +256,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -398,10 +398,10 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	testConnectionPair(ctx, t, src, dst)
 
 	t.Log("Creating channels")
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, true)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, true)
 	require.NoError(t, err)
 
 	t.Log("Ensuring two channels exist")
@@ -593,7 +593,7 @@ func TestUnorderedChannelBlockHeightTimeout(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error
@@ -691,7 +691,7 @@ func TestUnorderedChannelTimestampTimeout(t *testing.T) {
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
+	err = src.CreateOpenChannels(ctx, dst, 3, timeout, DefaultSrcPortID, DefaultDstPortID, DefaultOrder, DefaultVersion, false)
 	require.NoError(t, err)
 
 	// query open channels and ensure there is no error

--- a/_test/test_queries.go
+++ b/_test/test_queries.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	clientypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/stretchr/testify/require"
 )
@@ -93,11 +94,23 @@ func testChannel(ctx context.Context, t *testing.T, src, dst *relayer.Chain, cha
 
 	chans, err := src.ChainProvider.QueryChannels(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(chans))
-	require.Equal(t, chans[0].Ordering.String(), "ORDER_UNORDERED")
-	require.Equal(t, chans[0].State.String(), "STATE_OPEN")
-	require.Equal(t, chans[0].Counterparty.ChannelId, channelID)
-	require.Equal(t, chans[0].Counterparty.GetPortID(), portID)
+	require.GreaterOrEqual(t, len(chans), 1)
+
+	var channel *chantypes.IdentifiedChannel
+	for _, ch := range chans {
+		if ch.Counterparty.ChannelId == channelID && ch.Counterparty.PortId == portID {
+			channel = ch
+			break
+		}
+	}
+
+	require.NotNil(t, channel)
+
+	require.Equal(t, channel.Ordering.String(), "ORDER_UNORDERED")
+	require.True(t,
+		channel.State.String() == "STATE_TRY_OPEN" || channel.State.String() == "STATE_OPEN",
+		"State: %s is not STATE_TRY_OPEN or STATE_OPEN", channel.State.String(),
+	)
 
 	h, err := src.ChainProvider.QueryLatestHeight(ctx)
 	require.NoError(t, err)
@@ -108,5 +121,5 @@ func testChannel(ctx context.Context, t *testing.T, src, dst *relayer.Chain, cha
 	require.Equal(t, ch.Channel.Ordering.String(), "ORDER_UNORDERED")
 	require.Equal(t, ch.Channel.State.String(), "STATE_OPEN")
 	require.Equal(t, ch.Channel.Counterparty.ChannelId, channelID)
-	require.Equal(t, ch.Channel.Counterparty.GetPortID(), portID)
+	require.Equal(t, ch.Channel.Counterparty.PortId, portID)
 }

--- a/_test/test_queries.go
+++ b/_test/test_queries.go
@@ -107,7 +107,7 @@ func testChannel(ctx context.Context, t *testing.T, src, dst *relayer.Chain, cha
 	require.NotNil(t, channel)
 
 	require.Equal(t, channel.Ordering.String(), "ORDER_UNORDERED")
-	require.True(t,
+	require.Truef(t,
 		channel.State.String() == "STATE_TRY_OPEN" || channel.State.String() == "STATE_OPEN",
 		"State: %s is not STATE_TRY_OPEN or STATE_OPEN", channel.State.String(),
 	)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -471,18 +471,7 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 			}
 
 			// create channel if it isn't already created
-			modified, err := c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
-			if err != nil {
-				return fmt.Errorf("error creating channels: %w", err)
-			}
-
-			if modified {
-				if err := a.OverwriteConfig(a.Config); err != nil {
-					return err
-				}
-			}
-
-			return nil
+			return c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
 		},
 	}
 
@@ -512,6 +501,11 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 				return err
 			}
 
+			retries, err := cmd.Flags().GetUint64(flagMaxRetries)
+			if err != nil {
+				return err
+			}
+
 			channelID := args[1]
 			portID := args[2]
 
@@ -528,16 +522,16 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 				return err
 			}
 
-			channel, err := c[src].ChainProvider.QueryChannel(cmd.Context(), srch, channelID, portID)
+			_, err = c[src].ChainProvider.QueryChannel(cmd.Context(), srch, channelID, portID)
 			if err != nil {
 				return err
 			}
 
-			return c[src].CloseChannel(cmd.Context(), c[dst], to, channelID, portID, channel)
+			return c[src].CloseChannel(cmd.Context(), c[dst], retries, to, channelID, portID)
 		},
 	}
 
-	return timeoutFlag(a.Viper, cmd)
+	return retryFlag(a.Viper, timeoutFlag(a.Viper, cmd))
 }
 
 func linkCmd(a *appState) *cobra.Command {
@@ -646,17 +640,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			}
 
 			// create channel if it isn't already created
-			modified, err = c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
-			if err != nil {
-				return fmt.Errorf("error creating channels: %w", err)
-			}
-			if modified {
-				if err := a.OverwriteConfig(a.Config); err != nil {
-					return err
-				}
-			}
-
-			return nil
+			return c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override)
 		},
 	}
 

--- a/ibctest/docker.go
+++ b/ibctest/docker.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"path/filepath"
 	"runtime"
@@ -62,10 +63,10 @@ func handleDockerBuildOutput(t *testing.T, body io.Reader) {
 
 		_ = json.Unmarshal([]byte(line), &logLine)
 		if logLine.Stream != "" {
-			t.Log(logLine.Stream)
+			fmt.Print(logLine.Stream)
 		}
 		if logLine.Aux != nil {
-			t.Log(logLine.Aux)
+			fmt.Print(logLine.Aux)
 		}
 	}
 

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -3,13 +3,11 @@ package relayer
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/avast/retry-go/v4"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
-	"github.com/cosmos/ibc-go/v3/modules/core/exported"
+	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
 )
@@ -22,881 +20,133 @@ func (c *Chain) CreateOpenChannels(
 	timeout time.Duration,
 	srcPortID, dstPortID, order, version string,
 	override bool,
-) (modified bool, err error) {
+) error {
 	// client and connection identifiers must be filled in
 	if err := ValidateConnectionPaths(c, dst); err != nil {
-		return modified, err
+		return err
 	}
 
 	// port identifiers and channel ORDER must be valid
 	if err := ValidateChannelParams(srcPortID, dstPortID, order); err != nil {
-		return modified, err
+		return err
 	}
 
-	ticker := time.NewTicker(timeout)
-	defer ticker.Stop()
-
-	// Populate the immediate channel so we begin processing right away.
-	immediate := make(chan struct{}, 1)
-	immediate <- struct{}{}
-
-	var (
-		srcChannelID, dstChannelID string
-		failures                   uint64
-	)
-	for {
-		// Block until the immediate signal or the ticker fires.
-		select {
-		case <-immediate:
-			// Keep going.
-		case <-ticker.C:
-			// Keep going.
-		case <-ctx.Done():
-			return modified, ctx.Err()
-		}
-
-		var success, lastStep, recentlyModified bool
-		var err error
-		srcChannelID, dstChannelID, success, lastStep, recentlyModified, err = ExecuteChannelStep(ctx, c, dst, srcChannelID,
-			dstChannelID, srcPortID, dstPortID, order, version, override)
-		if err != nil {
-			c.log.Info("Error executing channel step", zap.Error(err))
-		}
-		if recentlyModified {
-			modified = true
-		}
-
-		switch {
-		// In the case of success and this being the last transaction
-		// debug logging, log created channel and break
-		case success && lastStep:
-
-			if c.debug {
-				srch, dsth, err := QueryLatestHeights(ctx, c, dst)
-				if err != nil {
-					return modified, err
-				}
-				srcChan, dstChan, err := QueryChannelPair(ctx, c, dst, srch, dsth, srcChannelID, dstChannelID, srcPortID, dstPortID)
-				if err != nil {
-					return modified, err
-				}
-				logChannelStates(c, dst, srcChan, dstChan)
-			}
-
-			c.log.Info(
-				"Channel created",
-				zap.String("src_chain_id", c.ChainID()),
-				zap.String("src_channel_id", srcChannelID),
-				zap.String("src_port_id", srcPortID),
-				zap.String("dst_chain_id", dst.ChainID()),
-				zap.String("dst_channel_id", dstChannelID),
-				zap.String("dst_port_id", dstPortID),
-			)
-
-			return modified, nil
-
-		// In the case of success, reset the failures counter
-		case success:
-			failures = 0
-
-			if !recentlyModified {
-				c.log.Debug("Short delay before retrying channel open transaction, because the last check was a no-op...")
-				select {
-				case <-time.After(timeout / 8):
-					// Nothing to do.
-				case <-ctx.Done():
-					return false, ctx.Err()
-				}
-			}
-
-			select {
-			case immediate <- struct{}{}:
-				// Proceed immediately to the next step if possible.
-			default:
-				// If can't write to ch -- could that ever happen? -- that's fine, don't block here.
-			}
-
-			continue
-
-		// In the case of failure, increment the failures counter and exit if this is the 3rd failure
-		case !success:
-			failures++
-			if failures > maxRetries {
-				return modified, fmt.Errorf("! Channel failed: [%s]chan{%s}port{%s} -> [%s]chan{%s}port{%s}",
-					c.ChainID(), srcChannelID, srcPortID,
-					dst.ChainID(), dstChannelID, dstPortID)
-			}
-
-			c.log.Debug("Delaying before retrying channel open transaction...")
-			select {
-			case <-time.After(5 * time.Second):
-				// Nothing to do.
-			case <-ctx.Done():
-				return modified, ctx.Err()
-			}
-		}
+	channel, err := QueryPortChannel(ctx, c, srcPortID)
+	if !override && err == nil && channel != nil {
+		return fmt.Errorf("channel {%s} with port {%s} already exists on chain {%s}", channel.ChannelId, channel.PortId, c.ChainID())
 	}
 
-	panic("unreachable")
-}
+	channel, err = QueryPortChannel(ctx, dst, dstPortID)
+	if !override && err == nil && channel != nil {
+		return fmt.Errorf("channel {%s} with port {%s} already exists on chain {%s}", channel.ChannelId, channel.PortId, dst.ChainID())
+	}
 
-// ExecuteChannelStep executes the next channel step based on the
-// states of two channel ends specified by the provided channel identifiers passed in as arguments.
-// The booleans returned indicate if the message was successfully executed and if this was the last handshake step.
-func ExecuteChannelStep(ctx context.Context, src, dst *Chain, srcChanID, dstChanID, srcPortID, dstPortID, order, version string, override bool) (
-	newSrcChanID, newDstChanID string, success, last, modified bool, err error) {
+	srcPathChain := pathChain{
+		provider: c.ChainProvider,
+		pathEnd:  processor.NewPathEnd(c.PathEnd.ChainID, c.PathEnd.ClientID, "", []processor.ChannelKey{}),
+	}
+	dstPathChain := pathChain{
+		provider: dst.ChainProvider,
+		pathEnd:  processor.NewPathEnd(dst.PathEnd.ChainID, dst.PathEnd.ClientID, "", []processor.ChannelKey{}),
+	}
 
-	var (
-		srch, dsth           int64
-		srcHeader, dstHeader exported.Header
-		msgs                 []provider.RelayerMessage
-		res                  *provider.RelayerTxResponse
+	// Timeout is per message. Four channel handshake messages, allowing maxRetries for each.
+	processorTimeout := timeout * 4 * time.Duration(maxRetries)
+
+	processorCtx, processorCtxCancel := context.WithTimeout(ctx, processorTimeout)
+	defer processorCtxCancel()
+
+	pp := processor.NewPathProcessor(
+		c.log,
+		srcPathChain.pathEnd,
+		dstPathChain.pathEnd,
 	)
 
-	if err = retry.Do(func() error {
-		srch, dsth, err = QueryLatestHeights(ctx, src, dst)
-		if err != nil || srch == 0 || dsth == 0 {
-			return fmt.Errorf("failed to query latest heights: %w", err)
-		}
-		return nil
-	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-		return srcChanID, dstChanID, success, last, modified, err
-	}
-
-	// if either identifier is missing, an existing channel that matches the required fields is chosen
-	// or a new channel is created.
-	if srcChanID == "" || dstChanID == "" {
-		newSrcChanID, newDstChanID, success, modified, err = InitializeChannel(ctx, src, dst, srcChanID, dstChanID, srcPortID,
-			dstPortID, order, version, override)
-
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		return newSrcChanID, newDstChanID, success, false, modified, nil
-	}
-
-	// Query Channel data from src and dst
-	srcChan, dstChan, err := QueryChannelPair(ctx, src, dst, srch-1, dsth-1, srcChanID, dstChanID, srcPortID, dstPortID)
-	if err != nil {
-		return srcChanID, dstChanID, false, false, false, err
-	}
-
-	switch {
-
-	// OpenTry on source in case of crossing hellos (both channels are on INIT)
-	// obtain proof of counterparty in TRYOPEN state and submit to source chain to update state
-	// from INIT to TRYOPEN.
-	case srcChan.Channel.State == chantypes.INIT && dstChan.Channel.State == chantypes.INIT:
-		if src.debug {
-			logChannelStates(src, dst, srcChan, dstChan)
-		}
-
-		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to query latest heights. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
-		})); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		msgs, err = src.ChainProvider.ChannelOpenTry(ctx, dst.ChainProvider, dstHeader, srcPortID, dstPortID,
-			srcChanID, dstChanID, version, src.ConnectionID(), src.ClientID())
-
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
-		if err != nil {
-			src.LogFailedTx(res, err, msgs)
-		}
-		if !success {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-	// OpenAck on source if dst is at TRYOPEN and src is at INIT or TRYOPEN (crossing hellos)
-	// obtain proof of counterparty in TRYOPEN state and submit to source chain to update state
-	// from INIT/TRYOPEN to OPEN.
-	case (srcChan.Channel.State == chantypes.INIT || srcChan.Channel.State == chantypes.TRYOPEN) &&
-		dstChan.Channel.State == chantypes.TRYOPEN:
-
-		if src.debug {
-			logChannelStates(src, dst, srcChan, dstChan)
-		}
-
-		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to query latest heights. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
-		})); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		msgs, err = src.ChainProvider.ChannelOpenAck(ctx, dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstChanID, dstPortID)
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
-		if err != nil {
-			src.LogFailedTx(res, err, msgs)
-		}
-		if !success {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-	// OpenAck on counterparty
-	// obtain proof of source in TRYOPEN state and submit to counterparty chain to update state
-	// from INIT to OPEN.
-	case srcChan.Channel.State == chantypes.TRYOPEN && dstChan.Channel.State == chantypes.INIT:
-		if dst.debug {
-			logChannelStates(dst, src, dstChan, srcChan)
-		}
-
-		if err = retry.Do(func() error {
-			srch, err = src.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil || srch == 0 {
-				return fmt.Errorf("failed to query latest heights. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		if err = retry.Do(func() error {
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
-			if err != nil || srch == 0 {
-				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			src.LogRetryGetIBCUpdateHeader(n, err)
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
-		})); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		msgs, err = dst.ChainProvider.ChannelOpenAck(ctx, src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcChanID, srcPortID)
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
-		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
-		}
-		if !success {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-	// OpenConfirm on source
-	case srcChan.Channel.State == chantypes.TRYOPEN && dstChan.Channel.State == chantypes.OPEN:
-		if src.debug {
-			logChannelStates(src, dst, srcChan, dstChan)
-		}
-
-		if err = retry.Do(func() error {
-			dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to query latest heights. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		if err = retry.Do(func() error {
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
-			if err != nil || dsth == 0 {
-				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			dst.LogRetryGetIBCUpdateHeader(n, err)
-			dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
-		})); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		msgs, err = src.ChainProvider.ChannelOpenConfirm(ctx, dst.ChainProvider, dstHeader, src.ClientID(), srcPortID, srcChanID, dstPortID, dstChanID)
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		last = true
-
-		res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
-		if err != nil {
-			src.LogFailedTx(res, err, msgs)
-		}
-		if !success {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-	// OpenConfirm on counterparty
-	case srcChan.Channel.State == chantypes.OPEN && dstChan.Channel.State == chantypes.TRYOPEN:
-		if dst.debug {
-			logChannelStates(dst, src, dstChan, srcChan)
-		}
-
-		if err = retry.Do(func() error {
-			srch, err = src.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil || srch == 0 {
-				return fmt.Errorf("failed to query latest heights. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		if err = retry.Do(func() error {
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
-			if err != nil || srch == 0 {
-				return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-			}
-			return err
-		}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-			src.LogRetryGetIBCUpdateHeader(n, err)
-			srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
-		})); err != nil {
-			return srcChanID, dstChanID, success, last, modified, err
-		}
-
-		msgs, err = dst.ChainProvider.ChannelOpenConfirm(ctx, src.ChainProvider, srcHeader, dst.ClientID(), dstPortID, dstChanID, srcPortID, srcChanID)
-		if err != nil {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
-		if err != nil {
-			dst.LogFailedTx(res, err, msgs)
-		}
-		if !success {
-			return srcChanID, dstChanID, false, false, false, err
-		}
-
-		last = true
-
-	case srcChan.Channel.State == chantypes.OPEN && dstChan.Channel.State == chantypes.OPEN:
-		last = true
-
-	}
-
-	return srcChanID, dstChanID, true, last, false, nil
-}
-
-// InitializeChannel creates a new channel on either the source or destination chain.
-// NOTE: This function may need to be called twice if neither channel exists.
-func InitializeChannel(ctx context.Context, src, dst *Chain, srcChanID, dstChanID, srcPortID, dstPortID, order, version string, override bool) (
-	newSrcChanID, newDstChanID string, success, modified bool, err error) {
-
-	var (
-		srch, dsth           int64
-		srcHeader, dstHeader exported.Header
-		msgs                 []provider.RelayerMessage
-		res                  *provider.RelayerTxResponse
-		existingChanID       string
-		found                bool
+	c.log.Info("Starting event processor for channel handshake",
+		zap.String("src_chain_id", c.PathEnd.ChainID),
+		zap.String("src_port_id", srcPortID),
+		zap.String("dst_chain_id", dst.PathEnd.ChainID),
+		zap.String("dst_port_id", dstPortID),
 	)
 
-	switch {
-
-	// OpenInit on source
-	// Neither channel has been initialized
-	case srcChanID == "" && dstChanID == "":
-		src.log.Debug(
-			"Attempting to create new channel ends",
-			zap.String("src_chain_id", src.ChainID()),
-			zap.String("dst_chain_id", dst.ChainID()),
-		)
-
-		if !override {
-			existingChanID, found = FindMatchingChannel(ctx, src, srcPortID, dstPortID, order, version)
-		}
-
-		if !found || override {
-			if err = retry.Do(func() error {
-				dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
-				if err != nil || dsth == 0 {
-					return fmt.Errorf("failed to query latest heights. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			if err = retry.Do(func() error {
-				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
-				if err != nil || dsth == 0 {
-					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-				dst.LogRetryGetIBCUpdateHeader(n, err)
-				dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
-			})); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			msgs, err = src.ChainProvider.ChannelOpenInit(src.ClientID(), src.ConnectionID(), srcPortID, version, dstPortID, OrderFromString(strings.ToUpper(order)), dstHeader)
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
-			if err != nil {
-				src.LogFailedTx(res, err, msgs)
-			}
-			if !success {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			// use index 1, channel open init is the second message in the transaction
-			existingChanID, err = ParseChannelIDFromEvents(res.Events)
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-		} else {
-			src.log.Debug(
-				"Channel end already exists",
-				zap.String("channel_id", existingChanID),
-				zap.String("src_chain_id", src.ChainID()),
-				zap.String("dst_chain_id", dst.ChainID()),
-			)
-		}
-
-		return existingChanID, dstChanID, true, true, nil
-
-	// OpenTry on source
-	// source channel does not exist, but counterparty channel exists
-	case srcChanID == "" && dstChanID != "":
-		src.log.Debug(
-			"Attempting to open channel end",
-			zap.String("src_chain_id", src.ChainID()),
-			zap.String("dst_chain_id", dst.ChainID()),
-		)
-
-		if !override {
-			existingChanID, found = FindMatchingChannel(ctx, src, srcPortID, dstPortID, order, version)
-		}
-
-		if !found || override {
-
-			if err = retry.Do(func() error {
-				dsth, err = dst.ChainProvider.QueryLatestHeight(ctx)
-				if err != nil || dsth == 0 {
-					return fmt.Errorf("failed to query latest heights. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			if err = retry.Do(func() error {
-				dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, src.ChainProvider, src.ClientID())
-				if err != nil || dsth == 0 {
-					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-				dst.LogRetryGetIBCUpdateHeader(n, err)
-				dsth, _ = dst.ChainProvider.QueryLatestHeight(ctx)
-			})); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			// open try on source chain
-			msgs, err = src.ChainProvider.ChannelOpenTry(ctx, dst.ChainProvider, dstHeader, srcPortID, dstPortID, srcChanID, dstChanID, version, src.ConnectionID(), src.ClientID())
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			res, success, err = src.ChainProvider.SendMessages(ctx, msgs)
-			if err != nil {
-				src.LogFailedTx(res, err, msgs)
-			}
-			if !success {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			// use index 1, channel open try is the second message in the transaction
-			existingChanID, err = ParseChannelIDFromEvents(res.Events)
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-		} else {
-			src.log.Debug(
-				"Channel end already exists",
-				zap.String("channel_id", existingChanID),
-				zap.String("src_chain_id", src.ChainID()),
-				zap.String("dst_chain_id", dst.ChainID()),
-			)
-		}
-
-		return existingChanID, dstChanID, true, true, nil
-
-	// OpenTry on counterparty
-	// source channel exists, but counterparty channel does not exist
-	case srcChanID != "" && dstChanID == "":
-		dst.log.Debug(
-			"Attempting to open channel end",
-			zap.String("src_chain_id", dst.ChainID()),
-			zap.String("dst_chain_id", src.ChainID()),
-		)
-
-		if !override {
-			existingChanID, found = FindMatchingChannel(ctx, dst, dstPortID, srcPortID, order, version)
-		}
-
-		if !found || override {
-
-			if err = retry.Do(func() error {
-				srch, err = src.ChainProvider.QueryLatestHeight(ctx)
-				if err != nil || srch == 0 {
-					return fmt.Errorf("failed to query latest heights. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			if err = retry.Do(func() error {
-				srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
-				if err != nil || srch == 0 {
-					return fmt.Errorf("failed to get IBC update header. Err: %w", err)
-				}
-				return err
-			}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-				src.LogRetryGetIBCUpdateHeader(n, err)
-				srch, _ = src.ChainProvider.QueryLatestHeight(ctx)
-			})); err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			// open try on destination chain
-			msgs, err = dst.ChainProvider.ChannelOpenTry(ctx, src.ChainProvider, srcHeader, dstPortID, srcPortID, dstChanID, srcChanID, version, dst.ConnectionID(), dst.ClientID())
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			res, success, err = dst.ChainProvider.SendMessages(ctx, msgs)
-			if err != nil {
-				dst.LogFailedTx(res, err, msgs)
-			}
-			if !success {
-				return srcChanID, dstChanID, false, false, err
-			}
-
-			// use index 1, channel open try is the second message in the transaction
-			existingChanID, err = ParseChannelIDFromEvents(res.Events)
-			if err != nil {
-				return srcChanID, dstChanID, false, false, err
-			}
-		} else {
-			dst.log.Debug(
-				"Channel end already exists",
-				zap.String("channel_id", existingChanID),
-				zap.String("src_chain_id", dst.ChainID()),
-				zap.String("dst_chain_id", src.ChainID()),
-			)
-		}
-
-		return srcChanID, existingChanID, true, true, nil
-
-	default:
-		return srcChanID, dstChanID, false, false, fmt.Errorf("channel ends already created")
-	}
+	return processor.NewEventProcessor().
+		WithChainProcessors(
+			srcPathChain.chainProcessor(c.log),
+			dstPathChain.chainProcessor(c.log)).
+		WithPathProcessors(pp).
+		WithInitialBlockHistory(0).
+		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
+			Initial: &processor.ChannelMessage{
+				ChainID: c.PathEnd.ChainID,
+				Action:  processor.MsgChannelOpenInit,
+				Info: provider.ChannelInfo{
+					PortID:             srcPortID,
+					CounterpartyPortID: dstPortID,
+					ConnID:             c.PathEnd.ConnectionID,
+					Version:            version,
+					Order:              OrderFromString(order),
+				},
+			},
+			Termination: &processor.ChannelMessage{
+				ChainID: dst.PathEnd.ChainID,
+				Action:  processor.MsgChannelOpenConfirm,
+				Info: provider.ChannelInfo{
+					PortID:             dstPortID,
+					CounterpartyPortID: srcPortID,
+				},
+			},
+		}).
+		Build().
+		Run(processorCtx)
 }
 
 // CloseChannel runs the channel closing messages on timeout until they pass.
-// TODO: add max retries or something to this function
-func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, to time.Duration, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) error {
-	ticker := time.NewTicker(to)
-	defer ticker.Stop()
-
-	dstChanID := srcChan.Channel.Counterparty.ChannelId
-	dstPortID := srcChan.Channel.Counterparty.PortId
-
-	for ; true; <-ticker.C {
-		closeSteps, isLast, err := c.CloseChannelStep(ctx, dst, srcChanID, srcPortID, srcChan)
-		if err != nil {
-			return err
-		}
-
-		if !closeSteps.Ready() {
-			break
-		}
-
-		result := closeSteps.Send(ctx, c.log, AsRelayMsgSender(c), AsRelayMsgSender(dst))
-		if err := result.Error(); err != nil {
-			c.log.Info(
-				"Error when attempting to close channel",
-				zap.String("src_chain_id", c.ChainID()),
-				zap.String("src_channel_id", srcChanID),
-				zap.String("src_port_id", srcPortID),
-				zap.String("dst_chain_id", dst.ChainID()),
-				zap.String("dst_channel_id", dstChanID),
-				zap.String("dst_port_id", dstPortID),
-				zap.Error(err),
-			)
-			continue
-		}
-
-		if !isLast {
-			continue
-		}
-
-		srch, dsth, err := QueryLatestHeights(ctx, c, dst)
-		if err != nil {
-			return err
-		}
-
-		srcChan, dstChan, err := QueryChannelPair(ctx, c, dst, srch, dsth, srcChanID, dstChanID, srcPortID, dstPortID)
-		if err != nil {
-			return err
-		}
-
-		if c.debug {
-			logChannelStates(c, dst, srcChan, dstChan)
-		}
-		c.log.Info(
-			"Closed source channel",
-			zap.String("src_chain_id", c.ChainID()),
-			zap.String("src_channel_id", srcChanID),
-			zap.String("src_port_id", srcPortID),
-			zap.String("dst_chain_id", dst.ChainID()),
-			zap.String("dst_channel_id", dstChanID),
-			zap.String("dst_port_id", dstPortID),
-		)
-		break
+func (c *Chain) CloseChannel(ctx context.Context, dst *Chain, maxRetries uint64, timeout time.Duration, srcChanID, srcPortID string) error {
+	srcPathChain := pathChain{
+		provider: c.ChainProvider,
+		pathEnd:  processor.NewPathEnd(c.PathEnd.ChainID, c.PathEnd.ClientID, "", []processor.ChannelKey{}),
 	}
-	return nil
-}
-
-// CloseChannelStep returns the next set of messages for closing a channel with given
-// identifiers between chains src and dst. If the closing handshake hasn't started, then CloseChannelStep
-// will begin the handshake on the src chain.
-//
-// CloseChannelStep returns a set of messages to send,
-// and a bool reporting whether the closing handshake has started.
-func (c *Chain) CloseChannelStep(ctx context.Context, dst *Chain, srcChanID, srcPortID string, srcChan *chantypes.QueryChannelResponse) (*RelayMsgs, bool, error) {
-	dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
-	if err != nil {
-		return nil, false, err
+	dstPathChain := pathChain{
+		provider: dst.ChainProvider,
+		pathEnd:  processor.NewPathEnd(dst.PathEnd.ChainID, dst.PathEnd.ClientID, "", []processor.ChannelKey{}),
 	}
 
-	out := new(RelayMsgs)
-	if err := ValidatePaths(c, dst); err != nil {
-		return nil, false, err
-	}
+	// Timeout is per message. Two close channel handshake messages, allowing maxRetries for each.
+	processorTimeout := timeout * 2 * time.Duration(maxRetries)
 
-	dstChanID := srcChan.Channel.Counterparty.ChannelId
-	dstPortID := srcChan.Channel.Counterparty.PortId
+	processorCtx, processorCtxCancel := context.WithTimeout(ctx, processorTimeout)
+	defer processorCtxCancel()
 
-	dstChan, err := dst.ChainProvider.QueryChannel(ctx, dsth, dstChanID, dstPortID)
-	if err != nil {
-		return nil, false, err
-	}
-
-	logChannelStates(c, dst, srcChan, dstChan)
-
-	isLast := false
-	switch {
-	// Closing handshake has not started, relay `updateClient` and `chanCloseInit` to src or dst according
-	// to the srcChan state
-	case srcChan.Channel.State != chantypes.CLOSED && dstChan.Channel.State != chantypes.CLOSED:
-		if srcChan.Channel.State != chantypes.UNINITIALIZED {
-			if c.debug {
-				logChannelStates(c, dst, srcChan, dstChan)
-			}
-
-			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, c.ChainProvider, c.ClientID())
-			if err != nil {
-				return nil, false, err
-			}
-
-			updateMsg, err := c.ChainProvider.MsgUpdateClient(c.ClientID(), dstHeader)
-			if err != nil {
-				return nil, false, err
-			}
-
-			msg, err := c.ChainProvider.ChannelCloseInit(srcPortID, srcChanID)
-			if err != nil {
-				return nil, false, err
-			}
-			out.Src = append(out.Src, updateMsg, msg)
-		} else if dstChan.Channel.State != chantypes.UNINITIALIZED {
-			if dst.debug {
-				logChannelStates(dst, c, dstChan, srcChan)
-			}
-
-			srch, err := c.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil {
-				return nil, false, err
-			}
-
-			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
-			if err != nil {
-				return nil, false, err
-			}
-
-			updateMsg, err := dst.ChainProvider.MsgUpdateClient(dst.ClientID(), srcHeader)
-			if err != nil {
-				return nil, false, err
-			}
-
-			msg, err := dst.ChainProvider.ChannelCloseInit(dstPortID, dstChanID)
-			if err != nil {
-				return nil, false, err
-			}
-			out.Dst = append(out.Dst, updateMsg, msg)
-		}
-
-	// Closing handshake has started on src, relay `updateClient` and `chanCloseConfirm` to dst
-	case srcChan.Channel.State == chantypes.CLOSED && dstChan.Channel.State != chantypes.CLOSED:
-		if dstChan.Channel.State != chantypes.UNINITIALIZED {
-			if dst.debug {
-				logChannelStates(dst, c, dstChan, srcChan)
-			}
-
-			srch, err := c.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil {
-				return nil, false, err
-			}
-
-			srcHeader, err := c.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.ClientID())
-			if err != nil {
-				return nil, false, err
-			}
-
-			updateMsg, err := dst.ChainProvider.MsgUpdateClient(dst.ClientID(), srcHeader)
-			if err != nil {
-				return nil, false, err
-			}
-
-			chanCloseConfirm, err := dst.ChainProvider.ChannelCloseConfirm(ctx, c.ChainProvider, srch, srcChanID, srcPortID, dstPortID, dstChanID)
-			if err != nil {
-				return nil, false, err
-			}
-
-			out.Dst = append(out.Dst,
-				updateMsg,
-				chanCloseConfirm,
-			)
-			isLast = true
-		}
-
-	// Closing handshake has started on dst, relay `updateClient` and `chanCloseConfirm` to src
-	case dstChan.Channel.State == chantypes.CLOSED && srcChan.Channel.State != chantypes.CLOSED:
-		if srcChan.Channel.State != chantypes.UNINITIALIZED {
-			if c.debug {
-				logChannelStates(c, dst, srcChan, dstChan)
-			}
-
-			dsth, err := dst.ChainProvider.QueryLatestHeight(ctx)
-			if err != nil {
-				return nil, false, err
-			}
-
-			dstHeader, err := dst.ChainProvider.GetIBCUpdateHeader(ctx, dsth, c.ChainProvider, c.ClientID())
-			if err != nil {
-				return nil, false, err
-			}
-
-			updateMsg, err := c.ChainProvider.MsgUpdateClient(c.ClientID(), dstHeader)
-			if err != nil {
-				return nil, false, err
-			}
-
-			chanCloseConfirm, err := c.ChainProvider.ChannelCloseConfirm(ctx, dst.ChainProvider, dsth, dstChanID, dstPortID, srcPortID, srcChanID)
-			if err != nil {
-				return nil, false, err
-			}
-
-			out.Src = append(out.Src,
-				updateMsg,
-				chanCloseConfirm,
-			)
-			isLast = true
-		}
-	}
-	return out, isLast, nil
-}
-
-// FindMatchingChannel will determine if there already exists a channel between source and counterparty
-// that matches the channel identifiers being passed in as arguments.
-func FindMatchingChannel(ctx context.Context, source *Chain, srcPortID, dstPortID, order, version string) (string, bool) {
-	// TODO: add appropriate offset and limits, along with retries
-	channelsResp, err := source.ChainProvider.QueryChannels(ctx)
-	if err != nil {
-		source.log.Info(
-			"Querying channels failed",
-			zap.String("src_chain_id", source.ChainID()),
-			zap.Error(err),
-		)
-		return "", false
-	}
-
-	for _, channel := range channelsResp {
-		if IsMatchingChannel(source, channel, srcPortID, dstPortID, order, version) {
-			// unused channel found
-			return channel.ChannelId, true
-		}
-	}
-
-	return "", false
-}
-
-// IsMatchingChannel determines if given channel matches required conditions.
-func IsMatchingChannel(source *Chain, channel *chantypes.IdentifiedChannel, srcPortID, dstPortID, order, version string) bool {
-	return channel.Ordering == OrderFromString(order) &&
-		IsConnectionFound(channel.ConnectionHops, source.ConnectionID()) &&
-		channel.Version == version &&
-		channel.PortId == srcPortID &&
-		channel.Counterparty.PortId == dstPortID &&
-		(((channel.State == chantypes.INIT || channel.State == chantypes.TRYOPEN) && channel.Counterparty.ChannelId == "") ||
-			(channel.State == chantypes.OPEN && (channel.Counterparty.ChannelId == "" || channel.Counterparty.PortId == dstPortID)))
-}
-
-// IsConnectionFound determines if given connectionId is present in channel connectionHops list.
-func IsConnectionFound(connectionHops []string, connectionID string) bool {
-	for _, id := range connectionHops {
-		if id == connectionID {
-			return true
-		}
-	}
-	return false
+	return processor.NewEventProcessor().
+		WithChainProcessors(
+			srcPathChain.chainProcessor(c.log),
+			dstPathChain.chainProcessor(c.log)).
+		WithPathProcessors(processor.NewPathProcessor(
+			c.log,
+			srcPathChain.pathEnd,
+			dstPathChain.pathEnd,
+		)).
+		WithInitialBlockHistory(0).
+		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
+			Initial: &processor.ChannelMessage{
+				ChainID: c.PathEnd.ChainID,
+				Action:  processor.MsgChannelCloseInit,
+				Info: provider.ChannelInfo{
+					PortID:    srcPortID,
+					ChannelID: srcChanID,
+				},
+			},
+			Termination: &processor.ChannelMessage{
+				ChainID: dst.PathEnd.ChainID,
+				Action:  processor.MsgChannelCloseConfirm,
+				Info: provider.ChannelInfo{
+					CounterpartyPortID:    srcPortID,
+					CounterpartyChannelID: srcChanID,
+				},
+			},
+		}).
+		Build().
+		Run(processorCtx)
 }
 
 // ValidateChannelParams validates a set of port-ids as well as the order.

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -31,6 +31,7 @@ func (c *Chain) CreateOpenConnections(
 		pathEnd:  processor.NewPathEnd(dst.PathEnd.ChainID, dst.PathEnd.ClientID, "", []processor.ChannelKey{}),
 	}
 
+	// Timeout is per message. Four connection handshake messages, allowing maxRetries for each.
 	processorTimeout := timeout * 4 * time.Duration(maxRetries)
 
 	processorCtx, processorCtxCancel := context.WithTimeout(ctx, processorTimeout)

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -34,8 +34,8 @@ func (c *Chain) CreateOpenConnections(
 	// Timeout is per message. Four connection handshake messages, allowing maxRetries for each.
 	processorTimeout := timeout * 4 * time.Duration(maxRetries)
 
-	processorCtx, processorCtxCancel := context.WithTimeout(ctx, processorTimeout)
-	defer processorCtxCancel()
+	ctx, cancel := context.WithTimeout(ctx, processorTimeout)
+	defer cancel()
 
 	pp := processor.NewPathProcessor(
 		c.log,
@@ -59,7 +59,8 @@ func (c *Chain) CreateOpenConnections(
 	return modified, processor.NewEventProcessor().
 		WithChainProcessors(
 			srcpathChain.chainProcessor(c.log),
-			dstpathChain.chainProcessor(c.log)).
+			dstpathChain.chainProcessor(c.log),
+		).
 		WithPathProcessors(pp).
 		WithInitialBlockHistory(0).
 		WithMessageLifecycle(&processor.ConnectionMessageLifecycle{
@@ -81,5 +82,5 @@ func (c *Chain) CreateOpenConnections(
 			},
 		}).
 		Build().
-		Run(processorCtx)
+		Run(ctx)
 }

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -3,6 +3,7 @@ package relayer
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/avast/retry-go/v4"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -145,14 +146,21 @@ func QueryPortChannel(ctx context.Context, src *Chain, portID string) (*chantype
 	}
 
 	// Find the specified channel in the slice of all channels
-	for _, channel := range srcChannels {
+	var sb strings.Builder
+	for i, channel := range srcChannels {
 		if channel.PortId == portID {
 			return channel, nil
 		}
+		if i != 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(channel.ChannelId)
+		sb.WriteString(":")
+		sb.WriteString(channel.PortId)
 	}
 
-	return nil, fmt.Errorf("channel with port{%s} not found for [%s] -> client{%s}@connection{%s}",
-		portID, src.ChainID(), src.ClientID(), src.ConnectionID())
+	return nil, fmt.Errorf("channel with port{%s} not found for [%s] -> client{%s}@connection{%s}channels{%s}",
+		portID, src.ChainID(), src.ClientID(), src.ConnectionID(), sb.String())
 }
 
 // GetIBCUpdateHeaders returns a pair of IBC update headers which can be used to update an on chain light client


### PR DESCRIPTION
Uses `PathProcessor` for channel handshakes, both automatically when channel handshake messages are detected on the relevant connections and also for the CLI channel creation.

After digging through the existing channel handshake code, the configuration never seems to be modified even in cases when returning `modified: true`, so I do not think a channel message subscriber will be necessary as it was for the connection handshakes.