### PR TITLE
Fix bug with tracking processing channel msgs

### DIFF
--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -1,6 +1,8 @@
 package cosmos
 
 import (
+	"fmt"
+
 	conntypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/processor"
@@ -78,6 +80,7 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(eventType string, ci provi
 		case chantypes.EventTypeChannelOpenAck, chantypes.EventTypeChannelOpenConfirm:
 			ccp.channelStateCache[channelKey] = true
 		case chantypes.EventTypeChannelCloseConfirm:
+			fmt.Println("in handleChannelMessage, ChannelCloseConfirm case hit")
 			for k := range ccp.channelStateCache {
 				if k.PortID == ci.PortID && k.ChannelID == ci.ChannelID {
 					ccp.channelStateCache[k] = false

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -1,8 +1,6 @@
 package cosmos
 
 import (
-	"fmt"
-
 	conntypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/processor"
@@ -80,7 +78,6 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(eventType string, ci provi
 		case chantypes.EventTypeChannelOpenAck, chantypes.EventTypeChannelOpenConfirm:
 			ccp.channelStateCache[channelKey] = true
 		case chantypes.EventTypeChannelCloseConfirm:
-			fmt.Println("in handleChannelMessage, ChannelCloseConfirm case hit")
 			for k := range ccp.channelStateCache {
 				if k.PortID == ci.PortID && k.ChannelID == ci.ChannelID {
 					ccp.channelStateCache[k] = false

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -494,7 +494,6 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		toDelete := make(map[string][]ChannelKey)
 		toDeleteCounterparty := make(map[string][]ChannelKey)
 		toDeletePacket := make(map[string][]uint64)
-		toDeleteCounterpartyPacket := make(map[string][]uint64)
 
 		counterpartyKey := channelKey.Counterparty()
 		switch eventType {
@@ -508,8 +507,8 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
 			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.MsgInitKey()}
 		case chantypes.EventTypeChannelCloseConfirm:
-			toDeleteCounterparty[chantypes.EventTypeChannelCloseInit] = []ChannelKey{counterpartyKey}
-			toDelete[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{channelKey}
+			toDeleteCounterparty[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{counterpartyKey}
+			toDelete[chantypes.EventTypeChannelCloseInit] = []ChannelKey{channelKey}
 
 			// Gather relevant send packet messages, for this channel key, that should be deleted if we
 			// are operating on an ordered channel.
@@ -539,7 +538,7 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		// delete in progress send for this specific message
 		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: {channelKey}})
 		pathEnd.messageCache.PacketFlow[channelKey].DeleteMessages(toDeletePacket)
-		counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
+		//counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
 
 		// delete all connection handshake retention history for this channel
 		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -525,11 +525,11 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 
 			// Gather relevant timeout messages, for this counterparty channel key, that should be deleted if we
 			// are operating on an ordered channel.
-			if messageCache, ok := counterparty.messageCache.PacketFlow[counterpartyKey]; ok {
+			if messageCache, ok := pathEnd.messageCache.PacketFlow[channelKey]; ok {
 				if seqCache, ok := messageCache[chantypes.EventTypeTimeoutPacket]; ok {
 					for seq, packetInfo := range seqCache {
 						if packetInfo.ChannelOrder == chantypes.ORDERED.String() {
-							toDeleteCounterpartyPacket[chantypes.EventTypeTimeoutPacket] = append(toDeleteCounterpartyPacket[chantypes.EventTypeTimeoutPacket], seq)
+							toDeletePacket[chantypes.EventTypeTimeoutPacket] = append(toDeletePacket[chantypes.EventTypeTimeoutPacket], seq)
 						}
 					}
 				}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -525,11 +525,11 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 
 			// Gather relevant timeout messages, for this counterparty channel key, that should be deleted if we
 			// are operating on an ordered channel.
-			if messageCache, ok := counterparty.messageCache.PacketFlow[channelKey]; ok {
+			if messageCache, ok := counterparty.messageCache.PacketFlow[counterpartyKey]; ok {
 				if seqCache, ok := messageCache[chantypes.EventTypeTimeoutPacket]; ok {
 					for seq, packetInfo := range seqCache {
 						if packetInfo.ChannelOrder == chantypes.ORDERED.String() {
-							toDeleteCounterpartyPacket[chantypes.EventTypeTimeoutPacket] = append(toDeletePacket[chantypes.EventTypeTimeoutPacket], seq)
+							toDeleteCounterpartyPacket[chantypes.EventTypeTimeoutPacket] = append(toDeleteCounterpartyPacket[chantypes.EventTypeTimeoutPacket], seq)
 						}
 					}
 				}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -127,11 +127,12 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache, 
 		newCmc := make(ChannelMessageCache)
 		for k, ci := range cmc {
 			if !pathEnd.isRelevantChannel(k.ChannelID) {
+				fmt.Printf("Observed irrelevant chan handshake msg, %v \n", eventType)
 				continue
 			}
 			// can complete channel handshakes on this client
 			// since PathProcessor holds reference to the counterparty chain pathEndRuntime.
-
+			fmt.Printf("Observed relevant chan handshake msg, %v \n", eventType)
 			if eventType == chantypes.EventTypeChannelOpenInit {
 				// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
 				for k := range pathEnd.connectionStateCache {
@@ -146,6 +147,7 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache, 
 		if len(newCmc) == 0 {
 			continue
 		}
+
 		channelHandshakeMessages[eventType] = newCmc
 	}
 	pathEnd.messageCache.ChannelHandshake.Merge(channelHandshakeMessages)

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -507,6 +507,9 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
 			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.MsgInitKey()}
 		case chantypes.EventTypeChannelCloseConfirm:
+			toDeleteCounterparty[chantypes.EventTypeChannelCloseInit] = []ChannelKey{counterpartyKey}
+			toDelete[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{channelKey}
+
 			// Gather relevant send packet messages, for this channel key, that should be deleted if we
 			// are operating on an ordered channel.
 			if messageCache, ok := pathEnd.messageCache.PacketFlow[channelKey]; ok {
@@ -536,6 +539,10 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: {channelKey}})
 		pathEnd.messageCache.PacketFlow[channelKey].DeleteMessages(toDeletePacket)
 		//counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
+
+		// delete all connection handshake retention history for this channel
+		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)
+		counterparty.messageCache.ChannelHandshake.DeleteMessages(toDeleteCounterparty)
 
 		return false
 	}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -536,6 +536,13 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: {channelKey}})
 		pathEnd.messageCache.PacketFlow[channelKey].DeleteMessages(toDeletePacket)
 		//counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
+<<<<<<< HEAD
+=======
+
+		// delete all connection handshake retention history for this channel
+		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)
+		counterparty.messageCache.ChannelHandshake.DeleteMessages(toDeleteCounterparty)
+>>>>>>> 15fed43 (reverse channel close msg purging)
 
 		return false
 	}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"fmt"
 
 	conntypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
@@ -127,12 +126,10 @@ func (pathEnd *pathEndRuntime) mergeMessageCache(messageCache IBCMessagesCache, 
 		newCmc := make(ChannelMessageCache)
 		for k, ci := range cmc {
 			if !pathEnd.isRelevantChannel(k.ChannelID) {
-				fmt.Printf("Observed irrelevant chan handshake msg, %v \n", eventType)
 				continue
 			}
 			// can complete channel handshakes on this client
 			// since PathProcessor holds reference to the counterparty chain pathEndRuntime.
-			fmt.Printf("Observed relevant chan handshake msg, %v \n", eventType)
 			if eventType == chantypes.EventTypeChannelOpenInit {
 				// CounterpartyConnectionID is needed to construct MsgChannelOpenTry.
 				for k := range pathEnd.connectionStateCache {
@@ -511,7 +508,6 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
 			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.MsgInitKey()}
 		case chantypes.EventTypeChannelCloseConfirm:
-			fmt.Println("shouldSendChannelMessage: ChannelCloseConfirm case hit on max retries")
 			toDeleteCounterparty[chantypes.EventTypeChannelCloseInit] = []ChannelKey{counterpartyKey}
 			toDelete[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{channelKey}
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 
 	conntypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	chantypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
@@ -508,6 +509,7 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
 			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.MsgInitKey()}
 		case chantypes.EventTypeChannelCloseConfirm:
+			fmt.Println("shouldSendChannelMessage: ChannelCloseConfirm case hit on max retries")
 			toDeleteCounterparty[chantypes.EventTypeChannelCloseInit] = []ChannelKey{counterpartyKey}
 			toDelete[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{channelKey}
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -536,13 +536,6 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: {channelKey}})
 		pathEnd.messageCache.PacketFlow[channelKey].DeleteMessages(toDeletePacket)
 		//counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
-<<<<<<< HEAD
-=======
-
-		// delete all connection handshake retention history for this channel
-		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)
-		counterparty.messageCache.ChannelHandshake.DeleteMessages(toDeleteCounterparty)
->>>>>>> 15fed43 (reverse channel close msg purging)
 
 		return false
 	}

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -507,9 +507,6 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 			toDelete[chantypes.EventTypeChannelOpenTry] = []ChannelKey{channelKey}
 			toDeleteCounterparty[chantypes.EventTypeChannelOpenInit] = []ChannelKey{counterpartyKey.MsgInitKey()}
 		case chantypes.EventTypeChannelCloseConfirm:
-			toDeleteCounterparty[chantypes.EventTypeChannelCloseConfirm] = []ChannelKey{counterpartyKey}
-			toDelete[chantypes.EventTypeChannelCloseInit] = []ChannelKey{channelKey}
-
 			// Gather relevant send packet messages, for this channel key, that should be deleted if we
 			// are operating on an ordered channel.
 			if messageCache, ok := pathEnd.messageCache.PacketFlow[channelKey]; ok {
@@ -539,10 +536,6 @@ func (pathEnd *pathEndRuntime) shouldSendChannelMessage(message channelIBCMessag
 		pathEnd.channelProcessing.deleteMessages(map[string][]ChannelKey{eventType: {channelKey}})
 		pathEnd.messageCache.PacketFlow[channelKey].DeleteMessages(toDeletePacket)
 		//counterparty.messageCache.PacketFlow[counterpartyKey].DeleteMessages(toDeleteCounterpartyPacket)
-
-		// delete all connection handshake retention history for this channel
-		pathEnd.messageCache.ChannelHandshake.DeleteMessages(toDelete)
-		counterparty.messageCache.ChannelHandshake.DeleteMessages(toDeleteCounterparty)
 
 		return false
 	}

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -138,10 +138,7 @@ func (pp *PathProcessor) channelPairs() []channelPair {
 	}
 	pairs := make([]channelPair, len(channels))
 	i := 0
-	for k, open := range channels {
-		if !open {
-			continue
-		}
+	for k, _ := range channels {
 		pairs[i] = channelPair{
 			pathEnd1ChannelKey: k,
 			pathEnd2ChannelKey: k.Counterparty(),

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -597,9 +597,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		}
 
 		pathEnd1ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages)
-		fmt.Printf("Path End 1 Process: %+v \n", pathEnd1ProcessRes[i].DstChannelMessage)
 		pathEnd2ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd2PacketFlowMessages)
-		fmt.Printf("Path End 2 Process: %+v \n", pathEnd2ProcessRes[i].DstChannelMessage)
 	}
 
 	// concatenate applicable messages for pathend

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -176,7 +176,13 @@ MsgTransferLoop:
 		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], timeoutOnCloseSeq)
 		res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose], timeoutOnCloseSeq)
 	}
-	fmt.Printf("%+v", pathEndPacketFlowMessages)
+
+	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgTransfer)
+	fmt.Printf("%+v", pathEndPacketFlowMessages.DstMsgRecvPacket)
+	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgAcknowledgement)
+	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgTimeout)
+	fmt.Printf("%+v", pathEndPacketFlowMessages.DstMsgChannelCloseConfirm)
+
 	return res
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -74,7 +74,7 @@ MsgTransferLoop:
 						}
 
 						if pathEndPacketFlowMessages.Src.shouldSendChannelMessage(closeChan, pathEndPacketFlowMessages.Dst) {
-							fmt.Println("Should send Channel Close Msg")
+							fmt.Println("Should send MsgChannelCloseConfirm")
 							res.DstChannelMessage = append(res.DstChannelMessage, closeChan)
 						}
 					} else {
@@ -895,6 +895,7 @@ func (pp *PathProcessor) assembleChannelMessage(
 		// don't need proof for this message
 		assembleMessage = dst.chainProvider.MsgChannelCloseInit
 	case chantypes.EventTypeChannelCloseConfirm:
+		fmt.Println("assembleChannelMessage: MsgChannelCloseConfirm has been assembled")
 		chanProof = src.chainProvider.ChannelProof
 		assembleMessage = dst.chainProvider.MsgChannelCloseConfirm
 	default:

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -597,7 +597,9 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		}
 
 		pathEnd1ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages)
