### PR TITLE
feat: add new clients-expiration query returning time before expiration

### DIFF
--- a/relayer/query.go
+++ b/relayer/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/avast/retry-go/v4"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -300,4 +301,37 @@ func QueryBalance(ctx context.Context, chain *Chain, address string, showDenoms 
 		}
 	}
 	return out, nil
+}
+
+func QueryClientExpiration(ctx context.Context, src, dst *Chain) (time.Time, error) {
+	latestHeight, err := src.ChainProvider.QueryLatestHeight(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	clientState, err := src.QueryTMClientState(ctx, latestHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	trustingPeriod := clientState.TrustingPeriod
+	clientTime, err := dst.ChainProvider.BlockTime(ctx, int64(clientState.GetLatestHeight().GetRevisionHeight()))
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return clientTime.Add(trustingPeriod), nil
+}
+
+func SPrintClientExpiration(chain *Chain, expiration time.Time) string {
+	now := time.Now()
+	remainingTime := expiration.Sub(now)
+	expirationFormatted := expiration.Format(time.RFC822)
+
+	if remainingTime < 0 {
+		return fmt.Sprintf("client %s (%s) is already expired (%s)\n",
+			chain.ClientID(), chain.ChainID(), expirationFormatted)
+	}
+	return fmt.Sprintf("client %s (%s) expires in %s (%s)\n",
+		chain.ClientID(), chain.ChainID(), remainingTime.Round(time.Second), expirationFormatted)
 }

--- a/relayer/query_test.go
+++ b/relayer/query_test.go
@@ -1,0 +1,87 @@
+package relayer
+
+import (
+	"github.com/cosmos/relayer/v2/relayer/chains/cosmos"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPrintClientExpiration_PrintChainId(t *testing.T) {
+	previousTime := time.Now().Add(10 * time.Hour)
+
+	chain := mockChain("expected-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, previousTime)
+
+	require.Contains(t, expiration, "expected-chain-id")
+}
+
+func TestSPrintClientExpiration_PrintClientId(t *testing.T) {
+	previousTime := time.Now().Add(10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "expected-client-id")
+	expiration := SPrintClientExpiration(chain, previousTime)
+
+	require.Contains(t, expiration, "expected-client-id")
+}
+
+func TestSPrintClientExpiration_PrintIsAlreadyExpired_WhenTimeIsInPast(t *testing.T) {
+	previousTime := time.Now().Add(-10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, previousTime)
+
+	require.Contains(t, expiration, "is already expired")
+}
+
+func TestSPrintClientExpiration_PrintRFC822FormattedTime_WhenTimeIsInPast(t *testing.T) {
+	pastTime := time.Now().Add(-10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, pastTime)
+
+	require.Contains(t, expiration, pastTime.Format(time.RFC822))
+}
+
+func TestSPrintClientExpiration_PrintExpiresIn_WhenTimeIsInFuture(t *testing.T) {
+	previousTime := time.Now().Add(10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, previousTime)
+
+	require.Contains(t, expiration, "expires in")
+}
+
+func TestSPrintClientExpiration_PrintRFC822FormattedTime_WhenTimeIsInFuture(t *testing.T) {
+	futureTime := time.Now().Add(10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, futureTime)
+
+	require.Contains(t, expiration, futureTime.Format(time.RFC822))
+}
+
+func TestSPrintClientExpiration_PrintRemainingTime_WhenTimeIsInFuture(t *testing.T) {
+	futureTime := time.Now().Add(10 * time.Hour)
+
+	chain := mockChain("test-chain-id", "test-client-id")
+	expiration := SPrintClientExpiration(chain, futureTime)
+
+	require.Contains(t, expiration, "10h0m0s")
+}
+
+func mockChain(chainId string, clientId string) *Chain {
+	return &Chain{
+		Chainid: chainId,
+		ChainProvider: &cosmos.CosmosProvider{
+			PCfg: cosmos.CosmosProviderConfig{
+				ChainID: chainId,
+			},
+		},
+		PathEnd: &PathEnd{
+			ChainID:  chainId,
+			ClientID: clientId,
+		},
+	}
+}


### PR DESCRIPTION
It's currently not simple to get the time left before an IBC light client expires.

This PR adds a new `query clients-expiration path` that will check the state of the light client and return the duration before it expires.

```
$ rly query clients-expiration cosmoshub-irisnet
  client 07-tendermint-384 (cosmoshub-4) expires in 306h0m0s (08 Nov 22 10:05 UTC)
  client 07-tendermint-31 (irishub-1) expires in 307h0m0s (08 Nov 22 11:08 UTC)
```