### PR TITLE
Mainnet cleanup

### DIFF
--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -295,19 +295,13 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 		)
 		return false
 	}
-	// NOTE: this block of code cleans up the logs significantly since it gives
-	// a better guarantee that the proof will be committed, but it slows down relaying.
-	// The relayer can relay more packets in competitive environments by retrying
-	// proof queries, even though the logs will show more proof query errors.
-	if !competitiveRelaying {
-		if message.info.Height >= counterparty.latestBlock.Height {
-			pathEnd.log.Debug("Waiting to relay packet message until counterparty height has incremented",
-				zap.String("action", action),
-				zap.Uint64("sequence", sequence),
-				zap.Inline(k),
-			)
-			return false
-		}
+	if message.info.Height >= counterparty.latestBlock.Height {
+		pathEnd.log.Debug("Waiting to relay packet message until counterparty height has incremented",
+			zap.String("action", action),
+			zap.Uint64("sequence", sequence),
+			zap.Inline(k),
+		)
+		return false
 	}
 	if !pathEnd.channelStateCache[k] {
 		// channel is not open, do not send

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -12,14 +12,36 @@ import (
 const (
 	// durationErrorRetry determines how long to wait before retrying
 	// in the case of failure to send transactions with IBC messages.
-	durationErrorRetry         = 5 * time.Second
-	messageSendTimeout         = 10 * time.Second
-	packetProofQueryTimeout    = 5 * time.Second
-	blocksToRetryAssemblyAfter = 0
-	blocksToRetrySendAfter     = 2
-	maxMessageSendRetries      = 5
+	durationErrorRetry = 5 * time.Second
 
-	ibcHeadersToCache                          = 10
+	// Amount of time to wait when sending transactions before giving up
+	// and continuing on. Messages will be retried later if they are still
+	// relevant.
+	messageSendTimeout = 10 * time.Second
+
+	// Amount of time to wait for a proof to be queried before giving up.
+	// The proof query will be retried later if the message still needs
+	// to be relayed.
+	packetProofQueryTimeout = 5 * time.Second
+
+	// If message assembly fails from either proof query failure on the source
+	// or assembling the message for the destination, how many blocks should pass
+	// before retrying.
+	blocksToRetryAssemblyAfter = 0
+
+	// If the message was assembled successfully, but sending the message failed,
+	// how many blocks should pass before retrying.
+	blocksToRetrySendAfter = 2
+
+	// How many times to retry sending a message before giving up on it.
+	maxMessageSendRetries = 5
+
+	// How many blocks of history to retain ibc headers in the cache for.
+	ibcHeadersToCache = 10
+
+	// How many blocks of history before determining that a query needs to be
+	// made to retrieve the client consensus state in order to assemble a
+	// MsgUpdateClient message.
 	clientConsensusHeightUpdateThresholdBlocks = 2
 )
 

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -14,7 +14,8 @@ const (
 	// in the case of failure to send transactions with IBC messages.
 	durationErrorRetry         = 5 * time.Second
 	messageSendTimeout         = 10 * time.Second
-	blocksToRetryAssemblyAfter = 1
+	packetProofQueryTimeout    = 5 * time.Second
+	blocksToRetryAssemblyAfter = 0
 	blocksToRetrySendAfter     = 2
 	maxMessageSendRetries      = 5
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -558,14 +558,14 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 	// if sending messages fails to one pathEnd, we don't need to halt sending to the other pathEnd.
 	var eg errgroup.Group
 	eg.Go(func() error {
-		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1Messages, msgMemo); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd2, pp.pathEnd1, pathEnd1Messages); err != nil {
 			pp.logFailedTx(pp.pathEnd2.info, pp.pathEnd1.info, err)
 			return err
 		}
 		return nil
 	})
 	eg.Go(func() error {
-		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2Messages, msgMemo); err != nil {
+		if err := pp.assembleAndSendMessages(ctx, pp.pathEnd1, pp.pathEnd2, pathEnd2Messages); err != nil {
 			pp.logFailedTx(pp.pathEnd1.info, pp.pathEnd2.info, err)
 			return err
 		}

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -723,12 +723,12 @@ func (pp *PathProcessor) assemblePacketMessage(
 		return nil, fmt.Errorf("unexepected packet message action for message assembly: %s", msg.action)
 	}
 
-	proofQueryCtx, cancelProofQueryCtx := context.WithTimeout(ctx, packetProofQueryTimeout)
-	defer cancelProofQueryCtx()
+	ctx, cancel := context.WithTimeout(ctx, packetProofQueryTimeout)
+	defer cancel()
 
 	var proof provider.PacketProof
 	var err error
-	proof, err = packetProof(proofQueryCtx, msg.info, src.latestBlock.Height)
+	proof, err = packetProof(ctx, msg.info, src.latestBlock.Height)
 	if err != nil {
 		return nil, fmt.Errorf("error querying packet proof: %w", err)
 	}

--- a/relayer/processor/types_internal.go
+++ b/relayer/processor/types_internal.go
@@ -190,8 +190,11 @@ func channelInfoChannelKey(c provider.ChannelInfo) ChannelKey {
 // outgoingMessages is a slice of relayer messages that can be
 // appended to concurrently.
 type outgoingMessages struct {
-	mu   sync.Mutex
-	msgs []provider.RelayerMessage
+	mu       sync.Mutex
+	msgs     []provider.RelayerMessage
+	pktMsgs  []packetMessageToTrack
+	connMsgs []connectionMessageToTrack
+	chanMsgs []channelMessageToTrack
 }
 
 // Append acquires a lock on om's mutex and then appends msg.
@@ -201,4 +204,19 @@ func (om *outgoingMessages) Append(msg provider.RelayerMessage) {
 	om.mu.Lock()
 	defer om.mu.Unlock()
 	om.msgs = append(om.msgs, msg)
+}
+
+type packetMessageToTrack struct {
+	msg       packetIBCMessage
+	assembled bool
+}
+
+type connectionMessageToTrack struct {
+	msg       connectionIBCMessage
+	assembled bool
+}
+
+type channelMessageToTrack struct {
+	msg       channelIBCMessage
+	assembled bool
 }

--- a/relayer/provider/cosmos/tx.go
+++ b/relayer/provider/cosmos/tx.go
@@ -216,6 +216,8 @@ func (cc *CosmosProvider) buildMessages(ctx context.Context, msgs []provider.Rel
 		return nil, err
 	}
 
+	txf = txf.WithMemo("rly")
+
 	// TODO: Make this work with new CalculateGas method
 	// TODO: This is related to GRPC client stuff?
 	// https://github.com/cosmos/cosmos-sdk/blob/5725659684fc93790a63981c653feee33ecf3225/client/tx/tx.go#L297

--- a/relayer/provider/cosmos/tx.go
+++ b/relayer/provider/cosmos/tx.go
@@ -216,8 +216,6 @@ func (cc *CosmosProvider) buildMessages(ctx context.Context, msgs []provider.Rel
 		return nil, err
 	}
 
-	txf = txf.WithMemo("rly")
-
 	// TODO: Make this work with new CalculateGas method
 	// TODO: This is related to GRPC client stuff?
 	// https://github.com/cosmos/cosmos-sdk/blob/5725659684fc93790a63981c653feee33ecf3225/client/tx/tx.go#L297

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -198,13 +198,13 @@ type ChainProvider interface {
 	// These functions query the proof of the packet state on the chain.
 
 	// PacketCommitment queries for proof that a MsgTransfer has been committed on the chain.
-	PacketCommitment(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
+	PacketCommitment(ctx context.Context, msgTransfer PacketInfo, height uint64) (PacketProof, error)
 
 	// PacketAcknowledgement queries for proof that a MsgRecvPacket has been committed on the chain.
-	PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, latest LatestBlock) (PacketProof, error)
+	PacketAcknowledgement(ctx context.Context, msgRecvPacket PacketInfo, height uint64) (PacketProof, error)
 
 	// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
-	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, latest LatestBlock) (PacketProof, error)
+	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, height uint64) (PacketProof, error)
 
 	// MsgRecvPacket takes the packet information from a MsgTransfer along with the packet commitment,
 	// and assembles a full MsgRecvPacket ready to write to the chain.
@@ -231,10 +231,10 @@ type ChainProvider interface {
 	// [Begin] Connection handshake IBC message assembly
 
 	// ConnectionHandshakeProof queries for proof of an initialized connection handshake.
-	ConnectionHandshakeProof(ctx context.Context, msgOpenInit ConnectionInfo, latest LatestBlock) (ConnectionProof, error)
+	ConnectionHandshakeProof(ctx context.Context, msgOpenInit ConnectionInfo, height uint64) (ConnectionProof, error)
 
 	// ConnectionProof queries for proof of an acked handshake.
-	ConnectionProof(ctx context.Context, msgOpenAck ConnectionInfo, latest LatestBlock) (ConnectionProof, error)
+	ConnectionProof(ctx context.Context, msgOpenAck ConnectionInfo, height uint64) (ConnectionProof, error)
 
 	// MsgConnectionOpenInit takes connection info and assembles a MsgConnectionOpenInit message
 	// ready to write to the chain. The connection proof is not needed here, but it needs
@@ -258,7 +258,7 @@ type ChainProvider interface {
 	// [Begin] Channel handshake IBC message assembly
 
 	// ChannelProof queries for proof of a channel state.
-	ChannelProof(ctx context.Context, msg ChannelInfo, latest LatestBlock) (ChannelProof, error)
+	ChannelProof(ctx context.Context, msg ChannelInfo, height uint64) (ChannelProof, error)
 
 	// MsgChannelOpenInit takes channel info and assembles a MsgChannelOpenInit message
 	// ready to write to the chain. The channel proof is not needed here, but it needs


### PR DESCRIPTION
While testing EventProcessor-based relaying on the `cosmoshub`/`osmosis` path, I found a few places to cleanup, especially since the path is heavily trafficked by other relayers, creating a competitive environment.

The main issue was that the parallelization of the queries and message assembly introduced a concurrent map write race condition. This is solved by introducing types `packetMessageToTrack`, `connectionMessageToTrack`, and `channelMessageToTrack`. These are constructed and written to a fixed position in the slice on new properties on `outgoingMessages`, then the `trackProcessingPacketMessage`, `trackProcessingConnectionMessage`, and `trackProcessingChannelMessage` calls, which write to the maps, are made synchronously after that.

The next issue was that the `PacketCommitment` and `PacketAcknowledgement` implementations in the `CosmosProvider` are not returning an error if the commitment value is empty. This caused the `PathProcessor` to periodically attempt to send messages where the proof proved non-commitment.

Other than that:
- slims down proof functions in the provider to only require `height uint64` instead of `provider.LatestBlock` since only height was used for all proof queries.
- Changes `blocksToRetryAssemblyAfter` to `0` so that proof queries will be retried the next `PathProcessor` `processLatestMessages` assuming it did not observe another relayer handle the message already.
- Downgrades some log levels to `warn` or `debug` to clean up benign errors.