### PR TITLE
Consolidate provider

### DIFF
--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -14,6 +14,7 @@ import (
 	ibctestingmock "github.com/cosmos/ibc-go/v4/testing/mock"
 	"github.com/cosmos/relayer/v2/cmd"
 	"github.com/cosmos/relayer/v2/relayer"
+	"github.com/cosmos/relayer/v2/relayer/chains/cosmos"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -278,7 +279,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	latestHeight, err := dst.ChainProvider.QueryLatestHeight(ctx)
 	require.NoError(t, err)
 
-	header, err := dst.ChainProvider.QueryHeaderAtHeight(ctx, latestHeight)
+	header, err := dst.ChainProvider.QueryIBCHeader(ctx, latestHeight)
 	require.NoError(t, err)
 
 	clientState, err := src.QueryTMClientState(ctx, latestHeight)
@@ -296,9 +297,9 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 	pubKey, err := privVal.GetPubKey()
 	require.NoError(t, err)
 
-	tmHeader, ok := header.(*tmclient.Header)
+	tmHeader, ok := header.(cosmos.CosmosIBCHeader)
 	if !ok {
-		t.Fatalf("got data of type %T but wanted tmclient.Header \n", header)
+		t.Fatalf("got data of type %T but wanted cosmos.CosmosIBCHeader \n", header)
 	}
 	validator := tmtypes.NewValidator(pubKey, tmHeader.ValidatorSet.Proposer.VotingPower)
 	valSet := tmtypes.NewValidatorSet([]*tmtypes.Validator{validator})
@@ -306,7 +307,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 
 	// creating duplicate header
 	newHeader := createTMClientHeader(t, dst.ChainID(), int64(heightPlus1.RevisionHeight), height,
-		tmHeader.GetTime().Add(time.Minute), valSet, valSet, signers, tmHeader)
+		tmHeader.SignedHeader.Time.Add(time.Minute), valSet, valSet, signers, nil)
 
 	// update client with duplicate header
 	updateMsg, err := src.ChainProvider.MsgUpdateClient(src.PathEnd.ClientID, newHeader)

--- a/_test/relayer_chain_test.go
+++ b/_test/relayer_chain_test.go
@@ -299,7 +299,7 @@ func TestGaiaMisbehaviourMonitoring(t *testing.T) {
 
 	tmHeader, ok := header.(cosmos.CosmosIBCHeader)
 	if !ok {
-		t.Fatalf("got data of type %T but wanted cosmos.CosmosIBCHeader \n", header)
+		t.Fatalf("got data of type %T but wanted cosmos.CosmosIBCHeader", header)
 	}
 	validator := tmtypes.NewValidator(pubKey, tmHeader.ValidatorSet.Proposer.VotingPower)
 	valSet := tmtypes.NewValidatorSet([]*tmtypes.Validator{validator})

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -307,7 +307,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		eg.Go(func() (err error) {
 			queryCtx, cancelQueryCtx := context.WithTimeout(ctx, queryTimeout)
 			defer cancelQueryCtx()
-			ibcHeader, err = ccp.chainProvider.IBCHeaderAtHeight(queryCtx, i)
+			ibcHeader, err = ccp.chainProvider.QueryIBCHeader(queryCtx, i)
 			return err
 		})
 

--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -113,10 +113,6 @@ func (h CosmosIBCHeader) ConsensusState() ibcexported.ConsensusState {
 	}
 }
 
-func (h CosmosIBCHeader) ToCosmosValidatorSet() (*tmtypes.ValidatorSet, error) {
-	return h.ValidatorSet, nil
-}
-
 func (cc *CosmosProvider) ProviderConfig() provider.ProviderConfig {
 	return cc.PCfg
 }

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -1046,7 +1046,15 @@ func castClientStateToTMType(cs *codectypes.Any) (*tmclient.ClientState, error) 
 //DefaultUpgradePath is the default IBC upgrade path set for an on-chain light client
 var defaultUpgradePath = []string{"upgrade", "upgradedIBCState"}
 
