### PR TITLE
Fix link-then-start command to have correct flags

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -712,6 +712,10 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 	cmd = channelParameterFlags(a.Viper, cmd)
 	cmd = overrideFlag(a.Viper, cmd)
 	cmd = memoFlag(a.Viper, cmd)
+	cmd = debugServerFlags(a.Viper, cmd)
+	cmd = initBlockFlag(a.Viper, cmd)
+	cmd = processorFlag(a.Viper, cmd)
+	cmd = updateTimeFlags(a.Viper, cmd)
 	return cmd
 }
 


### PR DESCRIPTION
Currently the `link-then-start` command fails with an error because of unbound flags that are required by the `start` command.

This PR fixes the `link-then-start` command by binding the required flags at the top level.