### PR TITLE
fix: Serve NewRegistry Registered Metrics

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -109,8 +109,8 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 				}
 				log := a.Log.With(zap.String("sys", "debughttp"))
 				log.Info("Debug server listening", zap.String("addr", debugAddr))
-				relaydebug.StartDebugServer(cmd.Context(), log, ln)
 				prometheusMetrics = processor.NewPrometheusMetrics()
+				relaydebug.StartDebugServer(cmd.Context(), log, ln, prometheusMetrics.Registry)
 				for _, chain := range chains {
 					if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok {
 						ccp.SetMetrics(prometheusMetrics)

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -5,7 +5,7 @@
 **Prometheus exporter**
 
 If you started `rly` with the default `--debug-addr` argument,
-you can use `http://$IP:7597/metrics` as a target for your prometheus scraper.
+you can use `http://$IP:7597/relayer/metrics` as a target for your prometheus scraper.
 
 **Example metrics**
 


### PR DESCRIPTION
Fixes #1020 

The metrics registered with the NewRegistry must be explicitly served with a HandlerFor them.