+		fmt.Printf("Path End 1 Process: %+v \n", pathEnd1ProcessRes[i].DstChannelMessage)
 		pathEnd2ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd2PacketFlowMessages)
+		fmt.Printf("Path End 2 Process: %+v \n", pathEnd2ProcessRes[i].DstChannelMessage)
 	}
 
 	// concatenate applicable messages for pathend

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -74,7 +74,7 @@ MsgTransferLoop:
 						}
 
 						if pathEndPacketFlowMessages.Src.shouldSendChannelMessage(closeChan, pathEndPacketFlowMessages.Dst) {
-							fmt.Println("Sending Channel Close Msg")
+							fmt.Println("Should send Channel Close Msg")
 							res.DstChannelMessage = append(res.DstChannelMessage, closeChan)
 						}
 					} else {
@@ -597,7 +597,13 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		}
 
 		pathEnd1ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd1PacketFlowMessages)
+		if pathEnd1ProcessRes[i].DstChannelMessage != nil {
+			fmt.Printf("processLatestMessages: we have dst chan msgs on pe1 %v \n", pathEnd1ProcessRes[i].DstChannelMessage)
+		}
 		pathEnd2ProcessRes[i] = pp.getUnrelayedPacketsAndAcksAndToDelete(ctx, pathEnd2PacketFlowMessages)
