### PR TITLE
Switch correlation from action to event type

### DIFF
--- a/relayer/chains/cosmos/event_parser_test.go
+++ b/relayer/chains/cosmos/event_parser_test.go
@@ -8,7 +8,6 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
-	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -222,15 +221,6 @@ func TestParseEventLogs(t *testing.T) {
 			MsgIndex: 0,
 			Events: sdk.StringEvents{
 				{
-					Type: "message",
-					Attributes: []sdk.Attribute{
-						{
-							Key:   "action",
-							Value: processor.MsgUpdateClient,
-						},
-					},
-				},
-				{
 					Type: clienttypes.EventTypeUpdateClient,
 					Attributes: []sdk.Attribute{
 						{
@@ -248,15 +238,6 @@ func TestParseEventLogs(t *testing.T) {
 		{
 			MsgIndex: 1,
 			Events: sdk.StringEvents{
-				{
-					Type: "message",
-					Attributes: []sdk.Attribute{
-						{
-							Key:   "action",
-							Value: processor.MsgRecvPacket,
-						},
-					},
-				},
 				{
 					Type: chantypes.EventTypeRecvPacket,
 					Attributes: []sdk.Attribute{
@@ -312,7 +293,7 @@ func TestParseEventLogs(t *testing.T) {
 	require.Len(t, ibcMessages, 2)
 
 	msgUpdateClient := ibcMessages[0]
-	require.Equal(t, processor.MsgUpdateClient, msgUpdateClient.action)
+	require.Equal(t, clienttypes.EventTypeUpdateClient, msgUpdateClient.eventType)
 
 	clientInfoParsed, isClientInfo := msgUpdateClient.info.(*clientInfo)
 	require.True(t, isClientInfo, "messageInfo is not clientInfo")
@@ -326,7 +307,7 @@ func TestParseEventLogs(t *testing.T) {
 	}, cmp.AllowUnexported(clientInfo{}, clienttypes.Height{})), "parsed client info does not match expected")
 
 	msgRecvPacket := ibcMessages[1]
-	require.Equal(t, processor.MsgRecvPacket, msgRecvPacket.action, "message is not MsgRecvPacket")
+	require.Equal(t, chantypes.EventTypeRecvPacket, msgRecvPacket.eventType, "message event is not recv_packet")
 
 	packetInfoParsed, isPacketInfo := msgRecvPacket.info.(*packetInfo)
 	require.True(t, isPacketInfo, "messageInfo is not packetInfo")

--- a/relayer/chains/mock/message_handlers.go
+++ b/relayer/chains/mock/message_handlers.go
@@ -16,9 +16,9 @@ type msgHandlerParams struct {
 }
 
 var messageHandlers = map[string]func(msgHandlerParams){
-	processor.MsgTransfer:        handleMsgTransfer,
-	processor.MsgRecvPacket:      handleMsgRecvPacket,
-	processor.MsgAcknowledgement: handleMsgAcknowledgement,
+	chantypes.EventTypeSendPacket:        handleMsgTransfer,
+	chantypes.EventTypeRecvPacket:        handleMsgRecvPacket,
+	chantypes.EventTypeAcknowledgePacket: handleMsgAcknowledgement,
 
 	// TODO handlers for packet timeout, client, channel, and connection messages
 }
@@ -30,7 +30,7 @@ func handleMsgTransfer(p msgHandlerParams) {
 		CounterpartyChannelID: p.packetInfo.DestinationChannel,
 		CounterpartyPortID:    p.packetInfo.DestinationPort,
 	}
-	p.ibcMessagesCache.PacketFlow.Retain(channelKey, processor.MsgTransfer, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
+	p.ibcMessagesCache.PacketFlow.Retain(channelKey, chantypes.EventTypeSendPacket, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
 	p.mcp.log.Debug("observed MsgTransfer",
 		zap.String("chain_id", p.mcp.chainID),
 		zap.Uint64("sequence", p.packetInfo.Sequence),
@@ -48,7 +48,7 @@ func handleMsgRecvPacket(p msgHandlerParams) {
 		CounterpartyChannelID: p.packetInfo.SourceChannel,
 		CounterpartyPortID:    p.packetInfo.SourcePort,
 	}
-	p.ibcMessagesCache.PacketFlow.Retain(channelKey, processor.MsgRecvPacket, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
+	p.ibcMessagesCache.PacketFlow.Retain(channelKey, chantypes.EventTypeRecvPacket, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
 	p.mcp.log.Debug("observed MsgRecvPacket",
 		zap.String("chain_id", p.mcp.chainID),
 		zap.Uint64("sequence", p.packetInfo.Sequence),
@@ -66,7 +66,7 @@ func handleMsgAcknowledgement(p msgHandlerParams) {
 		CounterpartyChannelID: p.packetInfo.DestinationChannel,
 		CounterpartyPortID:    p.packetInfo.DestinationPort,
 	}
-	p.ibcMessagesCache.PacketFlow.Retain(channelKey, processor.MsgAcknowledgement, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
+	p.ibcMessagesCache.PacketFlow.Retain(channelKey, chantypes.EventTypeAcknowledgePacket, provider.PacketInfo{Sequence: p.packetInfo.Sequence})
 	p.mcp.log.Debug("observed MsgAcknowledgement",
 		zap.String("chain_id", p.mcp.chainID),
 		zap.Uint64("sequence", p.packetInfo.Sequence),

--- a/relayer/chains/mock/mock_chain_processor.go
+++ b/relayer/chains/mock/mock_chain_processor.go
@@ -35,7 +35,7 @@ type MockChainProcessor struct {
 
 // types used for parsing IBC messages from transactions, then passed to message handlers for mutating the MockChainProcessor state if necessary and retaining applicable messages for sending to the Path Processors
 type TransactionMessage struct {
-	Action     string
+	EventType  string
 	PacketInfo *chantypes.Packet
 }
 
@@ -151,7 +151,7 @@ func (mcp *MockChainProcessor) queryCycle(ctx context.Context, persistence *quer
 		// will do things like mutate chainprocessor state and add relevant messages to foundMessages
 		// this can be parralelized also
 		for _, m := range messages {
-			if handler, ok := messageHandlers[m.Action]; ok {
+			if handler, ok := messageHandlers[m.EventType]; ok {
 				handler(msgHandlerParams{
 					mcp:              mcp,
 					packetInfo:       m.PacketInfo,

--- a/relayer/chains/mock/mock_chain_processor_test.go
+++ b/relayer/chains/mock/mock_chain_processor_test.go
@@ -110,7 +110,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	*mockSequence++
 	mockMessages := []mock.TransactionMessage{
 		{
-			Action: chantypes.EventTypeSendPacket,
+			EventType: chantypes.EventTypeSendPacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequence,
 				SourceChannel:      channelKey.ChannelID,
@@ -127,7 +127,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	if *mockSequenceCounterparty > 1 && *lastSentMockMsgRecvCounterparty != *mockSequenceCounterparty {
 		*lastSentMockMsgRecvCounterparty = *mockSequenceCounterparty
 		mockMessages = append(mockMessages, mock.TransactionMessage{
-			Action: chantypes.EventTypeRecvPacket,
+			EventType: chantypes.EventTypeRecvPacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequenceCounterparty - 1,
 				SourceChannel:      channelKey.CounterpartyChannelID,
@@ -143,7 +143,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	}
 	if *mockSequence > 2 {
 		mockMessages = append(mockMessages, mock.TransactionMessage{
-			Action: chantypes.EventTypeAcknowledgePacket,
+			EventType: chantypes.EventTypeAcknowledgePacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequence - 2,
 				SourceChannel:      channelKey.ChannelID,

--- a/relayer/chains/mock/mock_chain_processor_test.go
+++ b/relayer/chains/mock/mock_chain_processor_test.go
@@ -68,13 +68,13 @@ func TestMockChainAndPathProcessors(t *testing.T) {
 	err := eventProcessor.Run(ctx)
 	require.NoError(t, err, "error running event processor")
 
-	pathEnd1LeftoverMsgTransfer := pathProcessor.PathEnd1Messages(mockChannelKey1, processor.MsgTransfer)
-	pathEnd1LeftoverMsgRecvPacket := pathProcessor.PathEnd1Messages(mockChannelKey1, processor.MsgRecvPacket)
-	pathEnd1LeftoverMsgAcknowledgement := pathProcessor.PathEnd1Messages(mockChannelKey1, processor.MsgAcknowledgement)
+	pathEnd1LeftoverMsgTransfer := pathProcessor.PathEnd1Messages(mockChannelKey1, chantypes.EventTypeSendPacket)
+	pathEnd1LeftoverMsgRecvPacket := pathProcessor.PathEnd1Messages(mockChannelKey1, chantypes.EventTypeRecvPacket)
+	pathEnd1LeftoverMsgAcknowledgement := pathProcessor.PathEnd1Messages(mockChannelKey1, chantypes.EventTypeAcknowledgePacket)
 
-	pathEnd2LeftoverMsgTransfer := pathProcessor.PathEnd2Messages(mockChannelKey2, processor.MsgTransfer)
-	pathEnd2LeftoverMsgRecvPacket := pathProcessor.PathEnd2Messages(mockChannelKey2, processor.MsgRecvPacket)
-	pathEnd2LeftoverMsgAcknowledgement := pathProcessor.PathEnd2Messages(mockChannelKey2, processor.MsgAcknowledgement)
+	pathEnd2LeftoverMsgTransfer := pathProcessor.PathEnd2Messages(mockChannelKey2, chantypes.EventTypeSendPacket)
+	pathEnd2LeftoverMsgRecvPacket := pathProcessor.PathEnd2Messages(mockChannelKey2, chantypes.EventTypeRecvPacket)
+	pathEnd2LeftoverMsgAcknowledgement := pathProcessor.PathEnd2Messages(mockChannelKey2, chantypes.EventTypeAcknowledgePacket)
 
 	log.Debug("leftover",
 		zap.Int("pathEnd1MsgTransfer", len(pathEnd1LeftoverMsgTransfer)),
@@ -110,7 +110,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	*mockSequence++
 	mockMessages := []mock.TransactionMessage{
 		{
-			Action: processor.MsgTransfer,
+			Action: chantypes.EventTypeSendPacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequence,
 				SourceChannel:      channelKey.ChannelID,
@@ -127,7 +127,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	if *mockSequenceCounterparty > 1 && *lastSentMockMsgRecvCounterparty != *mockSequenceCounterparty {
 		*lastSentMockMsgRecvCounterparty = *mockSequenceCounterparty
 		mockMessages = append(mockMessages, mock.TransactionMessage{
-			Action: processor.MsgRecvPacket,
+			Action: chantypes.EventTypeRecvPacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequenceCounterparty - 1,
 				SourceChannel:      channelKey.CounterpartyChannelID,
@@ -143,7 +143,7 @@ func getMockMessages(channelKey processor.ChannelKey, mockSequence, mockSequence
 	}
 	if *mockSequence > 2 {
 		mockMessages = append(mockMessages, mock.TransactionMessage{
-			Action: processor.MsgAcknowledgement,
+			Action: chantypes.EventTypeAcknowledgePacket,
 			PacketInfo: &chantypes.Packet{
 				Sequence:           *mockSequence - 2,
 				SourceChannel:      channelKey.ChannelID,

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -83,7 +83,7 @@ func (c *Chain) CreateOpenChannels(
 		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
 			Initial: &processor.ChannelMessage{
 				ChainID: c.PathEnd.ChainID,
-				Action:  processor.MsgChannelOpenInit,
+				Action:  chantypes.EventTypeChannelOpenInit,
 				Info: provider.ChannelInfo{
 					PortID:             srcPortID,
 					CounterpartyPortID: dstPortID,
@@ -94,7 +94,7 @@ func (c *Chain) CreateOpenChannels(
 			},
 			Termination: &processor.ChannelMessage{
 				ChainID: dst.PathEnd.ChainID,
-				Action:  processor.MsgChannelOpenConfirm,
+				Action:  chantypes.EventTypeChannelOpenConfirm,
 				Info: provider.ChannelInfo{
 					PortID:             dstPortID,
 					CounterpartyPortID: srcPortID,
@@ -145,7 +145,7 @@ func (c *Chain) CloseChannel(
 		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
 			Initial: &processor.ChannelMessage{
 				ChainID: c.PathEnd.ChainID,
-				Action:  processor.MsgChannelCloseInit,
+				Action:  chantypes.EventTypeChannelCloseInit,
 				Info: provider.ChannelInfo{
 					PortID:    srcPortID,
 					ChannelID: srcChanID,
@@ -153,7 +153,7 @@ func (c *Chain) CloseChannel(
 			},
 			Termination: &processor.ChannelMessage{
 				ChainID: dst.PathEnd.ChainID,
-				Action:  processor.MsgChannelCloseConfirm,
+				Action:  chantypes.EventTypeChannelCloseConfirm,
 				Info: provider.ChannelInfo{
 					CounterpartyPortID:    srcPortID,
 					CounterpartyChannelID: srcChanID,

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -82,8 +82,8 @@ func (c *Chain) CreateOpenChannels(
 		WithInitialBlockHistory(0).
 		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
 			Initial: &processor.ChannelMessage{
-				ChainID: c.PathEnd.ChainID,
-				Action:  chantypes.EventTypeChannelOpenInit,
+				ChainID:   c.PathEnd.ChainID,
+				EventType: chantypes.EventTypeChannelOpenInit,
 				Info: provider.ChannelInfo{
 					PortID:             srcPortID,
 					CounterpartyPortID: dstPortID,
@@ -93,8 +93,8 @@ func (c *Chain) CreateOpenChannels(
 				},
 			},
 			Termination: &processor.ChannelMessage{
-				ChainID: dst.PathEnd.ChainID,
-				Action:  chantypes.EventTypeChannelOpenConfirm,
+				ChainID:   dst.PathEnd.ChainID,
+				EventType: chantypes.EventTypeChannelOpenConfirm,
 				Info: provider.ChannelInfo{
 					PortID:             dstPortID,
 					CounterpartyPortID: srcPortID,
@@ -144,16 +144,16 @@ func (c *Chain) CloseChannel(
 		WithInitialBlockHistory(0).
 		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
 			Initial: &processor.ChannelMessage{
-				ChainID: c.PathEnd.ChainID,
-				Action:  chantypes.EventTypeChannelCloseInit,
+				ChainID:   c.PathEnd.ChainID,
+				EventType: chantypes.EventTypeChannelCloseInit,
 				Info: provider.ChannelInfo{
 					PortID:    srcPortID,
 					ChannelID: srcChanID,
 				},
 			},
 			Termination: &processor.ChannelMessage{
-				ChainID: dst.PathEnd.ChainID,
-				Action:  chantypes.EventTypeChannelCloseConfirm,
+				ChainID:   dst.PathEnd.ChainID,
+				EventType: chantypes.EventTypeChannelCloseConfirm,
 				Info: provider.ChannelInfo{
 					CounterpartyPortID:    srcPortID,
 					CounterpartyChannelID: srcChanID,

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
@@ -45,7 +46,7 @@ func (c *Chain) CreateOpenConnections(
 		memo,
 	)
 
-	pp.OnConnectionMessage(dst.PathEnd.ChainID, processor.MsgConnectionOpenConfirm, func(ci provider.ConnectionInfo) {
+	pp.OnConnectionMessage(dst.PathEnd.ChainID, conntypes.EventTypeConnectionOpenConfirm, func(ci provider.ConnectionInfo) {
 		dst.PathEnd.ConnectionID = ci.ConnID
 		c.PathEnd.ConnectionID = ci.CounterpartyConnID
 		modified = true
@@ -68,7 +69,7 @@ func (c *Chain) CreateOpenConnections(
 		WithMessageLifecycle(&processor.ConnectionMessageLifecycle{
 			Initial: &processor.ConnectionMessage{
 				ChainID: c.PathEnd.ChainID,
-				Action:  processor.MsgConnectionOpenInit,
+				Action:  conntypes.EventTypeConnectionOpenInit,
 				Info: provider.ConnectionInfo{
 					ClientID:             c.PathEnd.ClientID,
 					CounterpartyClientID: dst.PathEnd.ClientID,
@@ -76,7 +77,7 @@ func (c *Chain) CreateOpenConnections(
 			},
 			Termination: &processor.ConnectionMessage{
 				ChainID: dst.PathEnd.ChainID,
-				Action:  processor.MsgConnectionOpenConfirm,
+				Action:  conntypes.EventTypeConnectionOpenConfirm,
 				Info: provider.ConnectionInfo{
 					ClientID:             dst.PathEnd.ClientID,
 					CounterpartyClientID: c.PathEnd.ClientID,

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -68,16 +68,16 @@ func (c *Chain) CreateOpenConnections(
 		WithInitialBlockHistory(0).
 		WithMessageLifecycle(&processor.ConnectionMessageLifecycle{
 			Initial: &processor.ConnectionMessage{
-				ChainID: c.PathEnd.ChainID,
-				Action:  conntypes.EventTypeConnectionOpenInit,
+				ChainID:   c.PathEnd.ChainID,
+				EventType: conntypes.EventTypeConnectionOpenInit,
 				Info: provider.ConnectionInfo{
 					ClientID:             c.PathEnd.ClientID,
 					CounterpartyClientID: dst.PathEnd.ClientID,
 				},
 			},
 			Termination: &processor.ConnectionMessage{
-				ChainID: dst.PathEnd.ChainID,
-				Action:  conntypes.EventTypeConnectionOpenConfirm,
+				ChainID:   dst.PathEnd.ChainID,
+				EventType: conntypes.EventTypeConnectionOpenConfirm,
 				Info: provider.ConnectionInfo{
 					ClientID:             dst.PathEnd.ClientID,
 					CounterpartyClientID: c.PathEnd.ClientID,

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -164,10 +164,10 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
-		channelKey, err := PacketInfoChannelKey(m.Termination.Action, m.Termination.Info)
+		channelKey, err := PacketInfoChannelKey(m.Termination.EventType, m.Termination.Info)
 		if err != nil {
 			pathEnd.log.Error("Unexpected error checking packet message",
-				zap.String("event_type", m.Termination.Action),
+				zap.String("event_type", m.Termination.EventType),
 				zap.Inline(channelKey),
 				zap.Error(err),
 			)
@@ -177,7 +177,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		if !ok {
 			return false
 		}
-		sequenceCache, ok := eventTypeCache[m.Termination.Action]
+		sequenceCache, ok := eventTypeCache[m.Termination.EventType]
 		if !ok {
 			return false
 		}
@@ -192,7 +192,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
-		cache, ok := ibcMessagesCache.ChannelHandshake[m.Termination.Action]
+		cache, ok := ibcMessagesCache.ChannelHandshake[m.Termination.EventType]
 		if !ok {
 			return false
 		}
@@ -223,7 +223,7 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		if m.Termination == nil || m.Termination.ChainID != pathEnd.info.ChainID {
 			return false
 		}
-		cache, ok := ibcMessagesCache.ConnectionHandshake[m.Termination.Action]
+		cache, ok := ibcMessagesCache.ConnectionHandshake[m.Termination.EventType]
 		if !ok {
 			return false
 		}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -3,6 +3,8 @@ package processor
 import (
 	"context"
 
+	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
+	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
 )
@@ -93,7 +95,7 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 	}
 	pathEnd.messageCache.PacketFlow.Merge(packetMessages)
 
-	for action, cmc := range messageCache.ConnectionHandshake {
+	for eventType, cmc := range messageCache.ConnectionHandshake {
 		newCmc := make(ConnectionMessageCache)
 		for k, ci := range cmc {
 			if pathEnd.isRelevantConnection(k.ConnectionID) {
@@ -105,11 +107,11 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 		if len(newCmc) == 0 {
 			continue
 		}
-		connectionHandshakeMessages[action] = newCmc
+		connectionHandshakeMessages[eventType] = newCmc
 	}
 	pathEnd.messageCache.ConnectionHandshake.Merge(connectionHandshakeMessages)
 
-	for action, cmc := range messageCache.ChannelHandshake {
+	for eventType, cmc := range messageCache.ChannelHandshake {
 		newCmc := make(ChannelMessageCache)
 		for k, ci := range cmc {
 			if !pathEnd.isRelevantChannel(k.ChannelID) {
@@ -118,7 +120,7 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 			// can complete channel handshakes on this client
 			// since PathProcessor holds reference to the counterparty chain pathEndRuntime.
 
-			if action == MsgChannelOpenInit {
+			if eventType == chantypes.EventTypeChannelOpenInit {
 				// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
 				for k := range pathEnd.connectionStateCache {
 					if k.ConnectionID == ci.ConnID {
@@ -132,15 +134,15 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache) 
 		if len(newCmc) == 0 {
 			continue
 		}
-		channelHandshakeMessages[action] = newCmc
+		channelHandshakeMessages[eventType] = newCmc
 	}
 	pathEnd.messageCache.ChannelHandshake.Merge(channelHandshakeMessages)
 }
 
 func (pathEnd *pathEndRuntime) handleCallbacks(c IBCMessagesCache) {
 	if len(pathEnd.connSubscribers) > 0 {
-		for action, m := range c.ConnectionHandshake {
-			subscribers, ok := pathEnd.connSubscribers[action]
+		for eventType, m := range c.ConnectionHandshake {
+			subscribers, ok := pathEnd.connSubscribers[eventType]
 			if !ok {
 				continue
 			}
@@ -165,17 +167,17 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 		channelKey, err := PacketInfoChannelKey(m.Termination.Action, m.Termination.Info)
 		if err != nil {
 			pathEnd.log.Error("Unexpected error checking packet message",
-				zap.String("action", m.Termination.Action),
+				zap.String("event_type", m.Termination.Action),
 				zap.Inline(channelKey),
 				zap.Error(err),
 			)
 			return false
 		}
-		actionCache, ok := ibcMessagesCache.PacketFlow[channelKey]
+		eventTypeCache, ok := ibcMessagesCache.PacketFlow[channelKey]
 		if !ok {
 			return false
 		}
-		sequenceCache, ok := actionCache[m.Termination.Action]
+		sequenceCache, ok := eventTypeCache[m.Termination.Action]
 		if !ok {
 			return false
 		}
@@ -283,12 +285,12 @@ func (pathEnd *pathEndRuntime) mergeCacheData(ctx context.Context, cancel func()
 // shouldSendPacketMessage determines if the packet flow message should be sent now.
 // It will also determine if the message needs to be given up on entirely and remove retention if so.
 func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage, counterparty *pathEndRuntime) bool {
-	action := message.action
+	eventType := message.eventType
 	sequence := message.info.Sequence
 	k, err := message.channelKey()
 	if err != nil {
 		pathEnd.log.Error("Unexpected error checking if should send packet message",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
 			zap.Inline(k),
 			zap.Error(err),
@@ -297,7 +299,7 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 	}
 	if message.info.Height >= counterparty.latestBlock.Height {
 		pathEnd.log.Debug("Waiting to relay packet message until counterparty height has incremented",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
 			zap.Inline(k),
 		)
@@ -306,7 +308,7 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 	if !pathEnd.channelStateCache[k] {
 		// channel is not open, do not send
 		pathEnd.log.Warn("Refusing to relay packet message because channel is not open",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
 			zap.Inline(k),
 		)
@@ -317,9 +319,9 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 		// in progress cache does not exist for this channel, so can send.
 		return true
 	}
-	channelProcessingCache, ok := msgProcessCache[action]
+	channelProcessingCache, ok := msgProcessCache[eventType]
 	if !ok {
-		// in progress cache does not exist for this action, so can send
+		// in progress cache does not exist for this eventType, so can send
 		return true
 	}
 	inProgress, ok := channelProcessingCache[sequence]
@@ -341,7 +343,7 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 	}
 	if inProgress.retryCount >= maxMessageSendRetries {
 		pathEnd.log.Error("Giving up on sending packet message after max retries",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
 			zap.Inline(k),
 			zap.Int("max_retries", maxMessageSendRetries),
@@ -350,17 +352,17 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 		// remove all retention of this connection handshake in pathEnd.messagesCache.PacketFlow and counterparty
 		toDelete := make(map[string][]uint64)
 		toDeleteCounterparty := make(map[string][]uint64)
-		switch action {
-		case MsgRecvPacket:
-			toDelete[MsgRecvPacket] = []uint64{sequence}
-			toDeleteCounterparty[MsgTransfer] = []uint64{sequence}
-		case MsgAcknowledgement, MsgTimeout, MsgTimeoutOnClose:
-			toDelete[action] = []uint64{sequence}
-			toDeleteCounterparty[MsgRecvPacket] = []uint64{sequence}
-			toDelete[MsgTransfer] = []uint64{sequence}
+		switch eventType {
+		case chantypes.EventTypeRecvPacket:
+			toDelete[eventType] = []uint64{sequence}
+			toDeleteCounterparty[chantypes.EventTypeSendPacket] = []uint64{sequence}
+		case chantypes.EventTypeAcknowledgePacket, chantypes.EventTypeTimeoutPacket, chantypes.EventTypeTimeoutPacketOnClose:
+			toDelete[eventType] = []uint64{sequence}
+			toDeleteCounterparty[chantypes.EventTypeRecvPacket] = []uint64{sequence}
+			toDelete[chantypes.EventTypeSendPacket] = []uint64{sequence}
 		}
 		// delete in progress send for this specific message
-		pathEnd.packetProcessing[k].deleteMessages(map[string][]uint64{action: []uint64{sequence}})
+		pathEnd.packetProcessing[k].deleteMessages(map[string][]uint64{eventType: []uint64{sequence}})
 		// delete all packet flow retention history for this sequence
 		pathEnd.messageCache.PacketFlow[k].DeleteMessages(toDelete)
 		counterparty.messageCache.PacketFlow[k].DeleteMessages(toDeleteCounterparty)
@@ -373,18 +375,18 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 // shouldSendConnectionMessage determines if the connection handshake message should be sent now.
 // It will also determine if the message needs to be given up on entirely and remove retention if so.
 func (pathEnd *pathEndRuntime) shouldSendConnectionMessage(message connectionIBCMessage, counterparty *pathEndRuntime) bool {
-	action := message.action
+	eventType := message.eventType
 	k := connectionInfoConnectionKey(message.info).Counterparty()
 	if message.info.Height >= counterparty.latestBlock.Height {
 		pathEnd.log.Debug("Waiting to relay connection message until counterparty height has incremented",
 			zap.Inline(k),
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 		)
 		return false
 	}
-	msgProcessCache, ok := pathEnd.connProcessing[action]
+	msgProcessCache, ok := pathEnd.connProcessing[eventType]
 	if !ok {
-		// in progress cache does not exist for this action, so can send.
+		// in progress cache does not exist for this eventType, so can send.
 		return true
 	}
 	inProgress, ok := msgProcessCache[k]
@@ -406,26 +408,26 @@ func (pathEnd *pathEndRuntime) shouldSendConnectionMessage(message connectionIBC
 	}
 	if inProgress.retryCount >= maxMessageSendRetries {
 		pathEnd.log.Error("Giving up on sending connection message after max retries",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 		)
 		// giving up on sending this connection handshake message
 		// remove all retention of this connection handshake in pathEnd.messagesCache.ConnectionHandshake and counterparty
 		toDelete := make(map[string][]ConnectionKey)
 		toDeleteCounterparty := make(map[string][]ConnectionKey)
 		counterpartyKey := k.Counterparty()
-		switch action {
-		case MsgConnectionOpenTry:
-			toDeleteCounterparty[MsgConnectionOpenInit] = []ConnectionKey{counterpartyKey.msgInitKey()}
-		case MsgConnectionOpenAck:
-			toDeleteCounterparty[MsgConnectionOpenTry] = []ConnectionKey{counterpartyKey}
-			toDelete[MsgConnectionOpenInit] = []ConnectionKey{k.msgInitKey()}
-		case MsgConnectionOpenConfirm:
-			toDeleteCounterparty[MsgConnectionOpenAck] = []ConnectionKey{counterpartyKey}
-			toDelete[MsgConnectionOpenTry] = []ConnectionKey{k}
-			toDeleteCounterparty[MsgConnectionOpenInit] = []ConnectionKey{counterpartyKey.msgInitKey()}
+		switch eventType {
+		case conntypes.EventTypeConnectionOpenInit:
+			toDeleteCounterparty[conntypes.EventTypeConnectionOpenInit] = []ConnectionKey{counterpartyKey.msgInitKey()}
+		case conntypes.EventTypeConnectionOpenAck:
+			toDeleteCounterparty[conntypes.EventTypeConnectionOpenTry] = []ConnectionKey{counterpartyKey}
+			toDelete[conntypes.EventTypeConnectionOpenInit] = []ConnectionKey{k.msgInitKey()}
+		case conntypes.EventTypeConnectionOpenConfirm:
+			toDeleteCounterparty[conntypes.EventTypeConnectionOpenAck] = []ConnectionKey{counterpartyKey}
+			toDelete[conntypes.EventTypeConnectionOpenTry] = []ConnectionKey{k}
+			toDeleteCounterparty[conntypes.EventTypeConnectionOpenInit] = []ConnectionKey{counterpartyKey.msgInitKey()}
 		}
 		// delete in progress send for this specific message
-		pathEnd.connProcessing.deleteMessages(map[string][]ConnectionKey{action: []ConnectionKey{k}})
+		pathEnd.connProcessing.deleteMessages(map[string][]ConnectionKey{eventType: []ConnectionKey{k}})
 
 		// delete all connection handshake retention history for this connection
 		pathEnd.messageCache.ConnectionHandshake.DeleteMessages(toDelete)
@@ -440,18 +442,18 @@ func (pathEnd *pathEndRuntime) shouldSendConnectionMessage(message connectionIBC
 // shouldSendConnectionMessage determines if the channel handshake message should be sent now.
 // It will also determine if the message needs to be given up on entirely and remove retention if so.
 func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessage, counterparty *pathEndRuntime) bool {
-	action := message.action
+	eventType := message.eventType
 	channelKey := channelInfoChannelKey(message.info).Counterparty()
 	if message.info.Height >= counterparty.latestBlock.Height {
 		pathEnd.log.Debug("Waiting to relay channel message until counterparty height has incremented",
 			zap.Inline(channelKey),
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 		)
 		return false
 	}
-	msgProcessCache, ok := pathEnd.channelProcessing[action]
+	msgProcessCache, ok := pathEnd.channelProcessing[eventType]
 	if !ok {
-		// in progress cache does not exist for this action, so can send.
+		// in progress cache does not exist for this eventType, so can send.
 		return true
 	}
 	inProgress, ok := msgProcessCache[channelKey]
@@ -473,7 +475,7 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 	}
 	if inProgress.retryCount >= maxMessageSendRetries {
 		pathEnd.log.Error("Giving up on sending channel message after max retries",
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Int("max_retries", maxMessageSendRetries),
 		)
 		// giving up on sending this channel handshake message
@@ -481,19 +483,19 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		toDelete := make(map[string][]ChannelKey)
 		toDeleteCounterparty := make(map[string][]ChannelKey)
 		counterpartyKey := channelKey.Counterparty()
-		switch action {
-		case MsgChannelOpenTry:
-			toDeleteCounterparty[MsgChannelOpenInit] = []ChannelKey{counterpartyKey.msgInitKey()}
-		case MsgChannelOpenAck:
-			toDeleteCounterparty[MsgChannelOpenTry] = []ChannelKey{counterpartyKey}
-			toDelete[MsgChannelOpenInit] = []ChannelKey{channelKey.msgInitKey()}
-		case MsgChannelOpenConfirm:
-			toDeleteCounterparty[MsgChannelOpenAck] = []ChannelKey{counterpartyKey}
-			toDelete[MsgChannelOpenTry] = []ChannelKey{channelKey}
-			toDeleteCounterparty[MsgChannelOpenInit] = []ChannelKey{counterpartyKey.msgInitKey()}
+		switch eventType {
+		case chantypes.EventTypeChannelOpenTry:
+			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.msgInitKey()}
+		case chantypes.EventTypeChannelOpenAck:
+			toDeleteCounterparty[chantypes.EventTypeChannelOpenTry] = []ChannelKey{counterpartyKey}
+			toDelete[chantypes.EventTypeChannelOpenInit] = []ChannelKey{channelKey.msgInitKey()}
+		case chantypes.EventTypeChannelOpenConfirm:
+			toDeleteCounterparty[chantypes.EventTypeChannelOpenAck] = []ChannelKey{counterpartyKey}
+			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
+			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.msgInitKey()}
 		}
 		// delete in progress send for this specific message
-		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{action: []ChannelKey{channelKey}})
+		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: []ChannelKey{channelKey}})
 
 		// delete all connection handshake retention history for this channel
 		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)
@@ -506,13 +508,13 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 }
 
 func (pathEnd *pathEndRuntime) trackProcessingPacketMessage(t packetMessageToTrack) {
-	action := t.msg.action
+	eventType := t.msg.eventType
 	sequence := t.msg.info.Sequence
 	channelKey, err := t.msg.channelKey()
 	if err != nil {
 		pathEnd.log.Error("Unexpected error tracking processing packet",
 			zap.Inline(channelKey),
-			zap.String("action", action),
+			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
 			zap.Error(err),
 		)
@@ -523,10 +525,10 @@ func (pathEnd *pathEndRuntime) trackProcessingPacketMessage(t packetMessageToTra
 		msgProcessCache = make(packetChannelMessageCache)
 		pathEnd.packetProcessing[channelKey] = msgProcessCache
 	}
-	channelProcessingCache, ok := msgProcessCache[action]
+	channelProcessingCache, ok := msgProcessCache[eventType]
 	if !ok {
 		channelProcessingCache = make(packetMessageSendCache)
-		msgProcessCache[action] = channelProcessingCache
+		msgProcessCache[eventType] = channelProcessingCache
 	}
 
 	retryCount := uint64(0)
@@ -543,12 +545,12 @@ func (pathEnd *pathEndRuntime) trackProcessingPacketMessage(t packetMessageToTra
 }
 
 func (pathEnd *pathEndRuntime) trackProcessingConnectionMessage(t connectionMessageToTrack) {
-	action := t.msg.action
+	eventType := t.msg.eventType
 	connectionKey := connectionInfoConnectionKey(t.msg.info).Counterparty()
-	msgProcessCache, ok := pathEnd.connProcessing[action]
+	msgProcessCache, ok := pathEnd.connProcessing[eventType]
 	if !ok {
 		msgProcessCache = make(connectionKeySendCache)
-		pathEnd.connProcessing[action] = msgProcessCache
+		pathEnd.connProcessing[eventType] = msgProcessCache
 	}
 
 	retryCount := uint64(0)
@@ -565,12 +567,12 @@ func (pathEnd *pathEndRuntime) trackProcessingConnectionMessage(t connectionMess
 }
 
 func (pathEnd *pathEndRuntime) trackProcessingChannelMessage(t channelMessageToTrack) {
-	action := t.msg.action
+	eventType := t.msg.eventType
 	channelKey := channelInfoChannelKey(t.msg.info).Counterparty()
-	msgProcessCache, ok := pathEnd.channelProcessing[action]
+	msgProcessCache, ok := pathEnd.channelProcessing[eventType]
 	if !ok {
 		msgProcessCache = make(channelKeySendCache)
-		pathEnd.channelProcessing[action] = msgProcessCache
+		pathEnd.channelProcessing[eventType] = msgProcessCache
 	}
 
 	retryCount := uint64(0)

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -110,11 +110,11 @@ func (pp *PathProcessor) RelevantClientID(chainID string) string {
 }
 
 // OnConnectionMessage allows the caller to handle connection handshake messages with a callback.
-func (pp *PathProcessor) OnConnectionMessage(chainID string, action string, onMsg func(provider.ConnectionInfo)) {
+func (pp *PathProcessor) OnConnectionMessage(chainID string, eventType string, onMsg func(provider.ConnectionInfo)) {
 	if pp.pathEnd1.info.ChainID == chainID {
-		pp.pathEnd1.connSubscribers[action] = append(pp.pathEnd1.connSubscribers[action], onMsg)
+		pp.pathEnd1.connSubscribers[eventType] = append(pp.pathEnd1.connSubscribers[eventType], onMsg)
 	} else if pp.pathEnd2.info.ChainID == chainID {
-		pp.pathEnd2.connSubscribers[action] = append(pp.pathEnd2.connSubscribers[action], onMsg)
+		pp.pathEnd2.connSubscribers[eventType] = append(pp.pathEnd2.connSubscribers[eventType], onMsg)
 	}
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -398,10 +398,10 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		if m.Initial == nil {
 			return
 		}
-		channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
+		channelKey, err := PacketInfoChannelKey(m.Initial.EventType, m.Initial.Info)
 		if err != nil {
 			pp.log.Error("Unexpected error checking packet message",
-				zap.String("event_type", m.Termination.Action),
+				zap.String("event_type", m.Termination.EventType),
 				zap.Inline(channelKey),
 				zap.Error(err),
 			)
@@ -412,12 +412,12 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.packetMessages = append(pathEnd1Messages.packetMessages, packetIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.packetMessages = append(pathEnd2Messages.packetMessages, packetIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		}
@@ -430,12 +430,12 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.connectionMessages = append(pathEnd1Messages.connectionMessages, connectionIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.connectionMessages = append(pathEnd2Messages.connectionMessages, connectionIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		}
@@ -448,12 +448,12 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.channelMessages = append(pathEnd1Messages.channelMessages, channelIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.channelMessages = append(pathEnd2Messages.channelMessages, channelIBCMessage{
-				eventType: m.Initial.Action,
+				eventType: m.Initial.EventType,
 				info:      m.Initial.Info,
 			})
 		}

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
@@ -26,7 +27,7 @@ func (pp *PathProcessor) assemblePacketIBCMessage(
 	}
 	assembled, err := assembleMessage(ctx, partialMessage.info, signer, src.latestBlock)
 	if err != nil {
-		return nil, fmt.Errorf("error assembling %s for {%s}: %w", partialMessage.action, dst.info.ChainID, err)
+		return nil, fmt.Errorf("error assembling %s for {%s}: %w", partialMessage.eventType, dst.info.ChainID, err)
 	}
 
 	return assembled, nil
@@ -44,9 +45,9 @@ MsgTransferLoop:
 			if transferSeq == ackSeq {
 				// we have an ack for this packet, so packet flow is complete
 				// remove all retention of this sequence number
-				res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], transferSeq)
-				res.ToDeleteDst[MsgRecvPacket] = append(res.ToDeleteDst[MsgRecvPacket], transferSeq)
-				res.ToDeleteSrc[MsgAcknowledgement] = append(res.ToDeleteSrc[MsgAcknowledgement], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], transferSeq)
+				res.ToDeleteDst[chantypes.EventTypeRecvPacket] = append(res.ToDeleteDst[chantypes.EventTypeRecvPacket], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket] = append(res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket], transferSeq)
 				continue MsgTransferLoop
 			}
 		}
@@ -54,8 +55,8 @@ MsgTransferLoop:
 			if transferSeq == timeoutSeq {
 				// we have a timeout for this packet, so packet flow is complete
 				// remove all retention of this sequence number
-				res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], transferSeq)
-				res.ToDeleteSrc[MsgTimeout] = append(res.ToDeleteSrc[MsgTimeout], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeTimeoutPacket] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacket], transferSeq)
 				continue MsgTransferLoop
 			}
 		}
@@ -63,8 +64,8 @@ MsgTransferLoop:
 			if transferSeq == timeoutOnCloseSeq {
 				// we have a timeout for this packet, so packet flow is complete
 				// remove all retention of this sequence number
-				res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], transferSeq)
-				res.ToDeleteSrc[MsgTimeoutOnClose] = append(res.ToDeleteSrc[MsgTimeoutOnClose], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], transferSeq)
+				res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose], transferSeq)
 				continue MsgTransferLoop
 			}
 		}
@@ -72,8 +73,8 @@ MsgTransferLoop:
 			if transferSeq == msgRecvSeq {
 				// msg is received by dst chain, but no ack yet. Need to relay ack from dst to src!
 				ackMsg := packetIBCMessage{
-					action: MsgAcknowledgement,
-					info:   msgAcknowledgement,
+					eventType: chantypes.EventTypeAcknowledgePacket,
+					info:      msgAcknowledgement,
 				}
 				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(ackMsg, pathEndPacketFlowMessages.Dst) {
 					res.SrcMessages = append(res.SrcMessages, ackMsg)
@@ -90,16 +91,16 @@ MsgTransferLoop:
 			switch {
 			case errors.As(err, &timeoutHeightErr) || errors.As(err, &timeoutTimestampErr):
 				timeoutMsg := packetIBCMessage{
-					action: MsgTimeout,
-					info:   msgTransfer,
+					eventType: chantypes.EventTypeTimeoutPacket,
+					info:      msgTransfer,
 				}
 				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(timeoutMsg, pathEndPacketFlowMessages.Dst) {
 					res.SrcMessages = append(res.SrcMessages, timeoutMsg)
 				}
 			case errors.As(err, &timeoutOnCloseErr):
 				timeoutOnCloseMsg := packetIBCMessage{
-					action: MsgTimeoutOnClose,
-					info:   msgTransfer,
+					eventType: chantypes.EventTypeTimeoutPacketOnClose,
+					info:      msgTransfer,
 				}
 				if pathEndPacketFlowMessages.Src.shouldSendPacketMessage(timeoutOnCloseMsg, pathEndPacketFlowMessages.Dst) {
 					res.SrcMessages = append(res.SrcMessages, timeoutOnCloseMsg)
@@ -113,8 +114,8 @@ MsgTransferLoop:
 			continue MsgTransferLoop
 		}
 		recvPacketMsg := packetIBCMessage{
-			action: MsgRecvPacket,
-			info:   msgTransfer,
+			eventType: chantypes.EventTypeRecvPacket,
+			info:      msgTransfer,
 		}
 		if pathEndPacketFlowMessages.Dst.shouldSendPacketMessage(recvPacketMsg, pathEndPacketFlowMessages.Src) {
 			res.DstMessages = append(res.DstMessages, recvPacketMsg)
@@ -123,17 +124,17 @@ MsgTransferLoop:
 
 	// now iterate through packet-flow-complete messages and remove any leftover messages if the MsgTransfer or MsgRecvPacket was in a previous block that we did not query
 	for ackSeq := range pathEndPacketFlowMessages.SrcMsgAcknowledgement {
-		res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], ackSeq)
-		res.ToDeleteDst[MsgRecvPacket] = append(res.ToDeleteDst[MsgRecvPacket], ackSeq)
-		res.ToDeleteSrc[MsgAcknowledgement] = append(res.ToDeleteSrc[MsgAcknowledgement], ackSeq)
+		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], ackSeq)
+		res.ToDeleteDst[chantypes.EventTypeRecvPacket] = append(res.ToDeleteDst[chantypes.EventTypeRecvPacket], ackSeq)
+		res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket] = append(res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket], ackSeq)
 	}
 	for timeoutSeq := range pathEndPacketFlowMessages.SrcMsgTimeout {
-		res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], timeoutSeq)
-		res.ToDeleteSrc[MsgTimeout] = append(res.ToDeleteSrc[MsgTimeout], timeoutSeq)
+		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], timeoutSeq)
+		res.ToDeleteSrc[chantypes.EventTypeTimeoutPacket] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacket], timeoutSeq)
 	}
 	for timeoutOnCloseSeq := range pathEndPacketFlowMessages.SrcMsgTimeoutOnClose {
-		res.ToDeleteSrc[MsgTransfer] = append(res.ToDeleteSrc[MsgTransfer], timeoutOnCloseSeq)
-		res.ToDeleteSrc[MsgTimeoutOnClose] = append(res.ToDeleteSrc[MsgTimeoutOnClose], timeoutOnCloseSeq)
+		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], timeoutOnCloseSeq)
+		res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose], timeoutOnCloseSeq)
 	}
 	return res
 }
@@ -160,8 +161,8 @@ ConnectionHandshakeLoop:
 		if foundOpenTry == nil {
 			// need to send an open try to dst
 			msgOpenTry := connectionIBCMessage{
-				action: MsgConnectionOpenTry,
-				info:   openInitMsg,
+				eventType: conntypes.EventTypeConnectionOpenTry,
+				info:      openInitMsg,
 			}
 			if pathEndConnectionHandshakeMessages.Dst.shouldSendConnectionMessage(msgOpenTry, pathEndConnectionHandshakeMessages.Src) {
 				res.DstMessages = append(res.DstMessages, msgOpenTry)
@@ -178,8 +179,8 @@ ConnectionHandshakeLoop:
 		if foundOpenAck == nil {
 			// need to send an open ack to src
 			msgOpenAck := connectionIBCMessage{
-				action: MsgConnectionOpenAck,
-				info:   *foundOpenTry,
+				eventType: conntypes.EventTypeConnectionOpenAck,
+				info:      *foundOpenTry,
 			}
 			if pathEndConnectionHandshakeMessages.Src.shouldSendConnectionMessage(msgOpenAck, pathEndConnectionHandshakeMessages.Dst) {
 				res.SrcMessages = append(res.SrcMessages, msgOpenAck)
@@ -196,8 +197,8 @@ ConnectionHandshakeLoop:
 		if foundOpenConfirm == nil {
 			// need to send an open confirm to dst
 			msgOpenConfirm := connectionIBCMessage{
-				action: MsgConnectionOpenConfirm,
-				info:   *foundOpenAck,
+				eventType: conntypes.EventTypeConnectionOpenConfirm,
+				info:      *foundOpenAck,
 			}
 			if pathEndConnectionHandshakeMessages.Dst.shouldSendConnectionMessage(msgOpenConfirm, pathEndConnectionHandshakeMessages.Src) {
 				res.DstMessages = append(res.DstMessages, msgOpenConfirm)
@@ -205,24 +206,24 @@ ConnectionHandshakeLoop:
 			continue ConnectionHandshakeLoop
 		}
 		// handshake is complete for this connection, remove all retention.
-		res.ToDeleteDst[MsgConnectionOpenTry] = append(res.ToDeleteDst[MsgConnectionOpenTry], openInitKey)
-		res.ToDeleteSrc[MsgConnectionOpenAck] = append(res.ToDeleteSrc[MsgConnectionOpenAck], openInitKey)
-		res.ToDeleteDst[MsgConnectionOpenConfirm] = append(res.ToDeleteDst[MsgConnectionOpenConfirm], openInitKey)
+		res.ToDeleteDst[conntypes.EventTypeConnectionOpenTry] = append(res.ToDeleteDst[conntypes.EventTypeConnectionOpenTry], openInitKey)
+		res.ToDeleteSrc[conntypes.EventTypeConnectionOpenAck] = append(res.ToDeleteSrc[conntypes.EventTypeConnectionOpenAck], openInitKey)
+		res.ToDeleteDst[conntypes.EventTypeConnectionOpenConfirm] = append(res.ToDeleteDst[conntypes.EventTypeConnectionOpenConfirm], openInitKey)
 
 		// MsgConnectionOpenInit does not have CounterpartyConnectionID
 		openInitKey.CounterpartyConnID = ""
-		res.ToDeleteSrc[MsgConnectionOpenInit] = append(res.ToDeleteSrc[MsgConnectionOpenInit], openInitKey)
+		res.ToDeleteSrc[conntypes.EventTypeConnectionOpenInit] = append(res.ToDeleteSrc[conntypes.EventTypeConnectionOpenInit], openInitKey)
 	}
 
 	// now iterate through connection-handshake-complete messages and remove any leftover messages
 	for openConfirmKey := range pathEndConnectionHandshakeMessages.DstMsgConnectionOpenConfirm {
-		res.ToDeleteDst[MsgConnectionOpenTry] = append(res.ToDeleteDst[MsgConnectionOpenTry], openConfirmKey)
-		res.ToDeleteSrc[MsgConnectionOpenAck] = append(res.ToDeleteSrc[MsgConnectionOpenAck], openConfirmKey)
-		res.ToDeleteDst[MsgConnectionOpenConfirm] = append(res.ToDeleteDst[MsgConnectionOpenConfirm], openConfirmKey)
+		res.ToDeleteDst[conntypes.EventTypeConnectionOpenTry] = append(res.ToDeleteDst[conntypes.EventTypeConnectionOpenTry], openConfirmKey)
+		res.ToDeleteSrc[conntypes.EventTypeConnectionOpenAck] = append(res.ToDeleteSrc[conntypes.EventTypeConnectionOpenAck], openConfirmKey)
+		res.ToDeleteDst[conntypes.EventTypeConnectionOpenConfirm] = append(res.ToDeleteDst[conntypes.EventTypeConnectionOpenConfirm], openConfirmKey)
 
 		// MsgConnectionOpenInit does not have CounterpartyConnectionID
 		openConfirmKey.CounterpartyConnID = ""
-		res.ToDeleteSrc[MsgConnectionOpenInit] = append(res.ToDeleteSrc[MsgConnectionOpenInit], openConfirmKey)
+		res.ToDeleteSrc[conntypes.EventTypeConnectionOpenInit] = append(res.ToDeleteSrc[conntypes.EventTypeConnectionOpenInit], openConfirmKey)
 	}
 	return res
 }
@@ -249,8 +250,8 @@ ChannelHandshakeLoop:
 		if foundOpenTry == nil {
 			// need to send an open try to dst
 			msgOpenTry := channelIBCMessage{
-				action: MsgChannelOpenTry,
-				info:   openInitMsg,
+				eventType: chantypes.EventTypeChannelOpenTry,
+				info:      openInitMsg,
 			}
 			if pathEndChannelHandshakeMessages.Dst.shouldSendChannelMessage(msgOpenTry, pathEndChannelHandshakeMessages.Src) {
 				res.DstMessages = append(res.DstMessages, msgOpenTry)
@@ -267,8 +268,8 @@ ChannelHandshakeLoop:
 		if foundOpenAck == nil {
 			// need to send an open ack to src
 			msgOpenAck := channelIBCMessage{
-				action: MsgChannelOpenAck,
-				info:   *foundOpenTry,
+				eventType: chantypes.EventTypeChannelOpenAck,
+				info:      *foundOpenTry,
 			}
 			if pathEndChannelHandshakeMessages.Src.shouldSendChannelMessage(msgOpenAck, pathEndChannelHandshakeMessages.Dst) {
 				res.SrcMessages = append(res.SrcMessages, msgOpenAck)
@@ -285,8 +286,8 @@ ChannelHandshakeLoop:
 		if foundOpenConfirm == nil {
 			// need to send an open confirm to dst
 			msgOpenConfirm := channelIBCMessage{
-				action: MsgChannelOpenConfirm,
-				info:   *foundOpenAck,
+				eventType: chantypes.EventTypeChannelOpenConfirm,
+				info:      *foundOpenAck,
 			}
 			if pathEndChannelHandshakeMessages.Dst.shouldSendChannelMessage(msgOpenConfirm, pathEndChannelHandshakeMessages.Src) {
 				res.DstMessages = append(res.DstMessages, msgOpenConfirm)
@@ -294,20 +295,20 @@ ChannelHandshakeLoop:
 			continue ChannelHandshakeLoop
 		}
 		// handshake is complete for this channel, remove all retention.
-		res.ToDeleteDst[MsgChannelOpenTry] = append(res.ToDeleteDst[MsgChannelOpenTry], openInitKey)
-		res.ToDeleteSrc[MsgChannelOpenAck] = append(res.ToDeleteSrc[MsgChannelOpenAck], openInitKey)
-		res.ToDeleteDst[MsgChannelOpenConfirm] = append(res.ToDeleteDst[MsgChannelOpenConfirm], openInitKey)
+		res.ToDeleteDst[chantypes.EventTypeChannelOpenTry] = append(res.ToDeleteDst[chantypes.EventTypeChannelOpenTry], openInitKey)
+		res.ToDeleteSrc[chantypes.EventTypeChannelOpenAck] = append(res.ToDeleteSrc[chantypes.EventTypeChannelOpenAck], openInitKey)
+		res.ToDeleteDst[chantypes.EventTypeChannelOpenConfirm] = append(res.ToDeleteDst[chantypes.EventTypeChannelOpenConfirm], openInitKey)
 		// MsgChannelOpenInit does not have CounterpartyChannelID
-		res.ToDeleteSrc[MsgChannelOpenInit] = append(res.ToDeleteSrc[MsgChannelOpenInit], openInitKey.msgInitKey())
+		res.ToDeleteSrc[chantypes.EventTypeChannelOpenInit] = append(res.ToDeleteSrc[chantypes.EventTypeChannelOpenInit], openInitKey.msgInitKey())
 	}
 
 	// now iterate through channel-handshake-complete messages and remove any leftover messages
 	for openConfirmKey := range pathEndChannelHandshakeMessages.DstMsgChannelOpenConfirm {
-		res.ToDeleteDst[MsgChannelOpenTry] = append(res.ToDeleteDst[MsgChannelOpenTry], openConfirmKey)
-		res.ToDeleteSrc[MsgChannelOpenAck] = append(res.ToDeleteSrc[MsgChannelOpenAck], openConfirmKey)
-		res.ToDeleteDst[MsgChannelOpenConfirm] = append(res.ToDeleteDst[MsgChannelOpenConfirm], openConfirmKey)
+		res.ToDeleteDst[chantypes.EventTypeChannelOpenTry] = append(res.ToDeleteDst[chantypes.EventTypeChannelOpenTry], openConfirmKey)
+		res.ToDeleteSrc[chantypes.EventTypeChannelOpenAck] = append(res.ToDeleteSrc[chantypes.EventTypeChannelOpenAck], openConfirmKey)
+		res.ToDeleteDst[chantypes.EventTypeChannelOpenConfirm] = append(res.ToDeleteDst[chantypes.EventTypeChannelOpenConfirm], openConfirmKey)
 		// MsgChannelOpenInit does not have CounterpartyChannelID
-		res.ToDeleteSrc[MsgChannelOpenInit] = append(res.ToDeleteSrc[MsgChannelOpenInit], openConfirmKey.msgInitKey())
+		res.ToDeleteSrc[chantypes.EventTypeChannelOpenInit] = append(res.ToDeleteSrc[chantypes.EventTypeChannelOpenInit], openConfirmKey.msgInitKey())
 	}
 	return res
 }
@@ -400,7 +401,7 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		channelKey, err := PacketInfoChannelKey(m.Initial.Action, m.Initial.Info)
 		if err != nil {
 			pp.log.Error("Unexpected error checking packet message",
-				zap.String("action", m.Termination.Action),
+				zap.String("event_type", m.Termination.Action),
 				zap.Inline(channelKey),
 				zap.Error(err),
 			)
@@ -411,13 +412,13 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.packetMessages = append(pathEnd1Messages.packetMessages, packetIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.packetMessages = append(pathEnd2Messages.packetMessages, packetIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		}
 	case *ConnectionMessageLifecycle:
@@ -429,13 +430,13 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.connectionMessages = append(pathEnd1Messages.connectionMessages, connectionIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.connectionMessages = append(pathEnd2Messages.connectionMessages, connectionIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		}
 	case *ChannelMessageLifecycle:
@@ -447,13 +448,13 @@ func (pp *PathProcessor) appendInitialMessageIfNecessary(msg MessageLifecycle, p
 		}
 		if m.Initial.ChainID == pp.pathEnd1.info.ChainID {
 			pathEnd1Messages.channelMessages = append(pathEnd1Messages.channelMessages, channelIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		} else if m.Initial.ChainID == pp.pathEnd2.info.ChainID {
 			pathEnd2Messages.channelMessages = append(pathEnd2Messages.channelMessages, channelIBCMessage{
-				action: m.Initial.Action,
-				info:   m.Initial.Info,
+				eventType: m.Initial.Action,
+				info:      m.Initial.Info,
 			})
 		}
 	}
@@ -470,18 +471,18 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 	pathEnd1ConnectionHandshakeMessages := pathEndConnectionHandshakeMessages{
 		Src:                         pp.pathEnd1,
 		Dst:                         pp.pathEnd2,
-		SrcMsgConnectionOpenInit:    pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenInit],
-		DstMsgConnectionOpenTry:     pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenTry],
-		SrcMsgConnectionOpenAck:     pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenAck],
-		DstMsgConnectionOpenConfirm: pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenConfirm],
+		SrcMsgConnectionOpenInit:    pp.pathEnd1.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenInit],
+		DstMsgConnectionOpenTry:     pp.pathEnd2.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenTry],
+		SrcMsgConnectionOpenAck:     pp.pathEnd1.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenAck],
+		DstMsgConnectionOpenConfirm: pp.pathEnd2.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenConfirm],
 	}
 	pathEnd2ConnectionHandshakeMessages := pathEndConnectionHandshakeMessages{
 		Src:                         pp.pathEnd2,
 		Dst:                         pp.pathEnd1,
-		SrcMsgConnectionOpenInit:    pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenInit],
-		DstMsgConnectionOpenTry:     pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenTry],
-		SrcMsgConnectionOpenAck:     pp.pathEnd2.messageCache.ConnectionHandshake[MsgConnectionOpenAck],
-		DstMsgConnectionOpenConfirm: pp.pathEnd1.messageCache.ConnectionHandshake[MsgConnectionOpenConfirm],
+		SrcMsgConnectionOpenInit:    pp.pathEnd2.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenInit],
+		DstMsgConnectionOpenTry:     pp.pathEnd1.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenTry],
+		SrcMsgConnectionOpenAck:     pp.pathEnd2.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenAck],
+		DstMsgConnectionOpenConfirm: pp.pathEnd1.messageCache.ConnectionHandshake[conntypes.EventTypeConnectionOpenConfirm],
 	}
 	pathEnd1ConnectionHandshakeRes := pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd1ConnectionHandshakeMessages)
 	pathEnd2ConnectionHandshakeRes := pp.getUnrelayedConnectionHandshakeMessagesAndToDelete(pathEnd2ConnectionHandshakeMessages)
@@ -489,18 +490,18 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 	pathEnd1ChannelHandshakeMessages := pathEndChannelHandshakeMessages{
 		Src:                      pp.pathEnd1,
 		Dst:                      pp.pathEnd2,
-		SrcMsgChannelOpenInit:    pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenInit],
-		DstMsgChannelOpenTry:     pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenTry],
-		SrcMsgChannelOpenAck:     pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenAck],
-		DstMsgChannelOpenConfirm: pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenConfirm],
+		SrcMsgChannelOpenInit:    pp.pathEnd1.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenInit],
+		DstMsgChannelOpenTry:     pp.pathEnd2.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenTry],
+		SrcMsgChannelOpenAck:     pp.pathEnd1.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenAck],
+		DstMsgChannelOpenConfirm: pp.pathEnd2.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenConfirm],
 	}
 	pathEnd2ChannelHandshakeMessages := pathEndChannelHandshakeMessages{
 		Src:                      pp.pathEnd2,
 		Dst:                      pp.pathEnd1,
-		SrcMsgChannelOpenInit:    pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenInit],
-		DstMsgChannelOpenTry:     pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenTry],
-		SrcMsgChannelOpenAck:     pp.pathEnd2.messageCache.ChannelHandshake[MsgChannelOpenAck],
-		DstMsgChannelOpenConfirm: pp.pathEnd1.messageCache.ChannelHandshake[MsgChannelOpenConfirm],
+		SrcMsgChannelOpenInit:    pp.pathEnd2.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenInit],
+		DstMsgChannelOpenTry:     pp.pathEnd1.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenTry],
+		SrcMsgChannelOpenAck:     pp.pathEnd2.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenAck],
+		DstMsgChannelOpenConfirm: pp.pathEnd1.messageCache.ChannelHandshake[chantypes.EventTypeChannelOpenConfirm],
 	}
 	pathEnd1ChannelHandshakeRes := pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd1ChannelHandshakeMessages)
 	pathEnd2ChannelHandshakeRes := pp.getUnrelayedChannelHandshakeMessagesAndToDelete(pathEnd2ChannelHandshakeMessages)
@@ -514,21 +515,21 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 			Src:                   pp.pathEnd1,
 			Dst:                   pp.pathEnd2,
 			ChannelKey:            pair.pathEnd1ChannelKey,
-			SrcMsgTransfer:        pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][MsgTransfer],
-			DstMsgRecvPacket:      pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgRecvPacket],
-			SrcMsgAcknowledgement: pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][MsgAcknowledgement],
-			SrcMsgTimeout:         pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][MsgTimeout],
-			SrcMsgTimeoutOnClose:  pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][MsgTimeoutOnClose],
+			SrcMsgTransfer:        pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeSendPacket],
+			DstMsgRecvPacket:      pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeRecvPacket],
+			SrcMsgAcknowledgement: pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeAcknowledgePacket],
+			SrcMsgTimeout:         pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeTimeoutPacket],
+			SrcMsgTimeoutOnClose:  pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeTimeoutPacketOnClose],
 		}
 		pathEnd2PacketFlowMessages := pathEndPacketFlowMessages{
 			Src:                   pp.pathEnd2,
 			Dst:                   pp.pathEnd1,
 			ChannelKey:            pair.pathEnd2ChannelKey,
-			SrcMsgTransfer:        pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgTransfer],
-			DstMsgRecvPacket:      pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][MsgRecvPacket],
-			SrcMsgAcknowledgement: pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgAcknowledgement],
-			SrcMsgTimeout:         pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgTimeout],
-			SrcMsgTimeoutOnClose:  pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][MsgTimeoutOnClose],
+			SrcMsgTransfer:        pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeSendPacket],
+			DstMsgRecvPacket:      pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeRecvPacket],
+			SrcMsgAcknowledgement: pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeAcknowledgePacket],
+			SrcMsgTimeout:         pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeTimeoutPacket],
+			SrcMsgTimeoutOnClose:  pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeTimeoutPacketOnClose],
 		}
 
 		pathEnd1ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages)
@@ -693,7 +694,7 @@ func (pp *PathProcessor) assembleAndSendMessages(
 		return fmt.Errorf("error sending messages: %w", err)
 	}
 	if !txSuccess {
-		return errors.New("error sending messages, transaction was not successful")
+		return errors.New("error sending messages, transeventType was not successful")
 	}
 
 	return nil
@@ -706,21 +707,21 @@ func (pp *PathProcessor) assemblePacketMessage(
 ) (provider.RelayerMessage, error) {
 	var packetProof func(context.Context, provider.PacketInfo, uint64) (provider.PacketProof, error)
 	var assembleMessage func(provider.PacketInfo, provider.PacketProof) (provider.RelayerMessage, error)
-	switch msg.action {
-	case MsgRecvPacket:
+	switch msg.eventType {
+	case chantypes.EventTypeRecvPacket:
 		packetProof = src.chainProvider.PacketCommitment
 		assembleMessage = dst.chainProvider.MsgRecvPacket
-	case MsgAcknowledgement:
+	case chantypes.EventTypeAcknowledgePacket:
 		packetProof = src.chainProvider.PacketAcknowledgement
 		assembleMessage = dst.chainProvider.MsgAcknowledgement
-	case MsgTimeout:
+	case chantypes.EventTypeTimeoutPacket:
 		packetProof = src.chainProvider.PacketReceipt
 		assembleMessage = dst.chainProvider.MsgTimeout
-	case MsgTimeoutOnClose:
+	case chantypes.EventTypeTimeoutPacketOnClose:
 		packetProof = src.chainProvider.PacketReceipt
 		assembleMessage = dst.chainProvider.MsgTimeoutOnClose
 	default:
-		return nil, fmt.Errorf("unexepected packet message action for message assembly: %s", msg.action)
+		return nil, fmt.Errorf("unexepected packet message eventType for message assembly: %s", msg.eventType)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, packetProofQueryTimeout)
@@ -742,21 +743,21 @@ func (pp *PathProcessor) assembleConnectionMessage(
 ) (provider.RelayerMessage, error) {
 	var connProof func(context.Context, provider.ConnectionInfo, uint64) (provider.ConnectionProof, error)
 	var assembleMessage func(provider.ConnectionInfo, provider.ConnectionProof) (provider.RelayerMessage, error)
-	switch msg.action {
-	case MsgConnectionOpenInit:
+	switch msg.eventType {
+	case conntypes.EventTypeConnectionOpenInit:
 		// don't need proof for this message
 		assembleMessage = dst.chainProvider.MsgConnectionOpenInit
-	case MsgConnectionOpenTry:
+	case conntypes.EventTypeConnectionOpenTry:
 		connProof = src.chainProvider.ConnectionHandshakeProof
 		assembleMessage = dst.chainProvider.MsgConnectionOpenTry
-	case MsgConnectionOpenAck:
+	case conntypes.EventTypeConnectionOpenAck:
 		connProof = src.chainProvider.ConnectionHandshakeProof
 		assembleMessage = dst.chainProvider.MsgConnectionOpenAck
-	case MsgConnectionOpenConfirm:
+	case conntypes.EventTypeConnectionOpenConfirm:
 		connProof = src.chainProvider.ConnectionProof
 		assembleMessage = dst.chainProvider.MsgConnectionOpenConfirm
 	default:
-		return nil, fmt.Errorf("unexepected connection message action for message assembly: %s", msg.action)
+		return nil, fmt.Errorf("unexepected connection message eventType for message assembly: %s", msg.eventType)
 	}
 	var proof provider.ConnectionProof
 	var err error
@@ -776,27 +777,27 @@ func (pp *PathProcessor) assembleChannelMessage(
 ) (provider.RelayerMessage, error) {
 	var chanProof func(context.Context, provider.ChannelInfo, uint64) (provider.ChannelProof, error)
 	var assembleMessage func(provider.ChannelInfo, provider.ChannelProof) (provider.RelayerMessage, error)
-	switch msg.action {
-	case MsgChannelOpenInit:
+	switch msg.eventType {
+	case chantypes.EventTypeChannelOpenInit:
 		// don't need proof for this message
 		assembleMessage = dst.chainProvider.MsgChannelOpenInit
-	case MsgChannelOpenTry:
+	case chantypes.EventTypeChannelOpenTry:
 		chanProof = src.chainProvider.ChannelProof
 		assembleMessage = dst.chainProvider.MsgChannelOpenTry
-	case MsgChannelOpenAck:
+	case chantypes.EventTypeChannelOpenAck:
 		chanProof = src.chainProvider.ChannelProof
 		assembleMessage = dst.chainProvider.MsgChannelOpenAck
-	case MsgChannelOpenConfirm:
+	case chantypes.EventTypeChannelOpenConfirm:
 		chanProof = src.chainProvider.ChannelProof
 		assembleMessage = dst.chainProvider.MsgChannelOpenConfirm
-	case MsgChannelCloseInit:
+	case chantypes.EventTypeChannelCloseInit:
 		// don't need proof for this message
 		assembleMessage = dst.chainProvider.MsgChannelCloseInit
-	case MsgChannelCloseConfirm:
+	case chantypes.EventTypeChannelCloseConfirm:
 		chanProof = src.chainProvider.ChannelProof
 		assembleMessage = dst.chainProvider.MsgChannelCloseConfirm
 	default:
-		return nil, fmt.Errorf("unexepected channel message action for message assembly: %s", msg.action)
+		return nil, fmt.Errorf("unexepected channel message eventType for message assembly: %s", msg.eventType)
 	}
 	var proof provider.ChannelProof
 	var err error

--- a/relayer/processor/types.go
+++ b/relayer/processor/types.go
@@ -19,9 +19,9 @@ type MessageLifecycle interface {
 }
 
 type PacketMessage struct {
-	ChainID string
-	Action  string
-	Info    provider.PacketInfo
+	ChainID   string
+	EventType string
+	Info      provider.PacketInfo
 }
 
 // PacketMessageLifecycle is used as a stop condition for the PathProcessor.
@@ -35,9 +35,9 @@ type PacketMessageLifecycle struct {
 func (t *PacketMessageLifecycle) messageLifecycler() {}
 
 type ConnectionMessage struct {
-	ChainID string
-	Action  string
-	Info    provider.ConnectionInfo
+	ChainID   string
+	EventType string
+	Info      provider.ConnectionInfo
 }
 
 // ConnectionMessageLifecycle is used as a stop condition for the PathProcessor.
@@ -51,9 +51,9 @@ type ConnectionMessageLifecycle struct {
 func (t *ConnectionMessageLifecycle) messageLifecycler() {}
 
 type ChannelMessage struct {
-	ChainID string
-	Action  string
-	Info    provider.ChannelInfo
+	ChainID   string
+	EventType string
+	Info      provider.ChannelInfo
 }
 
 // ChannelMessageLifecycle is used as a stop condition for the PathProcessor.

--- a/relayer/processor/types_internal.go
+++ b/relayer/processor/types_internal.go
@@ -18,35 +18,35 @@ type ibcMessage interface {
 	ibcMessageIndicator()
 }
 
-// packetIBCMessage holds a packet message's action and sequence along with it,
+// packetIBCMessage holds a packet message's eventType and sequence along with it,
 // useful for sending packets around internal to the PathProcessor.
 type packetIBCMessage struct {
-	info   provider.PacketInfo
-	action string
+	info      provider.PacketInfo
+	eventType string
 }
 
 func (packetIBCMessage) ibcMessageIndicator() {}
 
-// channelKey returns channel key for new message by this action
-// based on prior action.
+// channelKey returns channel key for new message by this eventType
+// based on prior eventType.
 func (p packetIBCMessage) channelKey() (ChannelKey, error) {
-	return PacketInfoChannelKey(p.action, p.info)
+	return PacketInfoChannelKey(p.eventType, p.info)
 }
 
-// channelIBCMessage holds a channel handshake message's action along with its details,
+// channelIBCMessage holds a channel handshake message's eventType along with its details,
 // useful for sending messages around internal to the PathProcessor.
 type channelIBCMessage struct {
-	action string
-	info   provider.ChannelInfo
+	eventType string
+	info      provider.ChannelInfo
 }
 
 func (channelIBCMessage) ibcMessageIndicator() {}
 
-// connectionIBCMessage holds a connection handshake message's action along with its details,
+// connectionIBCMessage holds a connection handshake message's eventType along with its details,
 // useful for sending messages around internal to the PathProcessor.
 type connectionIBCMessage struct {
-	action string
-	info   provider.ConnectionInfo
+	eventType string
+	info      provider.ConnectionInfo
 }
 
 func (connectionIBCMessage) ibcMessageIndicator() {}


### PR DESCRIPTION
To be more dynamic regardless of message `action`, key off of the `event.Type` instead for message retention and correlation in the `PathProcessor`. @jtieri pointed this out for how it will allow us to be dynamic for the different actions other than the typical initiation messages such `MsgTransfer` and `MsgChannelOpenInit`