### PR TITLE
cherrypick fix: Serve NewRegistry Registered Metrics into v2.2.0

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -109,8 +109,8 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 				}
 				log := a.Log.With(zap.String("sys", "debughttp"))
 				log.Info("Debug server listening", zap.String("addr", debugAddr))
-				relaydebug.StartDebugServer(cmd.Context(), log, ln)
 				prometheusMetrics = processor.NewPrometheusMetrics()
+				relaydebug.StartDebugServer(cmd.Context(), log, ln, prometheusMetrics.Registry)
 				for _, chain := range chains {
 					if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok {
 						ccp.SetMetrics(prometheusMetrics)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -3,7 +3,7 @@
 **Prometheus exporter**
 
 If you started `rly` with the default `--debug-addr` argument,
-you can use `http://$IP:7597/metrics` as a target for your prometheus scraper.
+you can use `http://$IP:7597/relayer/metrics` as a target for your prometheus scraper.
 
 **Example metrics**
 


### PR DESCRIPTION
merges the fix for #1020 into v2.2.0 branch