### PR TITLE
recv_packet/write_acknowledgement separation

### DIFF
--- a/relayer/chains/cosmos/event_parser.go
+++ b/relayer/chains/cosmos/event_parser.go
@@ -49,43 +49,15 @@ func ibcMessagesFromEvents(
 	chainID string,
 	height uint64,
 ) (messages []ibcMessage) {
-	recvPacketMsgs := make(map[packetKey]*packetInfo)
 	for _, event := range events {
 		evt := sdk.StringifyEvent(event)
-		switch event.Type {
-		case chantypes.EventTypeRecvPacket, chantypes.EventTypeWriteAck:
-			pi := &packetInfo{Height: height}
-			pi.parseAttrs(log, evt.Attributes)
-			ck, err := processor.PacketInfoChannelKey(event.Type, provider.PacketInfo(*pi))
-			if err == nil {
-				pk := packetKey{
-					sequence: pi.Sequence,
-					channel:  ck,
-				}
-				_, ok := recvPacketMsgs[pk]
-				if !ok {
-					recvPacketMsgs[pk] = pi
-				} else {
-					recvPacketMsgs[pk].parseAttrs(log, evt.Attributes)
-				}
-			}
-		default:
-			m := parseIBCMessageFromEvent(log, evt, chainID, height)
-			if m == nil || m.info == nil {
-				// Not an IBC message, don't need to log here
-				continue
-			}
-			messages = append(messages, *m)
+		m := parseIBCMessageFromEvent(log, evt, chainID, height)
+		if m == nil || m.info == nil {
+			// Not an IBC message, don't need to log here
+			continue
 		}
+		messages = append(messages, *m)
 	}
-
-	for _, recvPacketMsg := range recvPacketMsgs {
-		messages = append(messages, ibcMessage{
-			eventType: chantypes.EventTypeRecvPacket,
-			info:      recvPacketMsg,
-		})
-	}
-
 	return messages
 }
 
@@ -96,7 +68,7 @@ func parseIBCMessageFromEvent(
 	height uint64,
 ) *ibcMessage {
 	switch event.Type {
-	case chantypes.EventTypeSendPacket,
+	case chantypes.EventTypeSendPacket, chantypes.EventTypeRecvPacket, chantypes.EventTypeWriteAck,
 		chantypes.EventTypeAcknowledgePacket, chantypes.EventTypeTimeoutPacket,
 		chantypes.EventTypeTimeoutPacketOnClose:
 		pi := &packetInfo{Height: height}

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -36,11 +36,6 @@ func (ccp *CosmosChainProcessor) handlePacketMessage(eventType string, pi provid
 		return
 	}
 
-	if eventType == chantypes.EventTypeRecvPacket && len(pi.Ack) == 0 {
-		// ignore recv packet with empty ack bytes
-		return
-	}
-
 	if !c.PacketFlow.ShouldRetainSequence(ccp.pathProcessors, k, ccp.chainProvider.ChainId(), eventType, pi.Sequence) {
 		ccp.log.Debug("Not retaining packet message",
 			zap.String("event_type", eventType),

--- a/relayer/chains/cosmos/query.go
+++ b/relayer/chains/cosmos/query.go
@@ -701,7 +701,14 @@ func writeAcknowledgementQuery(channelID string, portID string, seq uint64) stri
 		fmt.Sprintf("%s.packet_dst_port='%s'", waTag, portID),
 		fmt.Sprintf("%s.packet_sequence='%d'", waTag, seq),
 	}
-	return strings.Join(x, " AND ")
+	writeAckPortion := strings.Join(x, " AND ")
+	y := []string{
+		fmt.Sprintf("%s.packet_dst_channel='%s'", rpTag, channelID),
+		fmt.Sprintf("%s.packet_dst_port='%s'", rpTag, portID),
+		fmt.Sprintf("%s.packet_sequence='%d'", rpTag, seq),
+	}
+	recvPacketPortion := strings.Join(y, " AND ")
+	return fmt.Sprintf("(%s) OR (%s)", writeAckPortion, recvPacketPortion)
 }
 
 func (cc *CosmosProvider) QuerySendPacket(
@@ -717,7 +724,7 @@ func (cc *CosmosProvider) QuerySendPacket(
 	}
 	for _, msg := range ibcMsgs {
 		if pi, ok := msg.info.(*packetInfo); ok {
-			if pi.Sequence == sequence {
+			if pi.SourceChannel == srcChanID && pi.SourcePort == srcPortID && pi.Sequence == sequence {
 				return provider.PacketInfo(*pi), nil
 			}
 		}
@@ -736,10 +743,27 @@ func (cc *CosmosProvider) QueryRecvPacket(
 	if err != nil {
 		return provider.PacketInfo{}, err
 	}
+	var recvPacket *packetInfo
+	var ack []byte
 	for _, msg := range ibcMsgs {
+		if msg.eventType != chantypes.EventTypeRecvPacket && msg.eventType != chantypes.EventTypeWriteAck {
+			continue
+		}
 		if pi, ok := msg.info.(*packetInfo); ok {
-			if pi.DestChannel == dstChanID && pi.Sequence == sequence {
-				return provider.PacketInfo(*pi), nil
+			if pi.DestChannel == dstChanID && pi.DestPort == dstPortID && pi.Sequence == sequence {
+				if msg.eventType == chantypes.EventTypeRecvPacket {
+					recvPacket = pi
+					if len(ack) > 0 {
+						recvPacket.Ack = ack
+						return provider.PacketInfo(*pi), nil
+					}
+				} else {
+					ack = pi.Ack
+					if recvPacket != nil {
+						recvPacket.Ack = ack
+						return provider.PacketInfo(*pi), nil
+					}
+				}
 			}
 		}
 	}

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -48,7 +48,6 @@ var (
 // Strings for parsing events
 var (
 	spTag       = "send_packet"
-	rpTag       = "recv_packet"
 	waTag       = "write_acknowledgement"
 	srcChanTag  = "packet_src_channel"
 	dstChanTag  = "packet_dst_channel"

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -48,6 +48,7 @@ var (
 // Strings for parsing events
 var (
 	spTag       = "send_packet"
+	rpTag       = "recv_packet"
 	waTag       = "write_acknowledgement"
 	srcChanTag  = "packet_src_channel"
 	dstChanTag  = "packet_dst_channel"

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -52,6 +52,7 @@ MsgTransferLoop:
 				// remove all retention of this sequence number
 				res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], transferSeq)
 				res.ToDeleteDst[chantypes.EventTypeRecvPacket] = append(res.ToDeleteDst[chantypes.EventTypeRecvPacket], transferSeq)
+				res.ToDeleteDst[chantypes.EventTypeWriteAck] = append(res.ToDeleteDst[chantypes.EventTypeWriteAck], transferSeq)
 				res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket] = append(res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket], transferSeq)
 				continue MsgTransferLoop
 			}
@@ -106,6 +107,10 @@ MsgTransferLoop:
 		}
 		for msgRecvSeq, msgAcknowledgement := range pathEndPacketFlowMessages.DstMsgRecvPacket {
 			if transferSeq == msgRecvSeq {
+				if len(msgAcknowledgement.Ack) == 0 {
+					// have recv_packet but not write_acknowledgement yet. skip for now.
+					continue MsgTransferLoop
+				}
 				// msg is received by dst chain, but no ack yet. Need to relay ack from dst to src!
 				ackMsg := packetIBCMessage{
 					eventType: chantypes.EventTypeAcknowledgePacket,
@@ -179,6 +184,7 @@ MsgTransferLoop:
 	for ackSeq := range pathEndPacketFlowMessages.SrcMsgAcknowledgement {
 		res.ToDeleteSrc[chantypes.EventTypeSendPacket] = append(res.ToDeleteSrc[chantypes.EventTypeSendPacket], ackSeq)
 		res.ToDeleteDst[chantypes.EventTypeRecvPacket] = append(res.ToDeleteDst[chantypes.EventTypeRecvPacket], ackSeq)
+		res.ToDeleteDst[chantypes.EventTypeWriteAck] = append(res.ToDeleteDst[chantypes.EventTypeWriteAck], ackSeq)
 		res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket] = append(res.ToDeleteSrc[chantypes.EventTypeAcknowledgePacket], ackSeq)
 	}
 	for timeoutSeq, msgTimeout := range pathEndPacketFlowMessages.SrcMsgTimeout {
@@ -582,12 +588,27 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 			}
 		}
 
+		// Append acks into recv packet info if present
+		pathEnd1DstMsgRecvPacket := pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeRecvPacket]
+		for seq, ackInfo := range pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeWriteAck] {
+			if recvPacketInfo, ok := pathEnd1DstMsgRecvPacket[seq]; ok {
+				recvPacketInfo.Ack = ackInfo.Ack
+			}
+		}
+
+		pathEnd2DstMsgRecvPacket := pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeRecvPacket]
+		for seq, ackInfo := range pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeWriteAck] {
+			if recvPacketInfo, ok := pathEnd2DstMsgRecvPacket[seq]; ok {
+				recvPacketInfo.Ack = ackInfo.Ack
+			}
+		}
+
 		pathEnd1PacketFlowMessages := pathEndPacketFlowMessages{
 			Src:                       pp.pathEnd1,
 			Dst:                       pp.pathEnd2,
 			ChannelKey:                pair.pathEnd1ChannelKey,
 			SrcMsgTransfer:            pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeSendPacket],
-			DstMsgRecvPacket:          pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeRecvPacket],
+			DstMsgRecvPacket:          pathEnd1DstMsgRecvPacket,
 			SrcMsgAcknowledgement:     pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeAcknowledgePacket],
 			SrcMsgTimeout:             pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeTimeoutPacket],
 			SrcMsgTimeoutOnClose:      pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeTimeoutPacketOnClose],
