### PR TITLE
Respect the `override` flag upon client creation

### DIFF
--- a/ibctest/go.sum
+++ b/ibctest/go.sum
@@ -1164,6 +1164,7 @@ github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.7.11/go.mod h1:gX+MP7DWMKJmNa1HfMozK+u04hQd3na9i0hyqf3/dOI=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
@@ -1470,8 +1471,6 @@ github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8L
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/strangelove-ventures/go-subkey v1.0.7 h1:cOP/Lajg3uxV/tvspu0m6+0Cu+DJgygkEAbx/s+f35I=
 github.com/strangelove-ventures/go-subkey v1.0.7/go.mod h1:E34izOIEm+sZ1YmYawYRquqBQWeZBjVB4pF7bMuhc1c=
-github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916035922-bf1eb3ad8c6e h1:lScbLD3JBwCUaNDcfjZ69tr02LYsxP8L7YHXcOIlUW0=
-github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916035922-bf1eb3ad8c6e/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916051004-abcda680ee7d h1:9f67V5dmwBcbQGZ7z5jmhjxPGkcGUJ6wmwHvXBgzK04=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916051004-abcda680ee7d/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/lens v0.5.2-0.20220822201013-1e7ffd450f20 h1:nYM1gFMJHbV3aYdiNCCS5jfBe/uMkORHwg8DSWZ5MRA=
@@ -2352,8 +2351,8 @@ gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=

