### PR TITLE
fix counterparty path filter

### DIFF
--- a/.github/workflows/ibctest.yml
+++ b/.github/workflows/ibctest.yml
@@ -70,3 +70,24 @@ jobs:
 
       - name: ibctest
         run: make ibctest-multiple
+  path-filter:
+    runs-on: self-hosted
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
+        id: go
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: ibctest
+        run: make ibctest-path-filter

--- a/.github/workflows/ibctest.yml
+++ b/.github/workflows/ibctest.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: ibctest
         run: make ibctest-multiple
-  path-filter-allow:
+  path-filter:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.18
@@ -90,25 +90,4 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: ibctest
-        run: make ibctest-path-filter-allow
-  path-filter-deny:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.18
-        id: go
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: ibctest
-        run: make ibctest-path-filter-deny
+        run: make ibctest-path-filter

--- a/.github/workflows/ibctest.yml
+++ b/.github/workflows/ibctest.yml
@@ -70,8 +70,8 @@ jobs:
 
       - name: ibctest
         run: make ibctest-multiple
-  path-filter:
-    runs-on: self-hosted
+  path-filter-allow:
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.18
         uses: actions/setup-go@v1
@@ -90,4 +90,25 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: ibctest
-        run: make ibctest-path-filter
+        run: make ibctest-path-filter-allow
+  path-filter-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
+        id: go
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: ibctest
+        run: make ibctest-path-filter-deny

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ ibctest-legacy:
 ibctest-multiple:
 	cd ibctest && go test -race -v -run TestRelayerMultiplePathsSingleProcess .
 
+ibctest-path-filter:
+	cd ibctest && go test -race -v -run TestPathFilter .
+
 coverage:
 	@echo "viewing test coverage..."
 	@go tool cover --html=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,8 @@ ibctest-legacy:
 ibctest-multiple:
 	cd ibctest && go test -race -v -run TestRelayerMultiplePathsSingleProcess .
 
-ibctest-path-filter-allow:
-	cd ibctest && go test -race -v -run TestPathFilterAllow .
-
-ibctest-path-filter-deny:
-	cd ibctest && go test -race -v -run TestPathFilterDeny .
+ibctest-path-filter:
+	cd ibctest && go test -race -v -run TestPathFilter .
 
 coverage:
 	@echo "viewing test coverage..."

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,11 @@ ibctest-legacy:
 ibctest-multiple:
 	cd ibctest && go test -race -v -run TestRelayerMultiplePathsSingleProcess .
 
