### PR TITLE
Add support for ORDERED channel timeouts

### DIFF
--- a/relayer/chains/cosmos/event_parser.go
+++ b/relayer/chains/cosmos/event_parser.go
@@ -270,6 +270,8 @@ func (res *packetInfo) parsePacketAttribute(log *zap.Logger, attr sdk.Attribute)
 		res.DestPort = attr.Value
 	case chantypes.AttributeKeyDstChannel:
 		res.DestChannel = attr.Value
+	case chantypes.AttributeKeyChannelOrdering:
+		res.ChannelOrder = attr.Value
 	}
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -715,10 +715,20 @@ func (pp *PathProcessor) assemblePacketMessage(
 		packetProof = src.chainProvider.PacketAcknowledgement
 		assembleMessage = dst.chainProvider.MsgAcknowledgement
 	case chantypes.EventTypeTimeoutPacket:
-		packetProof = src.chainProvider.PacketReceipt
+		if msg.info.ChannelOrder == chantypes.ORDERED.String() {
+			packetProof = src.chainProvider.NextSeqRecv
+		} else {
+			packetProof = src.chainProvider.PacketReceipt
+		}
+
 		assembleMessage = dst.chainProvider.MsgTimeout
 	case chantypes.EventTypeTimeoutPacketOnClose:
-		packetProof = src.chainProvider.PacketReceipt
+		if msg.info.ChannelOrder == chantypes.ORDERED.String() {
+			packetProof = src.chainProvider.NextSeqRecv
+		} else {
+			packetProof = src.chainProvider.PacketReceipt
+		}
+
 		assembleMessage = dst.chainProvider.MsgTimeoutOnClose
 	default:
 		return nil, fmt.Errorf("unexepected packet message eventType for message assembly: %s", msg.eventType)

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -71,6 +71,7 @@ type PacketInfo struct {
 	SourceChannel    string
 	DestPort         string
 	DestChannel      string
+	ChannelOrder     string
 	Data             []byte
 	TimeoutHeight    clienttypes.Height
 	TimeoutTimestamp uint64
@@ -205,6 +206,11 @@ type ChainProvider interface {
 
 	// PacketReceipt queries for proof that a MsgRecvPacket has not been committed to the chain.
 	PacketReceipt(ctx context.Context, msgTransfer PacketInfo, height uint64) (PacketProof, error)
+
+	// NextSeqRecv queries for the appropriate proof required to prove the next expected packet sequence number
+	// for a given counterparty channel. This is used in ORDERED channels to ensure packets are being delivered in the
+	// exact same order as they were sent over the wire.
+	NextSeqRecv(ctx context.Context, msgTransfer PacketInfo, height uint64) (PacketProof, error)
 
 	// MsgRecvPacket takes the packet information from a MsgTransfer along with the packet commitment,
 	// and assembles a full MsgRecvPacket ready to write to the chain.


### PR DESCRIPTION
This adds a field to the `PacketInfo` type for the channel's ordering. We use this information when determining which proof is needed to timeout a packet because on `ORDERED` channels we use a proof of next sequence received vs. a proof of msg timeout receipt.

I've tested these changes with the interchains account demo.

You can checkout this branch on the relayer and `make install` then clone down the ICA demo repo and run `make init-golang-rly`

https://github.com/jtieri/interchain-accounts-demo

As a note, I think there is still *one* more change that will need to be made around determining if a channel is in the `CLOSED` state after a packet timeout occurs. On `ORDERED` channels, a packet timing out means the channel becomes closed and needs to be re-opened. Gotta do some more digging and will follow up.