### PR TITLE
Implement remaining substrate query methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ChainSafe/gossamer v0.6.1-0.20220406182257-98400b30ca00
 	github.com/ComposableFi/go-merkle-trees v0.0.0-20220505132313-e976260288cc
 	github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd716026d
-	github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73
+	github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/avast/retry-go/v4 v4.1.0
 	github.com/cosmos/cosmos-sdk v0.46.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd
 github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd716026d/go.mod h1:swRgltPLuxQuM1AnrlRRXkbtkcHN0BjlMvGC0iEkNjk=
 github.com/ComposableFi/ibc-go/v5 v5.0.0-20220915110718-770f27ffee50 h1:7v9EkykfMvJfAZ4QbqcWpoGxiVdOEdeDEqHgDRwdl/4=
 github.com/ComposableFi/ibc-go/v5 v5.0.0-20220915110718-770f27ffee50/go.mod h1:xh/8e6kVVX1Ku8yCkn1UTT2xMKhf8v3bxeLzkbJ8VJA=
-github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73 h1:hhTKNQFywkrdPc6txNjShNqiROyHUNEkQt7dldb/29c=
-github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73/go.mod h1:abQmZdVblL6RhFPAB7uAx4K7y4+hYexcOlVXk36N5YM=
+github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643 h1:n8Yx34sAL1O1wsqLHNaP4NbbuXPMnGNqy88SinO4eII=
+github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643/go.mod h1:COUDqCdfNJo0xDA1rFndonQRkVBAgWq47oLjD+b6axY=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/ibctest/go.mod
+++ b/ibctest/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/ComposableFi/go-merkle-trees v0.0.0-20220505132313-e976260288cc // indirect
 	github.com/ComposableFi/go-subkey/v2 v2.0.0-tm03420 // indirect
 	github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd716026d // indirect
-	github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73 // indirect
+	github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.9.3 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect

--- a/ibctest/go.sum
+++ b/ibctest/go.sum
@@ -102,8 +102,8 @@ github.com/ComposableFi/go-subkey/v2 v2.0.0-tm03420 h1:oknQF/iIhf5lVjbwjsVDzDByu
 github.com/ComposableFi/go-subkey/v2 v2.0.0-tm03420/go.mod h1:KYkiMX5AbOlXXYfxkrYPrRPV6EbVUALTQh5ptUOJzu8=
 github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd716026d h1:dQbJo6PMzGltlkUgtYvB/K9/7eVR8tGTKIdL3Rq23lY=
 github.com/ComposableFi/go-substrate-rpc-client/v4 v4.0.1-0.20220921072213-b36dd716026d/go.mod h1:swRgltPLuxQuM1AnrlRRXkbtkcHN0BjlMvGC0iEkNjk=
-github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73 h1:hhTKNQFywkrdPc6txNjShNqiROyHUNEkQt7dldb/29c=
-github.com/ComposableFi/ics11-beefy v0.0.0-20220915123708-0965f4b89a73/go.mod h1:abQmZdVblL6RhFPAB7uAx4K7y4+hYexcOlVXk36N5YM=
+github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643 h1:n8Yx34sAL1O1wsqLHNaP4NbbuXPMnGNqy88SinO4eII=
+github.com/ComposableFi/ics11-beefy v0.0.0-20221204220936-07d28a34f643/go.mod h1:COUDqCdfNJo0xDA1rFndonQRkVBAgWq47oLjD+b6axY=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=

--- a/relayer/chains/substrate/construct.go
+++ b/relayer/chains/substrate/construct.go
@@ -391,7 +391,7 @@ func (sp *SubstrateProvider) constructParachainHeaders(
 			return nil, err
 		}
 
-		timestampExt, extProof, err := sp.constructExtrinsics(uint32(parachainHeaderDecoded.Number))
+		timestampExt, extProof, err := sp.constructExtrinsics(uint32(parachainHeaderDecoded.Number), true)
 		if err != nil {
 			return nil, err
 		}