-ibctest-path-filter:
-	cd ibctest && go test -race -v -run TestPathFilter .
+ibctest-path-filter-allow:
+	cd ibctest && go test -race -v -run TestPathFilterAllow .
+
+ibctest-path-filter-deny:
+	cd ibctest && go test -race -v -run TestPathFilterDeny .
 
 coverage:
 	@echo "viewing test coverage..."

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -45,6 +45,8 @@ const (
 	flagProcessor               = "processor"
 	flagInitialBlockHistory     = "block-history"
 	flagMemo                    = "memo"
+	flagFilterRule              = "filter-rule"
+	flagFilterChannels          = "filter-channels"
 )
 
 const (
@@ -147,6 +149,18 @@ func jsonFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 func fileFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(flagFile, "f", "", "fetch json data from specified file")
 	if err := v.BindPFlag(flagFile, cmd.Flags().Lookup(flagFile)); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func pathFilterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().String(flagFilterRule, "", `filter rule ("allowlist", "denylist", or "" for no filtering)`)
+	if err := v.BindPFlag(flagFilterRule, cmd.Flags().Lookup(flagFilterRule)); err != nil {
+		panic(err)
+	}
+	cmd.Flags().String(flagFilterChannels, "", "channels from source chain perspective to filter")
+	if err := v.BindPFlag(flagFilterRule, cmd.Flags().Lookup(flagFilterRule)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cosmos/relayer/v2/relayer"
+	"github.com/cosmos/relayer/v2/relayer/processor"
 	"github.com/google/go-github/v43/github"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -277,6 +278,9 @@ $ %s paths update demo-path --filter-rule denylist --filter-channels channel-0,c
 			filterRule, err := cmd.Flags().GetString(flagFilterRule)
 			if err != nil {
 				return err
+			}
+			if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
+				return fmt.Errorf(`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`, filterRule, processor.RuleAllowList, processor.RuleDenyList)
 			}
 
 			filterChannels, err := cmd.Flags().GetString(flagFilterChannels)

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -291,7 +291,7 @@ $ %s paths update demo-path --filter-rule denylist --filter-channels channel-0,c
 			var channelList []string
 
 			if filterChannels != "" {
-				channelList = append(channelList, strings.Split(filterChannels, ",")...)
+				channelList = strings.Split(filterChannels, ",")
 			}
 
 			p := a.Config.Paths.MustGet(name)

--- a/ibctest/go.mod
+++ b/ibctest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cosmos/relayer/v2 v2.0.0
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/moby/moby v20.10.17+incompatible
-	github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220919160614-77d0523e3378
+	github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.22.0
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29

--- a/ibctest/go.mod
+++ b/ibctest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cosmos/relayer/v2 v2.0.0
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/moby/moby v20.10.17+incompatible
-	github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed
+	github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922235050-6baac8c666ea
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.22.0
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29

--- a/ibctest/go.sum
+++ b/ibctest/go.sum
@@ -1480,6 +1480,8 @@ github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922165058-44b91229244d h1
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922165058-44b91229244d/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed h1:3/i6HIkTZEw7NYKXKFoyuxw6+JfXCjRsLDRLIqZnsGg=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922235050-6baac8c666ea h1:jQvO399MoK7+NLigd7Vj7lGsa1Y7LWt8uTtbYGPTyYo=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922235050-6baac8c666ea/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/lens v0.5.2-0.20220822201013-1e7ffd450f20 h1:nYM1gFMJHbV3aYdiNCCS5jfBe/uMkORHwg8DSWZ5MRA=
 github.com/strangelove-ventures/lens v0.5.2-0.20220822201013-1e7ffd450f20/go.mod h1:qrmVarKca7XLvuTEkR9jO50FrOprxQxukbmB7fpVrVo=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/ibctest/go.sum
+++ b/ibctest/go.sum
@@ -1476,6 +1476,10 @@ github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916051004-abcda680ee7d h1
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220916051004-abcda680ee7d/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220919160614-77d0523e3378 h1:xlSrlegNKmohCgDUdsXsCU2NZkQbl+/DNOjTcG5eVII=
 github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220919160614-77d0523e3378/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922165058-44b91229244d h1:MoeKypPrHDOPk2FuBsN5mMwoqqXmx+pCPRj5XrLCX+I=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922165058-44b91229244d/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed h1:3/i6HIkTZEw7NYKXKFoyuxw6+JfXCjRsLDRLIqZnsGg=
+github.com/strangelove-ventures/ibctest/v5 v5.0.0-20220922201145-4874b4d2e6ed/go.mod h1:C284t8FhFrldr1BfQHDLsAMMzAWczTgeruePi7M6TmA=
 github.com/strangelove-ventures/lens v0.5.2-0.20220822201013-1e7ffd450f20 h1:nYM1gFMJHbV3aYdiNCCS5jfBe/uMkORHwg8DSWZ5MRA=
 github.com/strangelove-ventures/lens v0.5.2-0.20220822201013-1e7ffd450f20/go.mod h1:qrmVarKca7XLvuTEkR9jO50FrOprxQxukbmB7fpVrVo=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/ibctest/path_filter_test.go
+++ b/ibctest/path_filter_test.go
@@ -20,6 +20,7 @@ import (
 
 // TestPathFilterAllow tests the channel allowlist
 func TestPathFilterAllow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nv := 1
@@ -157,6 +158,7 @@ func TestPathFilterAllow(t *testing.T) {
 
 // TestPathFilterDeny tests the channel denylist
 func TestPathFilterDeny(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nv := 1

--- a/ibctest/path_filter_test.go
+++ b/ibctest/path_filter_test.go
@@ -1,0 +1,157 @@
+package ibctest_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	transfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
+	relayeribctest "github.com/cosmos/relayer/v2/ibctest"
+	"github.com/cosmos/relayer/v2/relayer"
+	ibctest "github.com/strangelove-ventures/ibctest/v5"
+	"github.com/strangelove-ventures/ibctest/v5/ibc"
+	"github.com/strangelove-ventures/ibctest/v5/test"
+	"github.com/strangelove-ventures/ibctest/v5/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestPathFilter tests the channel allowlist
+func TestPathFilter(t *testing.T) {
+	ctx := context.Background()
+
+	// Chain Factory
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", Version: "v7.0.3"},
+		{Name: "osmosis", Version: "v11.0.1"},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+	gaia, osmosis := chains[0], chains[1]
+
+	// Relayer Factory
+	client, network := ibctest.DockerSetup(t)
+
+	r := relayeribctest.NewRelayerFactory(relayeribctest.RelayerConfig{
+		Processor:           relayer.ProcessorEvents,
+		InitialBlockHistory: 100,
+	}).Build(
+		t, client, network)
+
+	// Prep Interchain
+	const ibcPath = "gaia-osmosis"
+	ic := ibctest.NewInterchain().
+		AddChain(gaia).
+		AddChain(osmosis).
+		AddRelayer(r, "relayer").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  osmosis,
+			Relayer: r,
+			Path:    ibcPath,
+		})
+
+	// Log location
+	f, err := ibctest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
+	require.NoError(t, err)
+	// Reporter/logs
+	rep := testreporter.NewReporter(f)
+	eRep := rep.RelayerExecReporter(t)
+
+	// Build interchain
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+
+		SkipPathCreation: false,
+	}))
+
+	// Get Channel ID
+	gaiaChans, err := r.GetChannels(ctx, eRep, gaia.Config().ChainID)
+	require.NoError(t, err)
+	gaiaChannel := gaiaChans[0]
+	osmosisChannel := gaiaChans[0].Counterparty
+
+	r.UpdatePath(ctx, eRep, ibcPath, ibc.ChannelFilter{
+		Rule:        "allowlist",
+		ChannelList: []string{gaiaChannel.ChannelID},
+	})
+
+	// Create and Fund User Wallets
+	fundAmount := int64(10_000_000)
+	users := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(fundAmount), gaia, osmosis)
+
+	gaiaUser, osmosisUser := users[0], users[1]
+
+	r.StartRelayer(ctx, eRep, ibcPath)
+
+	// Send Transaction
+	amountToSend := int64(1_000_000)
+	gaiaDstAddress := gaiaUser.Bech32Address(osmosis.Config().Bech32Prefix)
+	osmosisDstAddress := osmosisUser.Bech32Address(gaia.Config().Bech32Prefix)
+
+	gaiaHeight, err := gaia.Height(ctx)
+	require.NoError(t, err)
+
+	osmosisHeight, err := osmosis.Height(ctx)
+	require.NoError(t, err)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		tx, err := gaia.SendIBCTransfer(ctx, gaiaChannel.ChannelID, gaiaUser.KeyName, ibc.WalletAmount{
+			Address: gaiaDstAddress,
+			Denom:   gaia.Config().Denom,
+			Amount:  amountToSend,
+		},
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		if err := tx.Validate(); err != nil {
+			return err
+		}
+		_, err = test.PollForAck(ctx, gaia, gaiaHeight, gaiaHeight+10, tx.Packet)
+		return err
+	})
+
+	eg.Go(func() error {
+		tx, err := osmosis.SendIBCTransfer(ctx, osmosisChannel.ChannelID, osmosisUser.KeyName, ibc.WalletAmount{
+			Address: osmosisDstAddress,
+			Denom:   osmosis.Config().Denom,
+			Amount:  amountToSend,
+		},
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		if err := tx.Validate(); err != nil {
+			return err
+		}
+		_, err = test.PollForAck(ctx, osmosis, osmosisHeight, osmosisHeight+10, tx.Packet)
+		return err
+	})
+	require.NoError(t, eg.Wait())
+
+	// Trace IBC Denom
+	gaiaDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(osmosisChannel.PortID, osmosisChannel.ChannelID, gaia.Config().Denom))
+	gaiaIbcDenom := gaiaDenomTrace.IBCDenom()
+
+	osmosisDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(gaiaChannel.PortID, gaiaChannel.ChannelID, osmosis.Config().Denom))
+	osmosisIbcDenom := osmosisDenomTrace.IBCDenom()
+
+	// Test destination wallet has increased funds
+	gaiaIBCBalance, err := osmosis.GetBalance(ctx, gaiaDstAddress, gaiaIbcDenom)
+	require.NoError(t, err)
+	require.Equal(t, amountToSend, gaiaIBCBalance)
+
+	osmosisIBCBalance, err := gaia.GetBalance(ctx, osmosisDstAddress, osmosisIbcDenom)
+	require.NoError(t, err)
+	require.Equal(t, amountToSend, osmosisIBCBalance)
+}

