### PR TITLE
fix: get-gaia command in Makefile used repo variable as branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ GAIA_REPO := $(CHAIN_CODE)/gaia
 
 get-gaia:
 	@mkdir -p $(CHAIN_CODE)/
-	@git clone --branch $(GAIA_REPO) --depth=1 https://github.com/cosmos/gaia.git $(GAIA_REPO)
+	@git clone --branch $(GAIA_VERSION) --depth=1 https://github.com/cosmos/gaia.git $(GAIA_REPO)
 
 build-gaia:
 	@[ -d $(GAIA_REPO) ] || { echo "Repositry for gaia does not exist at $(GAIA_REPO). Try running 'make get-gaia'..." ; exit 1; }


### PR DESCRIPTION
`make get-gaia` tries to clone a branch from the Gaia repository, which corresponds to the version defined at the top of the Makefile.

The specified branch however used the `GAIA_REPO` variable instead of `GAIA_VERSION`, which is fixed in this PR.