### PR TITLE
PacketInfo Packet method

### DIFF
--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	chantypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/provider"
 	"github.com/gogo/protobuf/proto"
 	lens "github.com/strangelove-ventures/lens/client"
@@ -226,17 +225,4 @@ func (cc *CosmosProvider) BlockTime(ctx context.Context, height int64) (int64, e
 		return 0, err
 	}
 	return resultBlock.Block.Time.UnixNano(), nil
-}
-
-func toCosmosPacket(pi provider.PacketInfo) chantypes.Packet {
-	return chantypes.Packet{
-		Sequence:           pi.Sequence,
-		SourcePort:         pi.SourcePort,
-		SourceChannel:      pi.SourceChannel,
-		DestinationPort:    pi.DestPort,
-		DestinationChannel: pi.DestChannel,
-		Data:               pi.Data,
-		TimeoutHeight:      pi.TimeoutHeight,
-		TimeoutTimestamp:   pi.TimeoutTimestamp,
-	}
 }

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -639,7 +639,7 @@ func (cc *CosmosProvider) MsgRecvPacket(
 		return nil, err
 	}
 	msg := &chantypes.MsgRecvPacket{
-		Packet:          toCosmosPacket(msgTransfer),
+		Packet:          msgTransfer.Packet(),
 		ProofCommitment: proof.Proof,
 		ProofHeight:     proof.ProofHeight,
 		Signer:          signer,
@@ -676,7 +676,7 @@ func (cc *CosmosProvider) MsgAcknowledgement(
 		return nil, err
 	}
 	msg := &chantypes.MsgAcknowledgement{
-		Packet:          toCosmosPacket(msgRecvPacket),
+		Packet:          msgRecvPacket.Packet(),
 		Acknowledgement: msgRecvPacket.Ack,
 		ProofAcked:      proof.Proof,
 		ProofHeight:     proof.ProofHeight,
@@ -729,7 +729,7 @@ func (cc *CosmosProvider) MsgTimeout(msgTransfer provider.PacketInfo, proof prov
 		return nil, err
 	}
 	assembled := &chantypes.MsgTimeout{
-		Packet:           toCosmosPacket(msgTransfer),
+		Packet:           msgTransfer.Packet(),
 		ProofUnreceived:  proof.Proof,
 		ProofHeight:      proof.ProofHeight,
 		NextSequenceRecv: msgTransfer.Sequence,
@@ -745,7 +745,7 @@ func (cc *CosmosProvider) MsgTimeoutOnClose(msgTransfer provider.PacketInfo, pro
 		return nil, err
 	}
 	assembled := &chantypes.MsgTimeoutOnClose{
-		Packet:           toCosmosPacket(msgTransfer),
+		Packet:           msgTransfer.Packet(),
 		ProofUnreceived:  proof.Proof,
 		ProofHeight:      proof.ProofHeight,
 		NextSequenceRecv: msgTransfer.Sequence,

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -78,6 +78,19 @@ type PacketInfo struct {
 	Ack              []byte
 }
 
+func (pi PacketInfo) Packet() chantypes.Packet {
+	return chantypes.Packet{
+		Sequence:           pi.Sequence,
+		SourcePort:         pi.SourcePort,
+		SourceChannel:      pi.SourceChannel,
+		DestinationPort:    pi.DestPort,
+		DestinationChannel: pi.DestChannel,
+		Data:               pi.Data,
+		TimeoutHeight:      pi.TimeoutHeight,
+		TimeoutTimestamp:   pi.TimeoutTimestamp,
+	}
+}
+
 // ConnectionInfo contains relevant properties from connection handshake messages
 // which may be necessary to construct the next message for the counterparty chain.
 type ConnectionInfo struct {


### PR DESCRIPTION
Moves helper for converting `PacketInfo` to `chantypes.Packet` as method on `PacketInfo`, since `chantypes.Packet` is an ibc-go type and this can be used outside of the cosmos module.