--- a/ibctest/path_filter_test.go
+++ b/ibctest/path_filter_test.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// TestPathFilter tests the channel allowlist
-func TestPathFilter(t *testing.T) {
+// TestPathFilterAllow tests the channel allowlist
+func TestPathFilterAllow(t *testing.T) {
 	ctx := context.Background()
 
 	// Chain Factory
@@ -154,4 +154,142 @@ func TestPathFilter(t *testing.T) {
 	osmosisIBCBalance, err := gaia.GetBalance(ctx, osmosisDstAddress, osmosisIbcDenom)
 	require.NoError(t, err)
 	require.Equal(t, amountToSend, osmosisIBCBalance)
+}
+
+// TestPathFilterAllow tests the channel denylist
+func TestPathFilterDeny(t *testing.T) {
+	ctx := context.Background()
+
+	// Chain Factory
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", Version: "v7.0.3"},
+		{Name: "osmosis", Version: "v11.0.1"},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+	gaia, osmosis := chains[0], chains[1]
+
+	// Relayer Factory
+	client, network := ibctest.DockerSetup(t)
+
+	r := relayeribctest.NewRelayerFactory(relayeribctest.RelayerConfig{
+		Processor:           relayer.ProcessorEvents,
+		InitialBlockHistory: 100,
+	}).Build(
+		t, client, network)
+
+	// Prep Interchain
+	const ibcPath = "gaia-osmosis"
+	ic := ibctest.NewInterchain().
+		AddChain(gaia).
+		AddChain(osmosis).
+		AddRelayer(r, "relayer").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  osmosis,
+			Relayer: r,
+			Path:    ibcPath,
+		})
+
+	// Log location
+	f, err := ibctest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
+	require.NoError(t, err)
+	// Reporter/logs
+	rep := testreporter.NewReporter(f)
+	eRep := rep.RelayerExecReporter(t)
+
+	// Build interchain
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+
+		SkipPathCreation: false,
+	}))
+
+	// Get Channel ID
+	gaiaChans, err := r.GetChannels(ctx, eRep, gaia.Config().ChainID)
+	require.NoError(t, err)
+	gaiaChannel := gaiaChans[0]
+	osmosisChannel := gaiaChans[0].Counterparty
+
+	r.UpdatePath(ctx, eRep, ibcPath, ibc.ChannelFilter{
+		Rule:        "denylist",
+		ChannelList: []string{gaiaChannel.ChannelID},
+	})
+
+	// Create and Fund User Wallets
+	fundAmount := int64(10_000_000)
+	users := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(fundAmount), gaia, osmosis)
+
+	gaiaUser, osmosisUser := users[0], users[1]
+
+	r.StartRelayer(ctx, eRep, ibcPath)
+
+	// Send Transaction
+	amountToSend := int64(1_000_000)
+	gaiaDstAddress := gaiaUser.Bech32Address(osmosis.Config().Bech32Prefix)
+	osmosisDstAddress := osmosisUser.Bech32Address(gaia.Config().Bech32Prefix)
+
+	gaiaHeight, err := gaia.Height(ctx)
+	require.NoError(t, err)
+
+	osmosisHeight, err := osmosis.Height(ctx)
+	require.NoError(t, err)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		tx, err := gaia.SendIBCTransfer(ctx, gaiaChannel.ChannelID, gaiaUser.KeyName, ibc.WalletAmount{
+			Address: gaiaDstAddress,
+			Denom:   gaia.Config().Denom,
+			Amount:  amountToSend,
+		},
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		if err := tx.Validate(); err != nil {
+			return err
+		}
+		_, err = test.PollForAck(ctx, gaia, gaiaHeight, gaiaHeight+10, tx.Packet)
+		return err
+	})
+
+	eg.Go(func() error {
+		tx, err := osmosis.SendIBCTransfer(ctx, osmosisChannel.ChannelID, osmosisUser.KeyName, ibc.WalletAmount{
+			Address: osmosisDstAddress,
+			Denom:   osmosis.Config().Denom,
+			Amount:  amountToSend,
+		},
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		if err := tx.Validate(); err != nil {
+			return err
+		}
+		_, err = test.PollForAck(ctx, osmosis, osmosisHeight, osmosisHeight+10, tx.Packet)
+		return err
+	})
+	require.Error(t, eg.Wait())
+
+	// Trace IBC Denom
+	gaiaDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(osmosisChannel.PortID, osmosisChannel.ChannelID, gaia.Config().Denom))
+	gaiaIbcDenom := gaiaDenomTrace.IBCDenom()
+
+	osmosisDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(gaiaChannel.PortID, gaiaChannel.ChannelID, osmosis.Config().Denom))
+	osmosisIbcDenom := osmosisDenomTrace.IBCDenom()
+
+	// Test destination wallet has increased funds
+	gaiaIBCBalance, err := osmosis.GetBalance(ctx, gaiaDstAddress, gaiaIbcDenom)
+	require.NoError(t, err)
+	require.Equal(t, 0, gaiaIBCBalance)
+
+	osmosisIBCBalance, err := gaia.GetBalance(ctx, osmosisDstAddress, osmosisIbcDenom)
+	require.NoError(t, err)
+	require.Equal(t, 0, osmosisIBCBalance)
 }

