### PR TITLE
cosmos - begin and end block event parsing

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -328,7 +328,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		ibcHeaderCache[heightUint64] = latestHeader
 		ppChanged = true
 
-		blockMsgs := ccp.ibcMessagesFromBlock(blockRes.BeginBlockEvents, blockRes.EndBlockEvents, heightUint64)
+		blockMsgs := ccp.ibcMessagesFromBlockEvents(blockRes.BeginBlockEvents, blockRes.EndBlockEvents, heightUint64)
 		for _, m := range blockMsgs {
 			ccp.handleMessage(m, ibcMessagesCache)
 		}

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -328,6 +328,11 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		ibcHeaderCache[heightUint64] = latestHeader
 		ppChanged = true
 
+		blockMsgs := ccp.ibcMessagesFromBlock(blockRes.BeginBlockEvents, blockRes.EndBlockEvents, heightUint64)
+		for _, m := range blockMsgs {
+			ccp.handleMessage(m, ibcMessagesCache)
+		}
+
 		for _, tx := range blockRes.TxsResults {
 			if tx.Code != 0 {
 				// tx was not successful

--- a/relayer/chains/cosmos/event_parser.go
+++ b/relayer/chains/cosmos/event_parser.go
@@ -27,17 +27,20 @@ type ibcMessageInfo interface {
 	MarshalLogObject(enc zapcore.ObjectEncoder) error
 }
 
-func (ccp *CosmosChainProcessor) ibcMessagesFromBlock(beginBlockEvents, endBlockEvents []abci.Event, height uint64) (res []ibcMessage) {
+func (ccp *CosmosChainProcessor) ibcMessagesFromBlock(
+	beginBlockEvents, endBlockEvents []abci.Event,
+	height uint64,
+) (res []ibcMessage) {
 	beginBlockStringified := sdk.StringifyEvents(beginBlockEvents)
 	beginBlockMessage, err := parseIBCMessagesFromEvents(ccp.log, beginBlockStringified, height)
 	if err == nil {
-		res = append(res, *beginBlockMessage)
+		res = append(res, beginBlockMessage)
 	}
 
 	endBlockStringified := sdk.StringifyEvents(endBlockEvents)
 	endBlockMessage, err := parseIBCMessagesFromEvents(ccp.log, endBlockStringified, height)
 	if err == nil {
-		res = append(res, *endBlockMessage)
+		res = append(res, endBlockMessage)
 	}
 	return res
 }
@@ -58,13 +61,13 @@ func parseABCILogs(log *zap.Logger, logs sdk.ABCIMessageLogs, height uint64) (me
 		if err != nil {
 			continue
 		}
-		messages = append(messages, *m)
+		messages = append(messages, m)
 	}
 
 	return messages
 }
 
-func parseIBCMessagesFromEvents(log *zap.Logger, events sdk.StringEvents, height uint64) (*ibcMessage, error) {
+func parseIBCMessagesFromEvents(log *zap.Logger, events sdk.StringEvents, height uint64) (ibcMessage, error) {
 	var info ibcMessageInfo
 	var eventType string
 	var packetAccumulator *packetInfo
@@ -106,9 +109,9 @@ func parseIBCMessagesFromEvents(log *zap.Logger, events sdk.StringEvents, height
 
 	if info == nil {
 		// Not an IBC message, don't need to log here
-		return nil, fmt.Errorf("not an IBC message")
+		return ibcMessage{}, fmt.Errorf("not an IBC message")
 	}
-	return &ibcMessage{
+	return ibcMessage{
 		eventType: eventType,
 		info:      info,
 	}, nil


### PR DESCRIPTION
ICA pushes `send_packet` events through the begin block events, which were being missed.