### PR TITLE
CosmosChainProcessor - dynamic block time targeting

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -60,8 +60,7 @@ func NewCosmosChainProcessor(log *zap.Logger, provider *cosmos.CosmosProvider) *
 }
 
 const (
-	queryTimeout                = 5 * time.Second
-	blockResultsQueryTimeout    = 2 * time.Minute
+	queryTimeout                = 10 * time.Second
 	latestHeightQueryRetryDelay = 1 * time.Second
 	latestHeightQueryRetries    = 5
 
@@ -69,7 +68,9 @@ const (
 	inSyncNumBlocksThreshold    = 2
 
 	blockQueryRetryDelay = 200 * time.Millisecond
-	blockQueryRetries    = 10
+
+	// With doubling the 10 second timeout each time, this gives ~3 mins max timeout
+	blockQueryRetries = 4
 )
 
 // latestClientState is a map of clientID to the latest clientInfo for that client.
@@ -136,9 +137,11 @@ func (ccp *CosmosChainProcessor) queryBlockResultsWithRetry(
 		retry.DelayType(retry.FixedDelay),
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(n uint, err error) {
+			// double timeout, longer timeouts are needed for larger blocks.
 			timeout *= 2
 			ccp.log.Error(
 				"Failed to query block results",
+				zap.Int64("height", height),
 				zap.Uint("attempt", n+1),
 				zap.Uint("max_attempts", blockQueryRetries),
 				zap.Error(err),
@@ -155,7 +158,7 @@ func (ccp *CosmosChainProcessor) queryIBCHeaderWithRetry(
 ) (ibcHeader provider.IBCHeader, err error) {
 	timeout := queryTimeout
 	return ibcHeader, retry.Do(func() error {
-		queryCtx, cancel := context.WithTimeout(ctx, queryTimeout)
+		queryCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		var err error
 		ibcHeader, err = ccp.chainProvider.IBCHeaderAtHeight(queryCtx, height)
@@ -168,8 +171,9 @@ func (ccp *CosmosChainProcessor) queryIBCHeaderWithRetry(
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(n uint, err error) {
 			timeout *= 2
-			ccp.log.Error(
+			ccp.log.Warn(
 				"Failed to query IBC header",
+				zap.Int64("height", height),
 				zap.Uint("attempt", n+1),
 				zap.Uint("max_attempts", blockQueryRetries),
 				zap.Error(err),

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -95,14 +95,14 @@ const (
 	// target ideal block query window.
 
 	// Clock drift addition when a block query fails
-	queryFailureClockDriftAdditionMs = 47
+	queryFailureClockDriftAdditionMs = 73
 
 	// Clock drift addition when the block queries succeeds
-	querySuccessClockDriftAdditionMs = -23
+	querySuccessClockDriftAdditionMs = -11
 
 	// Clock drift addition when the latest block is the same as
 	// the last successfully queried block
-	sameBlockClockDriftAdditionMs = 71
+	sameBlockClockDriftAdditionMs = 97
 )
 
 // latestClientState is a map of clientID to the latest clientInfo for that client.
@@ -235,8 +235,8 @@ func (p *queryCyclePersistence) dynamicBlockTime(
 
 	// also take into account older blocks, where timeQueriedAfterBlockTime > p.averageBlockTimeMs, by using remainder.
 	// clock drift tolerant using clockDriftMs trim value
-	targetedQueryTimeFromNow := p.averageBlockTimeMs - (timeQueriedAfterBlockTime % p.averageBlockTimeMs) -
-		queryDurationMs + p.clockDriftMs
+	targetedQueryTimeFromNow := p.averageBlockTimeMs - (timeQueriedAfterBlockTime % p.averageBlockTimeMs) +
+		p.clockDriftMs - queryDurationMs
 
 	p.minQueryLoopDuration = time.Millisecond * time.Duration(targetedQueryTimeFromNow)
 
@@ -376,7 +376,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 
 	if persistence.latestHeight == persistence.latestQueriedBlock {
 		persistence.addClockDriftMs(sameBlockClockDriftAdditionMs)
-		persistence.minQueryLoopDuration += 100 * time.Millisecond
+		persistence.minQueryLoopDuration = defaultMinQueryLoopDuration
 		return nil
 	}
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -261,9 +261,12 @@ func (p *queryCyclePersistence) dynamicBlockTime(
 		return
 	}
 
+	queryDurationMs := time.Since(queryStart).Milliseconds()
+
 	// also take into account older blocks, where timeQueriedAfterBlockTime > p.averageBlockTimeMs, by using remainder.
 	// clock drift tolerant using clockDriftMs trim value
-	targetedQueryTimeFromNow := p.averageBlockTimeMs - (timeQueriedAfterBlockTime % p.averageBlockTimeMs) + p.clockDriftMs
+	targetedQueryTimeFromNow := p.averageBlockTimeMs - (timeQueriedAfterBlockTime % p.averageBlockTimeMs) -
+		queryDurationMs + p.clockDriftMs
 
 	p.minQueryLoopDuration = time.Millisecond * time.Duration(targetedQueryTimeFromNow)
 


### PR DESCRIPTION
Adds block query targeting mechanism, accounting for clock drift and variable RPC node time from the block timestamp until blocks are ready to be queried. This removes the fixed 1 second `minQueryLoopDuration`  to reduce queries by holding a rolling average of the delta time between blocks. This will allow it to target block query times on chains with different consensus timeouts (block times). In addition, it compares the block timestamp against the timestamp when the queries were initiated. It holds a clock drift parameter for fine tuning the time when the next block queries will be initiated. This reduces the queries on the nodes, cleans up the logs, and optimizes so that it can capture blocks as soon as they  are ready to be queried.

