### PR TITLE
ignore recv packet with empty ack bytes

### DIFF
--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -34,6 +34,11 @@ func (ccp *CosmosChainProcessor) handlePacketMessage(eventType string, pi provid
 		return
 	}
 
+	if eventType == chantypes.EventTypeRecvPacket && len(pi.Ack) == 0 {
+		// ignore recv packet with empty ack bytes
+		return
+	}
+
 	if !c.PacketFlow.ShouldRetainSequence(ccp.pathProcessors, k, ccp.chainProvider.ChainId(), eventType, pi.Sequence) {
 		ccp.log.Debug("Not retaining packet message",
 			zap.String("event_type", eventType),


### PR DESCRIPTION
Multiple `recv_packet` events can be emitted for a specific packet with only a single accompanying `write_acknowledgement`. This will ignore constructed `packetInfo` that have empty ack bytes, so the only one that will be acted upon is the one that has the accompanying `write_acknowledgement`, which is the first successful handled `MsgRecvPacket` tx.