+		if pathEnd2ProcessRes[i].DstChannelMessage != nil {
+			fmt.Printf("processLatestMessages: we have dst chan msgs on pe2 %v \n", pathEnd2ProcessRes[i].DstChannelMessage)
+		}
 	}
 
 	// concatenate applicable messages for pathend

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -180,12 +180,6 @@ MsgTransferLoop:
 		res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose], timeoutOnCloseSeq)
 	}
 
-	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgTransfer)
-	fmt.Printf("%+v", pathEndPacketFlowMessages.DstMsgRecvPacket)
-	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgAcknowledgement)
-	fmt.Printf("%+v", pathEndPacketFlowMessages.SrcMsgTimeout)
-	fmt.Printf("%+v", pathEndPacketFlowMessages.DstMsgChannelCloseConfirm)
-
 	return res
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -176,6 +176,7 @@ MsgTransferLoop:
 		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], timeoutOnCloseSeq)
 		res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose] = append(res.ToDeleteSrc[chantypes.EventTypeTimeoutPacketOnClose], timeoutOnCloseSeq)
 	}
+	fmt.Printf("%+v", pathEndPacketFlowMessages)
 	return res
 }
 

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -58,6 +58,7 @@ MsgTransferLoop:
 				if msgTimeout.ChannelOrder == chantypes.ORDERED.String() {
 					// For ordered channel packets, flow is not done until channel-close-confirm is observed.
 					if pathEndPacketFlowMessages.DstMsgChannelCloseConfirm == nil {
+						fmt.Println("DstMsgChannelCloseConfirm was nil.")
 						// have not observed a channel-close-confirm yet for this channel, send it if ready.
 						// will come back through here next block if not yet ready.
 						closeChan := channelIBCMessage{
@@ -73,9 +74,11 @@ MsgTransferLoop:
 						}
 
 						if pathEndPacketFlowMessages.Src.shouldSendChannelMessage(closeChan, pathEndPacketFlowMessages.Dst) {
+							fmt.Println("Sending Channel Close Msg")
 							res.DstChannelMessage = append(res.DstChannelMessage, closeChan)
 						}
 					} else {
+						fmt.Println("Channel Close Confirm was observed, purging cache retention of packet msgs")
 						// ordered channel, and we have a channel close confirm, so packet-flow and channel-close-flow is complete.
 						// remove all retention of this sequence number and this channel-close-confirm.
 						res.ToDeleteDstChannel[chantypes.EventTypeChannelCloseConfirm] = append(res.ToDeleteDstChannel[chantypes.EventTypeChannelCloseConfirm], pathEndPacketFlowMessages.ChannelKey.Counterparty())

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -165,6 +165,7 @@ MsgTransferLoop:
 	for timeoutSeq, msgTimeout := range pathEndPacketFlowMessages.SrcMsgTimeout {
 		if msgTimeout.ChannelOrder == chantypes.ORDERED.String() {
 			if pathEndPacketFlowMessages.DstMsgChannelCloseConfirm != nil {
+				fmt.Println("Packet lifecycle complete, purging cache on MsgChannelCloseConfirm")
 				// For ordered channel packets, flow is not done until channel-close-confirm is observed.
 				res.ToDeleteDstChannel[chantypes.EventTypeChannelCloseConfirm] = append(res.ToDeleteDstChannel[chantypes.EventTypeChannelCloseConfirm], pathEndPacketFlowMessages.ChannelKey.Counterparty())
 				res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], timeoutSeq)
@@ -560,12 +561,14 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 
 		if pathEnd1ChanCloseConfirmMsgs, ok := pp.pathEnd1.messageCache.ChannelHandshake[chantypes.EventTypeChannelCloseConfirm]; ok {
 			if pathEnd1ChannelCloseConfirmMsg, ok := pathEnd1ChanCloseConfirmMsgs[pair.pathEnd1ChannelKey]; ok {
+				fmt.Println("Channel Close Confirm ready to send on path end 1")
 				pathEnd1ChannelCloseConfirm = &pathEnd1ChannelCloseConfirmMsg
 			}
 		}
 
 		if pathEnd2ChanCloseConfirmMsgs, ok := pp.pathEnd2.messageCache.ChannelHandshake[chantypes.EventTypeChannelCloseConfirm]; ok {
 			if pathEnd2ChannelCloseConfirmMsg, ok := pathEnd2ChanCloseConfirmMsgs[pair.pathEnd2ChannelKey]; ok {
+				fmt.Println("Channel Close Confirm ready to send on path end 2")
 				pathEnd2ChannelCloseConfirm = &pathEnd2ChannelCloseConfirmMsg
 			}
 		}


### PR DESCRIPTION
There was a bug in the relayer regarding how we handled `MsgChannelCloseConfirm` where msgs were not being tracked properly for in process channel msgs which resulted in the `MsgChannelCloseConfirm` being sent more than once.

Shout out to @agouin for help on this one!!