### PR TITLE
Update light client if close to expiration

### DIFF
--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -1,6 +1,8 @@
 package cosmos
 
 import (
+	"context"
+
 	conntypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/processor"
@@ -9,7 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func (ccp *CosmosChainProcessor) handleMessage(m ibcMessage, c processor.IBCMessagesCache) {
+func (ccp *CosmosChainProcessor) handleMessage(ctx context.Context, m ibcMessage, c processor.IBCMessagesCache) {
 	switch t := m.info.(type) {
 	case *packetInfo:
 		ccp.handlePacketMessage(m.eventType, provider.PacketInfo(*t), c)
@@ -18,7 +20,7 @@ func (ccp *CosmosChainProcessor) handleMessage(m ibcMessage, c processor.IBCMess
 	case *connectionInfo:
 		ccp.handleConnectionMessage(m.eventType, provider.ConnectionInfo(*t), c)
 	case *clientInfo:
-		ccp.handleClientMessage(m.eventType, *t)
+		ccp.handleClientMessage(ctx, m.eventType, *t)
 	}
 }
 
@@ -84,8 +86,8 @@ func (ccp *CosmosChainProcessor) handleConnectionMessage(eventType string, ci pr
 	ccp.logConnectionMessage(eventType, ci)
 }
 
-func (ccp *CosmosChainProcessor) handleClientMessage(eventType string, ci clientInfo) {
-	ccp.latestClientState.update(ci)
+func (ccp *CosmosChainProcessor) handleClientMessage(ctx context.Context, eventType string, ci clientInfo) {
+	ccp.latestClientState.update(ctx, ci, ccp)
 	ccp.logObservedIBCMessage(eventType, zap.String("client_id", ci.clientID))
 }
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -260,11 +260,17 @@ func (pathEnd *pathEndRuntime) shouldTerminate(ibcMessagesCache IBCMessagesCache
 	return false
 }
 
-func (pathEnd *pathEndRuntime) mergeCacheData(ctx context.Context, cancel func(), d ChainProcessorCacheData, messageLifecycle MessageLifecycle) {
+func (pathEnd *pathEndRuntime) mergeCacheData(ctx context.Context, cancel func(), d ChainProcessorCacheData, messageLifecycle MessageLifecycle, counterParty *pathEndRuntime) {
 	pathEnd.inSync = d.InSync
 	pathEnd.latestBlock = d.LatestBlock
 	pathEnd.latestHeader = d.LatestHeader
-	pathEnd.clientState = d.ClientState
+	if d.ClientState.ConsensusHeight != pathEnd.clientState.ConsensusHeight {
+		pathEnd.clientState = d.ClientState
+		ibcHeader, ok := counterParty.ibcHeaderCache[d.ClientState.ConsensusHeight.RevisionHeight]
+		if ok {
+			pathEnd.clientState.ConsensusTime = ibcHeader.Time()
+		}
+	}
 
 	pathEnd.handleCallbacks(d.IBCMessagesCache)
 

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -231,11 +231,11 @@ func (pp *PathProcessor) processAvailableSignals(ctx context.Context, cancel fun
 		return true
 	case d := <-pp.pathEnd1.incomingCacheData:
 		// we have new data from ChainProcessor for pathEnd1
-		pp.pathEnd1.mergeCacheData(ctx, cancel, d, messageLifecycle)
+		pp.pathEnd1.mergeCacheData(ctx, cancel, d, messageLifecycle, pp.pathEnd2)
 
 	case d := <-pp.pathEnd2.incomingCacheData:
 		// we have new data from ChainProcessor for pathEnd2
-		pp.pathEnd2.mergeCacheData(ctx, cancel, d, messageLifecycle)
+		pp.pathEnd2.mergeCacheData(ctx, cancel, d, messageLifecycle, pp.pathEnd1)
 
 	case <-pp.retryProcess:
 		// No new data to merge in, just retry handling.

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -557,8 +557,6 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 
 	pp.appendInitialMessageIfNecessary(messageLifecycle, &pathEnd1Messages, &pathEnd2Messages)
 
-	// if there are no pathEnd1 messages, check client states against trusing periods and see if clients need to be udpated
-
 	// now assemble and send messages in parallel
 	// if sending messages fails to one pathEnd, we don't need to halt sending to the other pathEnd.
 	var eg errgroup.Group

--- a/relayer/processor/types_test.go
+++ b/relayer/processor/types_test.go
@@ -2,6 +2,7 @@ package processor_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -12,6 +13,7 @@ type mockIBCHeader struct{}
 
 func (h mockIBCHeader) IBCHeaderIndicator() {}
 func (h mockIBCHeader) Height() uint64      { return 0 }
+func (h mockIBCHeader) Time() time.Time     { return time.Now() }
 
 func TestIBCHeaderCachePrune(t *testing.T) {
 	cache := make(processor.IBCHeaderCache)

--- a/relayer/provider/cosmos/provider.go
+++ b/relayer/provider/cosmos/provider.go
@@ -106,6 +106,10 @@ func (h CosmosIBCHeader) Height() uint64 {
 	return uint64(h.SignedHeader.Height)
 }
 
+func (h CosmosIBCHeader) Time() time.Time {
+	return h.SignedHeader.Time
+}
+
 func (cc *CosmosProvider) ProviderConfig() provider.ProviderConfig {
 	return cc.PCfg
 }

--- a/relayer/provider/cosmos/tx.go
+++ b/relayer/provider/cosmos/tx.go
@@ -730,7 +730,7 @@ func (cc *CosmosProvider) AutoUpdateClient(ctx context.Context, dst provider.Cha
 		return 0, err
 	}
 
-	clientState, err := cc.queryTMClientState(ctx, srch, srcClientId)
+	clientState, err := cc.QueryTMClientState(ctx, srch, srcClientId)
 	if err != nil {
 		return 0, err
 	}
@@ -755,7 +755,7 @@ func (cc *CosmosProvider) AutoUpdateClient(ctx context.Context, dst provider.Cha
 			zap.Uint("max_attempts", rtyAttNum),
 			zap.Error(err),
 		)
-		clientState, err = cc.queryTMClientState(ctx, srch, srcClientId)
+		clientState, err = cc.QueryTMClientState(ctx, srch, srcClientId)
 		if err != nil {
 			clientState = nil
 			cc.log.Info(
@@ -1953,9 +1953,9 @@ func (cc *CosmosProvider) InjectTrustedFields(ctx context.Context, header ibcexp
 	return h, nil
 }
 
-// queryTMClientState retrieves the latest consensus state for a client in state at a given height
+// QueryTMClientState retrieves the latest consensus state for a client in state at a given height
 // and unpacks/cast it to tendermint clientstate
-func (cc *CosmosProvider) queryTMClientState(ctx context.Context, srch int64, srcClientId string) (*tmclient.ClientState, error) {
+func (cc *CosmosProvider) QueryTMClientState(ctx context.Context, srch int64, srcClientId string) (*tmclient.ClientState, error) {
 	clientStateRes, err := cc.QueryClientStateResponse(ctx, srch, srcClientId)
 	if err != nil {
 		return &tmclient.ClientState{}, err

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -47,12 +47,15 @@ type LatestBlock struct {
 type IBCHeader interface {
 	IBCHeaderIndicator()
 	Height() uint64
+	Time() time.Time
 }
 
 // ClientState holds the current state of a client from a single chain's perspective
 type ClientState struct {
 	ClientID        string
 	ConsensusHeight clienttypes.Height
+	TrustingPeriod  time.Duration
+	ConsensusTime   time.Time
 }
 
 // ClientTrustedState holds the current state of a client from the perspective of both involved chains,


### PR DESCRIPTION
The goal of this PR is to ensure light clients don’t expire on low trafficked paths where `MsgUpdateClient` isn’t being sent regularly.

The `assembleAndSendMessages` function gets called on every block that has available signals to process. This is where we put a check to see if the light client is close to being expired. 
We update the light client if it has less than 1/3 of its trusting period left.

We get the trusting period of the client when we create a new `cosmos_chain_processor` and cache this info so it is not need to make this call every block.
I believe all of the client state info, including the trusting period, will be updated in the relayers cache every time it handles relevant transaction messages

**Question**:
- Is this OK to build into the overall relayer functionality? Will this effect non-cosmos based chains implementation of the relayer?

**Todo**:
- It would be nice to wire up a test in IBCtest to ensure this works properly.

Props to @agouin for taking the time to run through this with me.

Closes: https://github.com/cosmos/relayer/issues/853