@@ -423,6 +423,7 @@ func (sp *SubstrateProvider) constructParachainHeaders(
 
 func (sp *SubstrateProvider) constructExtrinsics(
 	blockNumber uint32,
+	proof bool,
 ) (timestampExtrinsic []byte, extrinsicProof [][]byte, err error) {
 	blockHash, err := sp.RPCClient.RPC.Chain.GetBlockHash(uint64(blockNumber))
 	if err != nil {
@@ -442,6 +443,10 @@ func (sp *SubstrateProvider) constructExtrinsics(
 	timestampExtrinsic, err = rpcclienttypes.Encode(exts[0])
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if !proof {
+		return timestampExtrinsic, nil, nil
 	}
 
 	t := trie.NewEmptyTrie()

--- a/relayer/chains/substrate/provider.go
+++ b/relayer/chains/substrate/provider.go
@@ -160,9 +160,9 @@ func (sp *SubstrateProvider) Key() string {
 }
 
 func (sp *SubstrateProvider) Address() (string, error) {
-	info, err := sp.Keybase.Key(sp.Key())
+	info, err := sp.Keybase.Key(sp.Config.Key)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return info.GetAddress(), nil
@@ -177,12 +177,12 @@ func (sp *SubstrateProvider) TrustingPeriod(ctx context.Context) (time.Duration,
 	return time.Duration(math.MaxInt), nil
 }
 
+// WaitForNBlocks is no-op as it isn't used anywhere
 func (sp *SubstrateProvider) WaitForNBlocks(ctx context.Context, n int64) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
+// Sprint is no-op as it isn't used anywhere
 func (sp *SubstrateProvider) Sprint(toPrint proto.Message) (string, error) {
-	//TODO implement me
-	panic("implement me")
+	return "", nil
 }

--- a/relayer/chains/substrate/provider.go
+++ b/relayer/chains/substrate/provider.go
@@ -42,6 +42,7 @@ type SubstrateProviderConfig struct {
 	Network              uint16  `json:"network" yaml:"network"`
 	ParaID               uint32  `json:"para-id" yaml:"para-id"`
 	BeefyActivationBlock uint32  `json:"beefy-activation-block" yaml:"beefy-activation-block"`
+	RelayChain           int32   `json:"relay-chain" yaml:"relay-chain"`
 }
 
 func (spc SubstrateProviderConfig) Validate() error {
@@ -176,9 +177,15 @@ func (sp *SubstrateProvider) Timeout() string {
 	return sp.Config.Timeout
 }
 
-func (sp *SubstrateProvider) TrustingPeriod(ctx context.Context) (time.Duration, error) {
-	// TODO: implement a proper trusting period
-	return time.Duration(math.MaxInt), nil
+func (sp *SubstrateProvider) TrustingPeriod(_ context.Context) (time.Duration, error) {
+	switch sp.Config.RelayChain {
+	case int32(beefyclienttypes.RelayChain_POLKADOT):
+		return beefyclienttypes.RelayChain_POLKADOT.TrustingPeriod(), nil
+	case int32(beefyclienttypes.RelayChain_KUSAMA):
+		return beefyclienttypes.RelayChain_KUSAMA.TrustingPeriod(), nil
+	default:
+		return math.MaxInt, nil
+	}
 }
 
 // WaitForNBlocks is no-op as it isn't used anywhere

--- a/relayer/chains/substrate/provider.go
+++ b/relayer/chains/substrate/provider.go
@@ -134,9 +134,13 @@ func (h SubstrateIBCHeader) ConsensusState() ibcexported.ConsensusState {
 	return h.SignedHeader.ConsensusState()
 }
 
-func (sp *SubstrateProvider) BlockTime(ctx context.Context, height int64) (time.Time, error) {
-	//TODO implement me
-	panic("implement me")
+func (sp *SubstrateProvider) BlockTime(_ context.Context, height int64) (time.Time, error) {
+	timestampExtrinsic, _, err := sp.constructExtrinsics(uint32(height), false)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return beefyclienttypes.DecodeExtrinsicTimestamp(timestampExtrinsic)
 }
 
 func (sp *SubstrateProvider) ChainName() string {

--- a/relayer/chains/substrate/query.go
+++ b/relayer/chains/substrate/query.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	rpcclienttypes "github.com/ComposableFi/go-substrate-rpc-client/v4/types"
+	"math"
 	"strings"
 	"time"
+
+	rpcclienttypes "github.com/ComposableFi/go-substrate-rpc-client/v4/types"
 
 	beefyclienttypes "github.com/ComposableFi/ics11-beefy/types"
 
@@ -66,7 +68,14 @@ func (sp *SubstrateProvider) QueryBalanceWithAddress(ctx context.Context, addres
 
 // QueryUnbondingPeriod returns the unbonding period of the chain
 func (sp *SubstrateProvider) QueryUnbondingPeriod(ctx context.Context) (time.Duration, error) {
-	return 0, nil
+	switch sp.Config.RelayChain {
+	case int32(beefyclienttypes.RelayChain_POLKADOT):
+		return beefyclienttypes.RelayChain_POLKADOT.UnbondingPeriod(), nil
+	case int32(beefyclienttypes.RelayChain_KUSAMA):
+		return beefyclienttypes.RelayChain_KUSAMA.UnbondingPeriod(), nil
+	default:
+		return math.MaxInt, nil
+	}
 }
 
 // QueryClientStateResponse retrieves the latest consensus state for a client in state at a given height

--- a/relayer/chains/substrate/query.go
+++ b/relayer/chains/substrate/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	rpcclienttypes "github.com/ComposableFi/go-substrate-rpc-client/v4/types"
 	"strings"
 	"time"
 
@@ -102,12 +103,6 @@ func (sp *SubstrateProvider) QueryClientConsensusState(ctx context.Context, chai
 		return nil, err
 	}
 	return res, nil
-}
-
-// QueryUpgradeProof performs an abci query with the given key and returns the proto encoded merkle proof
-// for the query and the height at which the proof will succeed on a tendermint verifier.
-func (sp *SubstrateProvider) QueryUpgradeProof(ctx context.Context, key []byte, height uint64) ([]byte, clienttypes.Height, error) {
-	return nil, clienttypes.Height{}, nil
 }
 
 // QueryUpgradedClient returns upgraded client info
@@ -458,13 +453,19 @@ func (sp *SubstrateProvider) QueryLatestHeight(ctx context.Context) (int64, erro
 		return 0, err
 	}
 
-	decodedHeader, err := beefyclienttypes.DecodeParachainHeader(header.HeadersWithProof.Headers[0].ParachainHeader)
-	if err != nil {
-		return 0, err
+	var latestParachainHeader rpcclienttypes.Header
+	for _, h := range header.HeadersWithProof.Headers {
+		parachainHeader, err := beefyclienttypes.DecodeParachainHeader(h.ParachainHeader)
+		if err != nil {
+			return 0, err
+		}
+		if parachainHeader.Number > latestParachainHeader.Number {
+			latestParachainHeader = parachainHeader
+		}
 	}
 
 	sp.LatestQueriedRelayChainHeight = int64(block.Block.Header.Number)
-	return int64(decodedHeader.Number), nil
+	return int64(latestParachainHeader.Number), nil
 }
 
 // QueryHeaderAtHeight returns the header at a given height
@@ -560,22 +561,4 @@ func (sp *SubstrateProvider) QueryDenomTraces(ctx context.Context, offset, limit
 	}
 
 	return res.DenomTraces, err
-}
-
-func (sp *SubstrateProvider) QueryConsensusStateABCI(ctx context.Context, clientID string, height ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error) {
-	res, err := sp.RPCClient.RPC.IBC.QueryConsensusState(ctx, uint32(height.GetRevisionHeight()))
-	if err != nil {
-		return nil, err
-	}
-
-	// check if consensus state exists
-	if len(res.Proof) == 0 {
-		return nil, fmt.Errorf(ErrTextConsensusStateNotFound, clientID)
-	}
-
-	return &clienttypes.QueryConsensusStateResponse{
-		ConsensusState: res.ConsensusState,
-		Proof:          res.Proof,
-		ProofHeight:    res.ProofHeight,
-	}, nil
 }


### PR DESCRIPTION
This PR implements some missing query methods for the substrate chain. These methods include trustingPeriod, unbondingPeriod, BlockTime. It also cleans up unecessary code in the substrate chain query implementation and comments methods that won't be used as no-op.