### PR TITLE
Add initial block history flag to the CLI cmds for creating connections

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -83,7 +83,7 @@ func chainTest(t *testing.T, tcs []testChain) {
 	require.NoError(t, err)
 
 	t.Log("Creating connections")
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -171,7 +171,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -198,7 +198,7 @@ func TestGaiaReuseIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	testClientPair(ctx, t, src, dst)
 
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -252,7 +252,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -393,7 +393,7 @@ func TestRelayAllChannelsOnConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Creating connections")
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -589,7 +589,7 @@ func TestUnorderedChannelBlockHeightTimeout(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 
@@ -687,7 +687,7 @@ func TestUnorderedChannelTimestampTimeout(t *testing.T) {
 	timeout, err := src.GetTimeout()
 	require.NoError(t, err)
 
-	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "")
+	_, err = src.CreateOpenConnections(ctx, dst, 3, timeout, "", 0)
 	require.NoError(t, err)
 	testConnectionPair(ctx, t, src, dst)
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -292,11 +292,15 @@ func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func processorFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+func processorFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagProcessor, "p", relayer.ProcessorLegacy, "which relayer processor to use")
 	if err := v.BindPFlag(flagProcessor, cmd.Flags().Lookup(flagProcessor)); err != nil {
 		panic(err)
 	}
+	return cmd
+}
+
+func initBlockFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Uint64P(flagInitialBlockHistory, "b", 20, "initial block history to query when using 'events' as the processor for relaying")
 	if err := v.BindPFlag(flagInitialBlockHistory, cmd.Flags().Lookup(flagInitialBlockHistory)); err != nil {
 		panic(err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -151,7 +151,8 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName)),
 	cmd = updateTimeFlags(a.Viper, cmd)
 	cmd = strategyFlag(a.Viper, cmd)
 	cmd = debugServerFlags(a.Viper, cmd)
-	cmd = processorFlags(a.Viper, cmd)
+	cmd = processorFlag(a.Viper, cmd)
+	cmd = initBlockFlag(a.Viper, cmd)
 	cmd = memoFlag(a.Viper, cmd)
 	return cmd
 }

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -391,6 +391,11 @@ $ %s tx conn demo-path --timeout 5s`,
 
 			memo := a.Config.memo(cmd)
 
+			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
+			if err != nil {
+				return err
+			}
+
 			// ensure that the clients exist
 			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, memo)
 			if err != nil {
@@ -402,7 +407,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				}
 			}
 
-			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to, memo)
+			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to, memo, initialBlockHistory)
 			if err != nil {
 				return err
 			}
@@ -421,6 +426,7 @@ $ %s tx conn demo-path --timeout 5s`,
 	cmd = clientParameterFlags(a.Viper, cmd)
 	cmd = overrideFlag(a.Viper, cmd)
 	cmd = memoFlag(a.Viper, cmd)
+	cmd = initBlockFlag(a.Viper, cmd)
 	return cmd
 }
 
@@ -644,6 +650,11 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 
 			memo := a.Config.memo(cmd)
 
+			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
+			if err != nil {
+				return err
+			}
+
 			// create clients if they aren't already created
 			modified, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, memo)
 			if err != nil {
@@ -656,7 +667,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			}
 
 			// create connection if it isn't already created
-			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to, memo)
+			modified, err = c[src].CreateOpenConnections(cmd.Context(), c[dst], retries, to, memo, initialBlockHistory)
 			if err != nil {
 				return fmt.Errorf("error creating connections: %w", err)
 			}
@@ -676,6 +687,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 	cmd = channelParameterFlags(a.Viper, cmd)
 	cmd = overrideFlag(a.Viper, cmd)
 	cmd = memoFlag(a.Viper, cmd)
+	cmd = initBlockFlag(a.Viper, cmd)
 	return cmd
 }
 

--- a/relayer/connection.go
+++ b/relayer/connection.go
@@ -18,6 +18,7 @@ func (c *Chain) CreateOpenConnections(
 	maxRetries uint64,
 	timeout time.Duration,
 	memo string,
+	initialBlockHistory uint64,
 ) (modified bool, err error) {
 	// client identifiers must be filled in
 	if err = ValidateClientPaths(c, dst); err != nil {
@@ -65,7 +66,7 @@ func (c *Chain) CreateOpenConnections(
 			dstpathChain.chainProcessor(c.log),
 		).
 		WithPathProcessors(pp).
-		WithInitialBlockHistory(0).
+		WithInitialBlockHistory(initialBlockHistory).
 		WithMessageLifecycle(&processor.ConnectionMessageLifecycle{
 			Initial: &processor.ConnectionMessage{
 				ChainID:   c.PathEnd.ChainID,


### PR DESCRIPTION
While testing the interchain accounts demo with the relayer I noticed intermittent failures when a client is created via `rly tx clients` and then a connection is created via a separate command,  `rly tx connection`, with some delay in between. What happens is the clients will be created but the attempt to create a connection will fail because there isn't an adequate amount of initial state.

Example logs:
```
2022-07-19T18:36:20.939496Z     info    Client Created  {"src_chain_id": "test-2", "src_client_id": "07-tendermint-0", "dst_chain_id": "test-1"}
2022-07-19T18:36:20.939506Z     info    Clients created {"src_client_id": "07-tendermint-0", "src_chain_id": "test-1", "dst_client_id": "07-tendermint-0", "dst_chain_id": "test-2"}

Initializing connection handshake...
2022-07-19T18:36:23.026966Z     info    Clients created {"src_client_id": "07-tendermint-0", "src_chain_id": "test-1", "dst_client_id": "07-tendermint-0", "dst_chain_id": "test-2"}
2022-07-19T18:36:23.027020Z     info    Starting event processor for connection handshake       {"src_chain_id": "test-1", "src_client_id": "07-tendermint-0", "dst_chain_id": "test-2", "dst_client_id": "07-tendermint-0"}
2022-07-19T18:36:23.064404Z     info    Chain is in sync        {"chain_name": "test-1", "chain_id": "test-1"}
2022-07-19T18:36:23.064439Z     info    Chain is in sync        {"chain_name": "test-2", "chain_id": "test-2"}
2022-07-19T18:36:24.105044Z     error   Error sending messages  {"src_chain_id": "test-2", "dst_chain_id": "test-1", "src_client_id": "07-tendermint-0", "dst_client_id": "07-tendermint-0", "error": "observed client trusted height: 0 does not equal latest client state height: 2"}
2022-07-19T18:36:47.146686Z     warn    Error querying block data       {"chain_name": "test-1", "chain_id": "test-1", "error": "RPC error -32603 - Internal error: could not find results for height #26"}
2022-07-19T18:37:02.160379Z     warn    Error querying block data       {"chain_name": "test-1", "chain_id": "test-1", "error": "RPC error -32603 - Internal error: could not find results for height #39"}
2022-07-19T18:37:06.145312Z     warn    Error querying block data       {"chain_name": "test-2", "chain_id": "test-2", "error": "RPC error -32603 - Internal error: could not find results for height #42"}
2022-07-19T18:37:13.147058Z     warn    Error querying block data       {"chain_name": "test-2", "chain_id": "test-2", "error": "RPC error -32603 - Internal error: could not find results for height #48"}
```

This required me splitting out the `processorFlag` and `initBlockHistoryFlag` into separate flags since we only need the block history flag for the related commands.