--- a/ibctest/relayer_override_test.go
+++ b/ibctest/relayer_override_test.go
@@ -1,0 +1,179 @@
+package ibctest_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cosmos/relayer/v2/cmd"
+	relayeribctest "github.com/cosmos/relayer/v2/ibctest"
+	"github.com/strangelove-ventures/ibctest/v5"
+	"github.com/strangelove-ventures/ibctest/v5/chain/cosmos"
+	"github.com/strangelove-ventures/ibctest/v5/ibc"
+	ibctestrelayer "github.com/strangelove-ventures/ibctest/v5/relayer"
+	ibctestrly "github.com/strangelove-ventures/ibctest/v5/relayer/rly"
+	"github.com/strangelove-ventures/ibctest/v5/test"
+	"github.com/strangelove-ventures/ibctest/v5/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestClientOverrideFlag(t *testing.T) {
+	relayeribctest.BuildRelayerImage(t)
+
+	client, network := ibctest.DockerSetup(t)
+	r := ibctest.NewBuiltinRelayerFactory(
+		ibc.CosmosRly,
+		zaptest.NewLogger(t),
+		ibctestrelayer.CustomDockerImage(relayeribctest.RelayerImageName, "latest", "100:1000"),
+		ibctestrelayer.ImagePull(false),
+	).Build(t, client, network)
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+
+	ctx := context.Background()
+
+	// Define chains involved in test
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{
+			Name:      "gaia",
+			ChainName: "gaia",
+			Version:   "v7.0.3",
+		},
+		{
+			Name:      "osmosis",
+			ChainName: "osmosis",
+			Version:   "v11.0.1",
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	gaia, osmosis := chains[0].(*cosmos.CosmosChain), chains[1].(*cosmos.CosmosChain)
+
+	// Build the network; spin up the chains and configure the relayer
+	const pathGaiaOsmosis = "gaia-osmosis"
+	const relayerName = "relayer"
+
+	ic := ibctest.NewInterchain().
+		AddChain(gaia).
+		AddChain(osmosis).
+		AddRelayer(r, relayerName).
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  osmosis,
+			Relayer: r,
+			Path:    pathGaiaOsmosis,
+		})
+
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+
+		SkipPathCreation: true,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	// Start the relayer
+	err = r.StartRelayer(ctx, eRep, pathGaiaOsmosis)
+	require.NoError(t, err)
+
+	t.Cleanup(
+		func() {
+			err := r.StopRelayer(ctx, eRep)
+			if err != nil {
+				t.Logf("an error occured while stopping the relayer: %s", err)
+			}
+		},
+	)
+
+	// Wait a few blocks for the relayer to start.
+	err = test.WaitForBlocks(ctx, 2, gaia, osmosis)
+	require.NoError(t, err)
+
+	// Generate a new IBC path
+	err = r.GeneratePath(ctx, eRep, gaia.Config().ChainID, osmosis.Config().ChainID, pathGaiaOsmosis)
+	require.NoError(t, err)
+
+	// Create clients and wait a few blocks for the clients to be created
+	err = r.CreateClients(ctx, eRep, pathGaiaOsmosis, ibc.DefaultClientOpts())
+	require.NoError(t, err)
+
+	err = test.WaitForBlocks(ctx, 5, gaia, osmosis)
+	require.NoError(t, err)
+
+	// Dump relayer config and verify client IDs are written to path config
+	rly := r.(*ibctestrly.CosmosRelayer)
+
+	showConfig := []string{"rly", "config", "show", "-j", "--home", rly.HomeDir()}
+	res := r.Exec(ctx, eRep, showConfig, nil)
+	require.NoError(t, res.Err)
+
+	config := &cmd.Config{}
+	err = json.Unmarshal(res.Stdout, config)
+	require.NoError(t, err)
+
+	rlyPath, err := config.Paths.Get(pathGaiaOsmosis)
+	require.NoError(t, err)
+
+	srcClientID := rlyPath.Src.ClientID
+	dstClientID := rlyPath.Dst.ClientID
+
+	require.NotEmpty(t, srcClientID)
+	require.NotEmpty(t, dstClientID)
+
+	// Create clients again without override and verify it was a noop
+	err = r.CreateClients(ctx, eRep, pathGaiaOsmosis, ibc.DefaultClientOpts())
+	require.NoError(t, err)
+
+	err = test.WaitForBlocks(ctx, 2, gaia, osmosis)
+	require.NoError(t, err)
+
+	res = r.Exec(ctx, eRep, showConfig, nil)
+	require.NoError(t, res.Err)
+
+	err = json.Unmarshal(res.Stdout, config)
+	require.NoError(t, err)
+
+	rlyPath, err = config.Paths.Get(pathGaiaOsmosis)
+	require.NoError(t, err)
+
+	newSrcClientID := rlyPath.Src.ClientID
+	newDstClientID := rlyPath.Dst.ClientID
+
+	require.NotEmpty(t, newSrcClientID)
+	require.NotEmpty(t, newDstClientID)
+	require.Equal(t, srcClientID, newSrcClientID)
+	require.Equal(t, dstClientID, newDstClientID)
+
+	// Create clients again with override and verify new client IDs are generated and added to config
+	clientsOverride := []string{"rly", "tx", "clients", pathGaiaOsmosis, "--override", "--home", rly.HomeDir()}
+	res = r.Exec(ctx, eRep, clientsOverride, nil)
+	require.NoError(t, res.Err)
+
+	err = test.WaitForBlocks(ctx, 5, gaia, osmosis)
+	require.NoError(t, err)
+
+	res = r.Exec(ctx, eRep, showConfig, nil)
+	require.NoError(t, res.Err)
+
+	err = json.Unmarshal(res.Stdout, config)
+	require.NoError(t, err)
+
+	rlyPath, err = config.Paths.Get(pathGaiaOsmosis)
+	require.NoError(t, err)
+
+	newSrcClientID = rlyPath.Src.ClientID
+	newDstClientID = rlyPath.Dst.ClientID
+
+	require.NotEmpty(t, newSrcClientID)
+	require.NotEmpty(t, newDstClientID)
+	require.NotEqual(t, srcClientID, newSrcClientID)
+	require.NotEqual(t, dstClientID, newDstClientID)
+}

--- a/ibctest/relayer_override_test.go
+++ b/ibctest/relayer_override_test.go
@@ -18,6 +18,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+// TestClientOverrideFlag tests that the --override flag is being respected when attempting to create new light clients.
+// If the override flag is not present, the relayer should attempt to look for an existing light client if there
+// is a client-id present in the relative path config. If the override flag is present, the relayer should always
+// attempt to create a new light client and then overwrite the config file if successful.
 func TestClientOverrideFlag(t *testing.T) {
 	relayeribctest.BuildRelayerImage(t)
 


### PR DESCRIPTION
Previously we were not checking if the `--override` flag was set and so if a user had an existing client configured for a particular path and then attempted to create a new client it would always return immediately after the call to `QueryClientStateResponse`

Now if a user has specified `--override` it will attempt to create a new client regardless of if there is already a client configured. The new client ID will be written to the config file upon completion.