-func (cc *CosmosProvider) NewClientState(dstChainID string, dstUpdateHeader provider.IBCHeader, dstTrustingPeriod, dstUbdPeriod time.Duration, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour bool) (ibcexported.ClientState, error) {
+// NewClientState creates a new tendermint client state tracking the dst chain.
+func (cc *CosmosProvider) NewClientState(
+	dstChainID string,
+	dstUpdateHeader provider.IBCHeader,
+	dstTrustingPeriod,
+	dstUbdPeriod time.Duration,
+	allowUpdateAfterExpiry,
+	allowUpdateAfterMisbehaviour bool,
+) (ibcexported.ClientState, error) {
 	revisionNumber := clienttypes.ParseChainID(dstChainID)
 
 	// Create the ClientState we want on 'c' tracking 'dst'

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -278,8 +278,11 @@ func (cc *CosmosProvider) buildMessages(ctx context.Context, msgs []provider.Rel
 	return txBytes, nil
 }
 
-// CreateClient creates an sdk.Msg to update the client on src with consensus state from dst
-func (cc *CosmosProvider) MsgCreateClient(clientState ibcexported.ClientState, consensusState ibcexported.ConsensusState) (provider.RelayerMessage, error) {
+// MsgCreateClient creates an sdk.Msg to update the client on src with consensus state from dst
+func (cc *CosmosProvider) MsgCreateClient(
+	clientState ibcexported.ClientState,
+	consensusState ibcexported.ConsensusState,
+) (provider.RelayerMessage, error) {
 	signer, err := cc.Address()
 	if err != nil {
 		return nil, err
@@ -940,6 +943,7 @@ func (cc *CosmosProvider) AcknowledgementFromSequence(ctx context.Context, dst p
 	return msg, nil
 }
 
+// QueryIBCHeader returns the IBC compatible block header (CosmosIBCHeader) at a specific height.
 func (cc *CosmosProvider) QueryIBCHeader(ctx context.Context, h int64) (provider.IBCHeader, error) {
 	if h == 0 {
 		return nil, fmt.Errorf("height cannot be 0")

--- a/relayer/naive-strategy.go
+++ b/relayer/naive-strategy.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	chantypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
-	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -384,6 +383,11 @@ func (rs *RelaySequences) Empty() bool {
 
 // RelayAcknowledgements creates transactions to relay acknowledgements from src to dst and from dst to src
 func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain, sp RelaySequences, maxTxSize, maxMsgLength uint64, memo string, srcChannel *chantypes.IdentifiedChannel) error {
+	srch, dsth, err := QueryLatestHeights(ctx, src, dst)
+	if err != nil {
+		return err
+	}
+
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []provider.RelayerMessage{},
@@ -392,116 +396,74 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 		MaxMsgLength: maxMsgLength,
 	}
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		srch, dsth, err := QueryLatestHeights(ctx, src, dst)
+	// add messages for received packets on dst
+	for _, seq := range sp.Dst {
+		// dst wrote the ack. acknowledgementFromSequence will query the acknowledgement
+		// from the counterparty chain (second chain provided in the arguments). The message
+		// should be sent to src.
+		relayAckMsgs, err := src.ChainProvider.AcknowledgementFromSequence(ctx, dst.ChainProvider, uint64(dsth), seq, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId)
 		if err != nil {
 			return err
 		}
 
-		var (
-			srcHeader, dstHeader ibcexported.Header
+		// Do not allow nil messages to the queued, or else we will panic in send()
+		if relayAckMsgs != nil {
+			msgs.Src = append(msgs.Src, relayAckMsgs)
+		}
+	}
+
+	// add messages for received packets on src
+	for _, seq := range sp.Src {
+		// src wrote the ack. acknowledgementFromSequence will query the acknowledgement
+		// from the counterparty chain (second chain provided in the arguments). The message
+		// should be sent to dst.
+		relayAckMsgs, err := dst.ChainProvider.AcknowledgementFromSequence(ctx, src.ChainProvider, uint64(srch), seq, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
+		if err != nil {
+			return err
+		}
+
+		// Do not allow nil messages to the queued, or else we will panic in send()
+		if relayAckMsgs != nil {
+			msgs.Dst = append(msgs.Dst, relayAckMsgs)
+		}
+	}
+
+	if !msgs.Ready() {
+		log.Info(
+			"No acknowledgements to relay",
+			zap.String("src_chain_id", src.ChainID()),
+			zap.String("src_port_id", srcChannel.PortId),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.String("dst_port_id", srcChannel.Counterparty.PortId),
 		)
-		eg, egCtx := errgroup.WithContext(ctx)
-		eg.Go(func() error {
-			var err error
-			srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(egCtx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
-			return err
-		})
-		eg.Go(func() error {
-			var err error
-			dstHeader, err = dst.ChainProvider.GetIBCUpdateHeader(egCtx, dsth, src.ChainProvider, src.PathEnd.ClientID)
-			return err
-		})
-		if err := eg.Wait(); err != nil {
-			return err
-		}
+		return nil
+	}
 
-		srcUpdateMsg, err := src.ChainProvider.MsgUpdateClient(src.PathEnd.ClientID, dstHeader)
-		if err != nil {
-			return err
-		}
-		dstUpdateMsg, err := dst.ChainProvider.MsgUpdateClient(dst.PathEnd.ClientID, srcHeader)
-		if err != nil {
-			return err
-		}
+	if err := msgs.PrependMsgUpdateClient(ctx, src, dst, srch, dsth); err != nil {
+		return err
+	}
 
-		// add messages for received packets on dst
-		for _, seq := range sp.Dst {
-			// dst wrote the ack. acknowledgementFromSequence will query the acknowledgement
-			// from the counterparty chain (second chain provided in the arguments). The message
-			// should be sent to src.
-			relayAckMsgs, err := src.ChainProvider.AcknowledgementFromSequence(ctx, dst.ChainProvider, uint64(dsth), seq, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId)
-			if err != nil {
-				return err
-			}
-
-			// Do not allow nil messages to the queued, or else we will panic in send()
-			if relayAckMsgs != nil {
-				msgs.Src = append(msgs.Src, relayAckMsgs)
-			}
-		}
-
-		// add messages for received packets on src
-		for _, seq := range sp.Src {
-			// src wrote the ack. acknowledgementFromSequence will query the acknowledgement
-			// from the counterparty chain (second chain provided in the arguments). The message
-			// should be sent to dst.
-			relayAckMsgs, err := dst.ChainProvider.AcknowledgementFromSequence(ctx, src.ChainProvider, uint64(srch), seq, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId)
-			if err != nil {
-				return err
-			}
-
-			// Do not allow nil messages to the queued, or else we will panic in send()
-			if relayAckMsgs != nil {
-				msgs.Dst = append(msgs.Dst, relayAckMsgs)
-			}
-		}
-
-		if !msgs.Ready() {
+	// send messages to their respective chains
+	result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst), memo)
+	if err := result.Error(); err != nil {
+		if result.PartiallySent() {
 			log.Info(
-				"No acknowledgements to relay",
+				"Partial success when relaying acknowledgements",
 				zap.String("src_chain_id", src.ChainID()),
 				zap.String("src_port_id", srcChannel.PortId),
 				zap.String("dst_chain_id", dst.ChainID()),
 				zap.String("dst_port_id", srcChannel.Counterparty.PortId),
+				zap.Error(err),
 			)
-			return nil
 		}
+		return err
+	}
 
-		// Prepend non-empty msg lists with UpdateClient
-		if len(msgs.Dst) != 0 {
-			msgs.Dst = append([]provider.RelayerMessage{dstUpdateMsg}, msgs.Dst...)
-		}
-
-		if len(msgs.Src) != 0 {
-			msgs.Src = append([]provider.RelayerMessage{srcUpdateMsg}, msgs.Src...)
-		}
-
-		// send messages to their respective chains
-		result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst), memo)
-		if err := result.Error(); err != nil {
-			if result.PartiallySent() {
-				log.Info(
-					"Partial success when relaying acknowledgements",
-					zap.String("src_chain_id", src.ChainID()),
-					zap.String("src_port_id", srcChannel.PortId),
-					zap.String("dst_chain_id", dst.ChainID()),
-					zap.String("dst_port_id", srcChannel.Counterparty.PortId),
-					zap.Error(err),
-				)
-			}
-			return err
-		}
-
-		if result.SuccessfulSrcBatches > 0 {
-			src.logPacketsRelayed(dst, result.SuccessfulSrcBatches, srcChannel)
-		}
-		if result.SuccessfulDstBatches > 0 {
-			dst.logPacketsRelayed(src, result.SuccessfulDstBatches, srcChannel)
-		}
+	if result.SuccessfulSrcBatches > 0 {
+		src.logPacketsRelayed(dst, result.SuccessfulSrcBatches, srcChannel)
+	}
+	if result.SuccessfulDstBatches > 0 {
+		dst.logPacketsRelayed(src, result.SuccessfulDstBatches, srcChannel)
 	}
 
 	return nil
@@ -509,6 +471,11 @@ func RelayAcknowledgements(ctx context.Context, log *zap.Logger, src, dst *Chain
 
 // RelayPackets creates transactions to relay packets from src to dst and from dst to src
 func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp RelaySequences, maxTxSize, maxMsgLength uint64, memo string, srcChannel *chantypes.IdentifiedChannel) error {
+	srch, dsth, err := QueryLatestHeights(ctx, src, dst)
+	if err != nil {
+		return err
+	}
+
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []provider.RelayerMessage{},
@@ -517,83 +484,63 @@ func RelayPackets(ctx context.Context, log *zap.Logger, src, dst *Chain, sp Rela
 		MaxMsgLength: maxMsgLength,
 	}
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		srch, dsth, err := QueryLatestHeights(ctx, src, dst)
-		if err != nil {
-			return err
-		}
+	eg, egCtx := errgroup.WithContext(ctx)
+	// add messages for sequences on src
+	eg.Go(func() error {
+		return AddMessagesForSequences(egCtx, sp.Src, src, dst, srch, dsth, &msgs.Src, &msgs.Dst,
+			srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.Ordering)
+	})
 
-		eg, egCtx := errgroup.WithContext(ctx)
-		// add messages for sequences on src
-		eg.Go(func() error {
-			return AddMessagesForSequences(egCtx, sp.Src, src, dst, srch, dsth, &msgs.Src, &msgs.Dst,
-				srcChannel.ChannelId, srcChannel.PortId, srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.Ordering)
-		})
+	// add messages for sequences on dst
+	eg.Go(func() error {
+		return AddMessagesForSequences(egCtx, sp.Dst, dst, src, dsth, srch, &msgs.Dst, &msgs.Src,
+			srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Ordering)
+	})
 
-		// add messages for sequences on dst
-		eg.Go(func() error {
-			return AddMessagesForSequences(egCtx, sp.Dst, dst, src, dsth, srch, &msgs.Dst, &msgs.Src,
-				srcChannel.Counterparty.ChannelId, srcChannel.Counterparty.PortId, srcChannel.ChannelId, srcChannel.PortId, srcChannel.Ordering)
-		})
+	if err = eg.Wait(); err != nil {
+		return err
+	}
 
-		if err = eg.Wait(); err != nil {
-			return err
-		}
+	if !msgs.Ready() {
+		log.Info(
+			"No packets to relay",
+			zap.String("src_chain_id", src.ChainID()),
+			zap.String("src_port_id", srcChannel.PortId),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.String("dst_port_id", srcChannel.Counterparty.PortId),
+		)
+		return nil
+	}
 
-		if !msgs.Ready() {
+	if err := msgs.PrependMsgUpdateClient(ctx, src, dst, srch, dsth); err != nil {
+		return err
+	}
+
+	// send messages to their respective chains
+	result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst), memo)
+	if err := result.Error(); err != nil {
+		if result.PartiallySent() {
 			log.Info(
-				"No packets to relay",
+				"Partial success when relaying packets",
 				zap.String("src_chain_id", src.ChainID()),
 				zap.String("src_port_id", srcChannel.PortId),
 				zap.String("dst_chain_id", dst.ChainID()),
 				zap.String("dst_port_id", srcChannel.Counterparty.PortId),
+				zap.Error(err),
 			)
-			return nil
 		}
-
-		// Prepend non-empty msg lists with UpdateClient
-
-		eg, egCtx = errgroup.WithContext(ctx) // New errgroup because previous egCtx is canceled at this point.
-		eg.Go(func() error {
-			return PrependUpdateClientMsg(egCtx, &msgs.Dst, src, dst, srch)
-		})
-
-		eg.Go(func() error {
-			return PrependUpdateClientMsg(egCtx, &msgs.Src, dst, src, dsth)
-		})
-
-		if err = eg.Wait(); err != nil {
-			return err
-		}
-
-		// send messages to their respective chains
-		result := msgs.Send(ctx, log, AsRelayMsgSender(src), AsRelayMsgSender(dst), memo)
-		if err := result.Error(); err != nil {
-			if result.PartiallySent() {
-				log.Info(
-					"Partial success when relaying packets",
-					zap.String("src_chain_id", src.ChainID()),
-					zap.String("src_port_id", srcChannel.PortId),
-					zap.String("dst_chain_id", dst.ChainID()),
-					zap.String("dst_port_id", srcChannel.Counterparty.PortId),
-					zap.Error(err),
-				)
-			}
-			return err
-		}
-
-		if result.SuccessfulSrcBatches > 0 {
-			src.logPacketsRelayed(dst, result.SuccessfulSrcBatches, srcChannel)
-		}
-		if result.SuccessfulDstBatches > 0 {
-			dst.logPacketsRelayed(src, result.SuccessfulDstBatches, srcChannel)
-		}
-
-		return nil
+		return err
 	}
+
+	if result.SuccessfulSrcBatches > 0 {
+		src.logPacketsRelayed(dst, result.SuccessfulSrcBatches, srcChannel)
+	}
+	if result.SuccessfulDstBatches > 0 {
+		dst.logPacketsRelayed(src, result.SuccessfulDstBatches, srcChannel)
+	}
+
+	return nil
+
 }
 
 // AddMessagesForSequences constructs RecvMsgs and TimeoutMsgs from sequence numbers on a src chain
@@ -608,13 +555,12 @@ func AddMessagesForSequences(
 	order chantypes.Order,
 ) error {
 	for _, seq := range sequences {
-		recvMsg, timeoutMsg, err := src.ChainProvider.RelayPacketFromSequence(
+		recvMsg, timeoutMsg, err := dst.ChainProvider.RelayPacketFromSequence(
 			ctx,
-			src.ChainProvider, dst.ChainProvider,
+			src.ChainProvider,
 			uint64(srch), uint64(dsth),
 			seq,
-			dstChanID, dstPortID, dst.ClientID(),
-			srcChanID, srcPortID, src.ClientID(),
+			srcChanID, srcPortID,
 			order,
 		)
 		if err != nil {
@@ -641,56 +587,6 @@ func AddMessagesForSequences(
 			*srcMsgs = append(*srcMsgs, timeoutMsg)
 		}
 	}
-
-	return nil
-}
-
-// PrependUpdateClientMsg adds an UpdateClient msg to the front of non-empty msg lists
-func PrependUpdateClientMsg(ctx context.Context, msgs *[]provider.RelayerMessage, src, dst *Chain, srch int64) error {
-	if len(*msgs) == 0 {
-		return nil
-	}
-
-	// Query IBC Update Header
-	var srcHeader ibcexported.Header
-	if err := retry.Do(func() error {
-		var err error
-		srcHeader, err = src.ChainProvider.GetIBCUpdateHeader(ctx, srch, dst.ChainProvider, dst.PathEnd.ClientID)
-		return err
-	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		src.log.Info(
-			"PrependUpdateClientMsg: failed to get IBC update header",
-			zap.String("src_chain_id", src.ChainID()),
-			zap.String("dst_chain_id", dst.ChainID()),
-			zap.Uint("attempt", n+1),
-			zap.Uint("attempt_limit", RtyAttNum),
-			zap.Error(err),
-		)
-
-	})); err != nil {
-		return err
-	}
-
-	// Construct UpdateClient msg
-	var updateMsg provider.RelayerMessage
-	if err := retry.Do(func() error {
-		var err error
-		updateMsg, err = dst.ChainProvider.MsgUpdateClient(dst.PathEnd.ClientID, srcHeader)
-		return err
-	}, retry.Context(ctx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		dst.log.Info(
-			"PrependUpdateClientMsg: failed to build message",
-			zap.String("dst_chain_id", dst.ChainID()),
-			zap.Uint("attempt", n+1),
-			zap.Uint("attempt_limit", RtyAttNum),
-			zap.Error(err),
-		)
-	})); err != nil {
-		return err
-	}
-
-	// Prepend UpdateClient msg to the slice of msgs
-	*msgs = append([]provider.RelayerMessage{updateMsg}, *msgs...)
 
 	return nil
 }

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -369,7 +369,7 @@ func (pp *PathProcessor) assembleMsgUpdateClient(ctx context.Context, src, dst *
 			return nil, fmt.Errorf("observed client trusted height: %d does not equal latest client state height: %d",
 				trustedConsensusHeight.RevisionHeight, clientConsensusHeight.RevisionHeight)
 		}
-		header, err := src.chainProvider.IBCHeaderAtHeight(ctx, int64(clientConsensusHeight.RevisionHeight+1))
+		header, err := src.chainProvider.QueryIBCHeader(ctx, int64(clientConsensusHeight.RevisionHeight+1))
 		if err != nil {
 			return nil, fmt.Errorf("error getting IBC header at height: %d for chain_id: %s, %w", clientConsensusHeight.RevisionHeight+1, src.info.ChainID, err)
 		}

--- a/relayer/processor/types_test.go
+++ b/relayer/processor/types_test.go
@@ -6,14 +6,12 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/stretchr/testify/require"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type mockIBCHeader struct{}
 
-func (h mockIBCHeader) Height() uint64                                       { return 0 }
-func (h mockIBCHeader) ConsensusState() ibcexported.ConsensusState           { return nil }
-func (h mockIBCHeader) ToCosmosValidatorSet() (*tmtypes.ValidatorSet, error) { return nil, nil }
+func (h mockIBCHeader) Height() uint64                             { return 0 }
+func (h mockIBCHeader) ConsensusState() ibcexported.ConsensusState { return nil }
 
 func TestIBCHeaderCachePrune(t *testing.T) {
 	cache := make(processor.IBCHeaderCache)

--- a/relayer/processor/types_test.go
+++ b/relayer/processor/types_test.go
@@ -3,15 +3,17 @@ package processor_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/cosmos/relayer/v2/relayer/processor"
+	"github.com/stretchr/testify/require"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type mockIBCHeader struct{}
 
-func (h mockIBCHeader) IBCHeaderIndicator() {}
-func (h mockIBCHeader) Height() uint64      { return 0 }
+func (h mockIBCHeader) Height() uint64                                       { return 0 }
+func (h mockIBCHeader) ConsensusState() ibcexported.ConsensusState           { return nil }
+func (h mockIBCHeader) ToCosmosValidatorSet() (*tmtypes.ValidatorSet, error) { return nil, nil }
 
 func TestIBCHeaderCachePrune(t *testing.T) {
 	cache := make(processor.IBCHeaderCache)

--- a/relayer/provider/matcher.go
+++ b/relayer/provider/matcher.go
@@ -78,19 +78,19 @@ func tendermintMatcher(ctx context.Context, src, dst ChainProvider, existingClie
 		}
 
 		// Construct a header for the consensus state of the counterparty chain.
-		header, err := dst.GetLightSignedHeaderAtHeight(ctx, int64(existingClientState.GetLatestHeight().GetRevisionHeight()))
+		ibcHeader, err := dst.QueryIBCHeader(ctx, int64(existingClientState.GetLatestHeight().GetRevisionHeight()))
 		if err != nil {
 			return "", err
 		}
 
-		tmHeader, ok := header.(*tmclient.Header)
+		consensusState, ok := ibcHeader.ConsensusState().(*tmclient.ConsensusState)
 		if !ok {
-			return "", fmt.Errorf("got type(%T) expected type(*tmclient.Header)", header)
+			return "", fmt.Errorf("got type(%T) expected type(*tmclient.ConsensusState)", consensusState)
 		}
 
 		// Determine if the existing consensus state on src for the potential matching client is identical
 		// to the consensus state of the counterparty chain.
-		if isMatchingTendermintConsensusState(existingConsensusState, tmHeader.ConsensusState()) {
+		if isMatchingTendermintConsensusState(existingConsensusState, consensusState) {
 			return existingClientID, nil // found matching client
 		}
 	}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -460,16 +460,3 @@ func (t *TimeoutOnCloseError) Error() string {
 func NewTimeoutOnCloseError(msg string) *TimeoutOnCloseError {
 	return &TimeoutOnCloseError{msg}
 }
-
-func ToIBCPacket(pi PacketInfo) chantypes.Packet {
-	return chantypes.Packet{
-		Sequence:           pi.Sequence,
-		SourcePort:         pi.SourcePort,
-		SourceChannel:      pi.SourceChannel,
-		DestinationPort:    pi.DestPort,
-		DestinationChannel: pi.DestChannel,
-		Data:               pi.Data,
-		TimeoutHeight:      pi.TimeoutHeight,
-		TimeoutTimestamp:   pi.TimeoutTimestamp,
-	}
-}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -12,7 +12,6 @@ import (
 	chantypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/gogo/protobuf/proto"
-	tmtypes "github.com/tendermint/tendermint/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -49,7 +48,6 @@ type IBCHeader interface {
 	Height() uint64
 	ConsensusState() ibcexported.ConsensusState
 	// require conversion implementation for third party chains
-	ToCosmosValidatorSet() (*tmtypes.ValidatorSet, error)
 }
 
 // ClientState holds the current state of a client from a single chain's perspective

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -9,7 +9,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clienttypes "github.com/cosmos/ibc-go/v4/modules/core/02-client/types"
-	conntypes "github.com/cosmos/ibc-go/v4/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v4/modules/core/exported"
 	tmclient "github.com/cosmos/ibc-go/v4/modules/light-clients/07-tendermint/types"
@@ -77,42 +76,6 @@ func QueryClientStates(ctx context.Context,
 		}))
 	})
 	err = eg.Wait()
-	return
-}
-
-// QueryConnectionPair returns a pair of connection responses
-func QueryConnectionPair(ctx context.Context, src, dst *Chain, srcH, dstH int64) (srcConn, dstConn *conntypes.QueryConnectionResponse, err error) {
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		var err error
-		srcConn, err = src.ChainProvider.QueryConnection(egCtx, srcH, src.ConnectionID())
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		dstConn, err = dst.ChainProvider.QueryConnection(egCtx, dstH, dst.ConnectionID())
-		return err
-	})
-	err = eg.Wait()
-	return
-}
-
-// QueryChannelPair returns a pair of channel responses
-func QueryChannelPair(ctx context.Context, src, dst *Chain, srcH, dstH int64, srcChanID, dstChanID, srcPortID, dstPortID string) (srcChan, dstChan *chantypes.QueryChannelResponse, err error) {
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		var err error
-		srcChan, err = src.ChainProvider.QueryChannel(egCtx, srcH, srcChanID, srcPortID)
-		return err
-	})
-	eg.Go(func() error {
-		var err error
-		dstChan, err = dst.ChainProvider.QueryChannel(egCtx, dstH, dstChanID, dstPortID)
-		return err
-	})
-	if err = eg.Wait(); err != nil {
-		return nil, nil, err
-	}
 	return
 }
 

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
 )
 
 // RelayMsgs contains the msgs that need to be sent to both a src and dst chain