@@ -598,7 +619,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 			Dst:                       pp.pathEnd1,
 			ChannelKey:                pair.pathEnd2ChannelKey,
 			SrcMsgTransfer:            pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeSendPacket],
-			DstMsgRecvPacket:          pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeRecvPacket],
+			DstMsgRecvPacket:          pathEnd2DstMsgRecvPacket,
 			SrcMsgAcknowledgement:     pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeAcknowledgePacket],
 			SrcMsgTimeout:             pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeTimeoutPacket],
 			SrcMsgTimeoutOnClose:      pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeTimeoutPacketOnClose],
@@ -806,7 +827,7 @@ func (pp *PathProcessor) sendMessages(ctx context.Context, src, dst *pathEndRunt
 	}
 	for _, m := range om.pktMsgs {
 		var channel, port string
-		if m.msg.eventType == chantypes.EventTypeRecvPacket {
+		if m.msg.eventType == chantypes.EventTypeRecvPacket || m.msg.eventType == chantypes.EventTypeWriteAck {
 			channel = m.msg.info.DestChannel
 			port = m.msg.info.DestPort
 		} else {

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -829,7 +829,7 @@ func (pp *PathProcessor) sendMessages(ctx context.Context, src, dst *pathEndRunt
 	}
 	for _, m := range om.pktMsgs {
 		var channel, port string
-		if m.msg.eventType == chantypes.EventTypeRecvPacket || m.msg.eventType == chantypes.EventTypeWriteAck {
+		if m.msg.eventType == chantypes.EventTypeRecvPacket {
 			channel = m.msg.info.DestChannel
 			port = m.msg.info.DestPort
 		} else {

--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -593,6 +593,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		for seq, ackInfo := range pp.pathEnd2.messageCache.PacketFlow[pair.pathEnd2ChannelKey][chantypes.EventTypeWriteAck] {
 			if recvPacketInfo, ok := pathEnd1DstMsgRecvPacket[seq]; ok {
 				recvPacketInfo.Ack = ackInfo.Ack
+				pathEnd1DstMsgRecvPacket[seq] = recvPacketInfo
 			}
 		}
 
@@ -600,6 +601,7 @@ func (pp *PathProcessor) processLatestMessages(ctx context.Context, messageLifec
 		for seq, ackInfo := range pp.pathEnd1.messageCache.PacketFlow[pair.pathEnd1ChannelKey][chantypes.EventTypeWriteAck] {
 			if recvPacketInfo, ok := pathEnd2DstMsgRecvPacket[seq]; ok {
 				recvPacketInfo.Ack = ackInfo.Ack
+				pathEnd2DstMsgRecvPacket[seq] = recvPacketInfo
 			}
 		}
 


### PR DESCRIPTION
Separate `recv_packet` from `write_acknowledgement` events since they can be in separate blocks with forward middleware.

This moves the duty of combining the data from the `write_acknowledgement` event with the `recv_packet` event into the path processor, which simplifies the event parser.