--- a/ibctest/relayer.go
+++ b/ibctest/relayer.go
@@ -110,6 +110,17 @@ func (r *Relayer) GeneratePath(ctx context.Context, _ ibc.RelayerExecReporter, s
 	return nil
 }
 
+func (r *Relayer) UpdatePath(ctx context.Context, _ ibc.RelayerExecReporter, pathName string, filter ibc.ChannelFilter) error {
+	res := r.sys().RunC(ctx, r.log(), "paths", "update", pathName,
+		"--filter-rule", filter.Rule,
+		"--filter-channels", strings.Join(filter.ChannelList, ","),
+	)
+	if res.Err != nil {
+		return res.Err
+	}
+	return nil
+}
+
 func (r *Relayer) GetChannels(ctx context.Context, _ ibc.RelayerExecReporter, chainID string) ([]ibc.ChannelOutput, error) {
 	res := r.sys().RunC(ctx, r.log(), "q", "channels", chainID)
 	if res.Err != nil {

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -6,15 +6,14 @@ import (
 
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	conntypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
+	"github.com/cosmos/relayer/v2/relayer/processor"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	check     = "✔"
-	xIcon     = "✘"
-	allowList = "allowlist"
-	denyList  = "denylist"
+	check = "✔"
+	xIcon = "✘"
 )
 
 // Paths represent connection paths between chains
@@ -142,9 +141,9 @@ type IBCdata struct {
 
 // ValidateChannelFilterRule verifies that the configured ChannelFilter rule is set to an appropriate value.
 func (p *Path) ValidateChannelFilterRule() error {
-	if p.Filter.Rule != allowList && p.Filter.Rule != denyList && p.Filter.Rule != "" {
+	if p.Filter.Rule != processor.RuleAllowList && p.Filter.Rule != processor.RuleDenyList && p.Filter.Rule != "" {
 		return fmt.Errorf("%s is not a valid channel filter rule, please "+
-			"ensure your channel filter rule is `%s` or '%s'", p.Filter.Rule, allowList, denyList)
+			"ensure your channel filter rule is `%s` or '%s'", p.Filter.Rule, processor.RuleAllowList, processor.RuleDenyList)
 	}
 	return nil
 }

--- a/relayer/processor/metrics.go
+++ b/relayer/processor/metrics.go
@@ -6,6 +6,7 @@ import (
 )
 
 type PrometheusMetrics struct {
+	Registry              *prometheus.Registry
 	PacketObservedCounter *prometheus.CounterVec
 	PacketRelayedCounter  *prometheus.CounterVec
 	LatestHeightGauge     *prometheus.GaugeVec
@@ -37,24 +38,27 @@ func NewPrometheusMetrics() *PrometheusMetrics {
 	packetLabels := []string{"path", "chain", "channel", "port", "type"}
 	heightLabels := []string{"chain"}
 	walletLabels := []string{"chain", "key", "denom"}
+	registry := prometheus.NewRegistry()
+	registerer := promauto.With(registry)
 	return &PrometheusMetrics{
-		PacketObservedCounter: promauto.NewCounterVec(prometheus.CounterOpts{
+		Registry: registry,
+		PacketObservedCounter: registerer.NewCounterVec(prometheus.CounterOpts{
 			Name: "cosmos_relayer_observed_packets",
 			Help: "The total number of observed packets",
 		}, packetLabels),
-		PacketRelayedCounter: promauto.NewCounterVec(prometheus.CounterOpts{
+		PacketRelayedCounter: registerer.NewCounterVec(prometheus.CounterOpts{
 			Name: "cosmos_relayer_relayed_packets",
 			Help: "The total number of relayed packets",
 		}, packetLabels),
-		LatestHeightGauge: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		LatestHeightGauge: registerer.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cosmos_relayer_chain_latest_height",
 			Help: "The current height of the chain",
 		}, heightLabels),
-		WalletBalance: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		WalletBalance: registerer.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cosmos_relayer_wallet_balance",
 			Help: "The current balance for the relayer's wallet",
 		}, walletLabels),
-		FeesSpent: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		FeesSpent: registerer.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cosmos_relayer_fees_spent",
 			Help: "The amount of fees spent from the relayer's wallet",
 		}, walletLabels),

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -166,9 +166,9 @@ func (pp *PathProcessor) SetChainProviderIfApplicable(chainProvider provider.Cha
 
 func (pp *PathProcessor) IsRelayedChannel(chainID string, channelKey ChannelKey) bool {
 	if pp.pathEnd1.info.ChainID == chainID {
-		return pp.pathEnd1.info.ShouldRelayChannel(ChainChannelKey{ChainID: chainID, ChannelKey: channelKey})
+		return pp.pathEnd1.info.ShouldRelayChannel(ChainChannelKey{ChainID: chainID, CounterpartyChainID: pp.pathEnd2.info.ChainID, ChannelKey: channelKey})
 	} else if pp.pathEnd2.info.ChainID == chainID {
-		return pp.pathEnd2.info.ShouldRelayChannel(ChainChannelKey{ChainID: chainID, ChannelKey: channelKey})
+		return pp.pathEnd2.info.ShouldRelayChannel(ChainChannelKey{ChainID: chainID, CounterpartyChainID: pp.pathEnd1.info.ChainID, ChannelKey: channelKey})
 	}
 	return false
 }
@@ -237,11 +237,11 @@ func (pp *PathProcessor) processAvailableSignals(ctx context.Context, cancel fun
 		return true
 	case d := <-pp.pathEnd1.incomingCacheData:
 		// we have new data from ChainProcessor for pathEnd1
-		pp.pathEnd1.mergeCacheData(ctx, cancel, d, pp.pathEnd2.inSync, messageLifecycle)
+		pp.pathEnd1.mergeCacheData(ctx, cancel, d, pp.pathEnd2.info.ChainID, pp.pathEnd2.inSync, messageLifecycle)
 
 	case d := <-pp.pathEnd2.incomingCacheData:
 		// we have new data from ChainProcessor for pathEnd2
-		pp.pathEnd2.mergeCacheData(ctx, cancel, d, pp.pathEnd1.inSync, messageLifecycle)
+		pp.pathEnd2.mergeCacheData(ctx, cancel, d, pp.pathEnd1.info.ChainID, pp.pathEnd1.inSync, messageLifecycle)
 
 	case <-pp.retryProcess:
 		// No new data to merge in, just retry handling.

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -286,7 +286,7 @@ func filterOpenChannels(channels []*types.IdentifiedChannel) map[string]*ActiveC
 // channels to relay on.
 func applyChannelFilterRule(filter ChannelFilter, channels []*types.IdentifiedChannel) []*types.IdentifiedChannel {
 	switch filter.Rule {
-	case allowList:
+	case processor.RuleAllowList:
 		var filteredChans []*types.IdentifiedChannel
 		for _, c := range channels {
 			if filter.InChannelList(c.ChannelId) {
@@ -294,7 +294,7 @@ func applyChannelFilterRule(filter ChannelFilter, channels []*types.IdentifiedCh
 			}
 		}
 		return filteredChans
-	case denyList:
+	case processor.RuleDenyList:
 		var filteredChans []*types.IdentifiedChannel
 		for _, c := range channels {
 			if filter.InChannelList(c.ChannelId) {


### PR DESCRIPTION
With allowlist/denylist applied, packets from dst -> src were being filtered out regardless of the filter setting.
The counterparty chain ID needs to be included in the `ChainChannelKey` for the checks to work.