### PR TITLE
AMD64/Aarch64 compatible Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,70 @@
-FROM --platform=$BUILDPLATFORM golang:1.18-alpine as BUILD
+FROM --platform=$BUILDPLATFORM golang:1.19-alpine3.16 AS build-env
 
-WORKDIR /relayer
+RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
 
-# Update and install needed deps prioir to installing the binary.
-RUN apk update && \
-  apk --no-cache add make git build-base
+ARG TARGETARCH
+ARG BUILDARCH
 
-# Copy go.mod and go.sum first and download for caching go modules
-COPY go.mod go.sum ./
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+        wget -c https://musl.cc/aarch64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
+    elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+        wget -c https://musl.cc/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
+    fi
 
-RUN go mod download
+ADD . .
 
-# Copy the files from host
-COPY . .
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+        export CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++;\
+    elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+        export CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++; \
+    fi; \
+    GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"' make install
 
-ARG TARGETARCH TARGETOS
-ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH}
-RUN make install
+RUN if [ -d "/go/bin/linux_${TARGETARCH}" ]; then mv /go/bin/linux_${TARGETARCH}/* /go/bin/; fi
 
-FROM alpine:latest
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
+RUN addgroup --gid 1025 -S relayer && adduser --uid 1025 -S relayer -G relayer
 
-ENV RELAYER /relayer
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
 
-RUN addgroup rlyuser && adduser -S -G rlyuser rlyuser -h "$RELAYER"
+# Build final image from scratch
+FROM scratch
 
-USER rlyuser
+LABEL org.opencontainers.image.source="https://github.com/cosmos/relayer"
 
-# Define working directory
-WORKDIR $RELAYER
+WORKDIR /bin
 
-# Copy binary from BUILD
-COPY --from=BUILD /go/bin/rly /usr/bin/rly
+# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm ./
 
-ENTRYPOINT ["/usr/bin/rly"]
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=busybox-min /busybox/busybox /bin/sh
+
+# Add hard links for read-only utils, then remove ln and rm
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN ln sh pwd && \
+    ln sh ls && \
+    ln sh cat && \
+    ln sh less && \
+    ln sh grep && \
+    ln sh sleep && \
+    ln sh env && \
+    ln sh tar && \
+    ln sh tee && \
+    ln sh du && \
+    rm ln rm
+
+# Install chain binaries
+COPY --from=build-env /bin/rly /bin
+
+# Install trusted CA certificates
+COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install relayer user
+COPY --from=busybox-min /etc/passwd /etc/passwd
+COPY --from=busybox-min --chown=1025:1025 /home/relayer /home/relayer
+
+WORKDIR /home/relayer
+USER relayer

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,34 +1,54 @@
-FROM golang:1.18-alpine as BUILD
+FROM golang:1.19-alpine3.16 AS build-env
 
-WORKDIR /relayer
+RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
 
-# Update and install needed deps prioir to installing the binary.
-RUN apk update && \
-  apk --no-cache add make git build-base 
+ADD . .
 
-# Copy go.mod and go.sum first and download for caching go modules
-COPY go.mod go.mod
-COPY go.sum go.sum
+RUN CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"' make install
 
-RUN go mod download
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
+RUN addgroup --gid 1025 -S relayer && adduser --uid 1025 -S relayer -G relayer
 
-# Copy the files from host
-COPY . .
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
 
-RUN make install
+# Build final image from scratch
+FROM scratch
 
-FROM alpine:latest
+LABEL org.opencontainers.image.source="https://github.com/cosmos/relayer"
 
-ENV RELAYER /relayer
+WORKDIR /bin
 
-RUN addgroup rlyuser && adduser -S -G rlyuser rlyuser -h "$RELAYER"
+# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm ./
 
-USER rlyuser
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=busybox-min /busybox/busybox /bin/sh
 
-# Define working directory
-WORKDIR $RELAYER
+# Add hard links for read-only utils, then remove ln and rm
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN ln sh pwd && \
+    ln sh ls && \
+    ln sh cat && \
+    ln sh less && \
+    ln sh grep && \
+    ln sh sleep && \
+    ln sh env && \
+    ln sh tar && \
+    ln sh tee && \
+    ln sh du && \
+    rm ln rm
 
-# Copy binary from BUILD
-COPY --from=BUILD /go/bin/rly /usr/bin/rly
+# Install chain binaries
+COPY --from=build-env /bin/rly /bin
 
-ENTRYPOINT ["/usr/bin/rly"]
+# Install trusted CA certificates
+COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install relayer user
+COPY --from=busybox-min /etc/passwd /etc/passwd
+COPY --from=busybox-min --chown=1025:1025 /home/relayer /home/relayer
+
+WORKDIR /home/relayer
+USER relayer


### PR DESCRIPTION
Using the Dockerfile setup from heighliner to enable amd64 and aarch64/arm64 builds when cgo is present.

 - [x] Remove the `installing rly binary... $(GOBIN)/rly` once this build passes