### PR TITLE
disable CountTotal in DefaultPageRequest

### DIFF
--- a/relayer/chains/cosmos/query.go
+++ b/relayer/chains/cosmos/query.go
@@ -921,7 +921,7 @@ func DefaultPageRequest() *querytypes.PageRequest {
 		Key:        []byte(""),
 		Offset:     0,
 		Limit:      1000,
-		CountTotal: true,
+		CountTotal: false,
 	}
 }
 


### PR DESCRIPTION
@jtieri helped me to understand that the create clients step can fail on mainnets without the `--override` flag due to the client states query being unsuccessful due to timing out or receiving a malformed response. We also see the node get stuck momentarily syncing blocks. I tried some queries from `gaiad` CLI against `cosmoshub-4` mainnet to reproduce:

`gaiad q ibc client states --limit 1000` executes immediately with the results. rapid firing this query does not have any issues.
`gaiad q ibc client states --limit 1000 --count-total` causes the query to run until timeout and caused the node to get out of sync momentarily. This behavior is consistent across multiple attempts.

I went down the path of trying to enable pagination, but it appears pagination isn't yet fully fixed. page key pagination appears to be non-working entirely on most paginated queries, and limit/offset pagination is partially functional. For example using `gaiad` CLI:
`gaiad q ibc client states  --limit 5 --offset 0` returns 3 results. I was confused why until I stepped through them:

`gaiad q ibc client states --limit 1 --offset 0` returns the first of the 3 from the `--limit 5` query
`gaiad q ibc client states --limit 1 --offset 1` returns an empty response
`gaiad q ibc client states --limit 1 --offset 2` returns the second of the 3 from the `--limit 5` query
`gaiad q ibc client states --limit 1 --offset 3` returns an empty response
`gaiad q ibc client states --limit 1 --offset 4` returns the last of the 3 from the `--limit 5` query

There are empty slots in between the data. This makes it difficult to workaround without counting the total since we won't know when we are done (since an empty result set does not necessarily mean there is not data at a later offset).

We don't use the `res.Pagination.Total` anywhere that we do queries that require pagination config, so we can turn off `CountTotal` in the `DefaultPageRequest` to lighten these queries on the nodes. For now, this seems to be the lowest hanging fruit until either pagination is fixed on these mainnets so that we can implement it properly or until we have reports of issues where more than 1000 records exist for these paginated queries and data is being missed.