### PR TITLE
Small Unbonding Period Leads to 0 Trusting Period

### DIFF
--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -189,7 +189,12 @@ func (cc *CosmosProvider) TrustingPeriod(ctx context.Context) (time.Duration, er
 	tp := res.UnbondingTime / 100 * 85
 
 	// And we only want the trusting period to be whole hours.
-	return tp.Truncate(time.Hour), nil
+	// But avoid rounding if the time is less than 1 hour
+	//  (otherwise the trusting period will go to 0)
+	if tp > time.Hour {
+		tp = tp.Truncate(time.Hour)
+	}
+	return tp, nil
 }
 
 // Sprint returns the json representation of the specified proto message.


### PR DESCRIPTION
* If there's a small unbonding period (often the case during local development), the trusting period will get truncated down to 0 which will cause an error when trying to link
* The solution is to ensure the trusting period is greater than 1 hour before truncating