@@ -35,6 +36,36 @@ func (r *RelayMsgs) Ready() bool {
 		return false
 	}
 	return true
+}
+
+func (r *RelayMsgs) PrependMsgUpdateClient(
+	ctx context.Context,
+	src, dst *Chain,
+	srch, dsth int64,
+) error {
+	eg, egCtx := errgroup.WithContext(ctx) // New errgroup because previous egCtx is canceled at this point.
+	if len(r.Src) > 0 {
+		eg.Go(func() error {
+			srcMsgUpdateClient, err := MsgUpdateClient(egCtx, dst, src, dsth, srch)
+			if err != nil {
+				return err
+			}
+			r.Src = append([]provider.RelayerMessage{srcMsgUpdateClient}, r.Src...)
+			return nil
+		})
+	}
+	if len(r.Dst) > 0 {
+		eg.Go(func() error {
+			dstMsgUpdateClient, err := MsgUpdateClient(egCtx, src, dst, srch, dsth)
+			if err != nil {
+				return err
+			}
+			r.Dst = append([]provider.RelayerMessage{dstMsgUpdateClient}, r.Dst...)
+			return nil
+		})
+	}
+
+	return eg.Wait()
 }
 
 func (r *RelayMsgs) IsMaxTx(msgLen, txSize uint64) bool {

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -43,7 +43,7 @@ func (r *RelayMsgs) PrependMsgUpdateClient(
 	src, dst *Chain,
 	srch, dsth int64,
 ) error {
-	eg, egCtx := errgroup.WithContext(ctx) // New errgroup because previous egCtx is canceled at this point.
+	eg, egCtx := errgroup.WithContext(ctx)
 	if len(r.Src) > 0 {
 		eg.Go(func() error {
 			srcMsgUpdateClient, err := MsgUpdateClient(egCtx, dst, src, dsth, srch)


### PR DESCRIPTION
Consolidates the provider methods used for the flush packet/acks mechanisms, the event processor, and the legacy processor.

The bulk of this change is consolidating `QueryHeaderAtHeight`, `GetIBCUpdateHeader`, and `IBCHeaderAtHeight` into the method `QueryIBCHeader` (which is a rename of `IBCHeaderAtHeight`), and the propagation of that out into the Client methods such as creating, updating, and upgrading clients.