### PR TITLE
fix: make build-gaia command installs relayer instead of Gaia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ get-gaia:
 
 build-gaia:
 	@[ -d $(GAIA_REPO) ] || { echo "Repositry for gaia does not exist at $(GAIA_REPO). Try running 'make get-gaia'..." ; exit 1; }
-	@cd $(GAIA_REPO)
-	@make install &> /dev/null
+	@cd $(GAIA_REPO) && \
+	make install &> /dev/null
 	@gaiad version --long
 
 .PHONY: two-chains test test-integration ibctest install build lint coverage clean


### PR DESCRIPTION
The `make build-gaia` command did not work - instead of executing `make install` in the cloned repository folder (see #1070) and installing Gaia, it is actually just installing the relayer.

This behaviour is fixed in this PR.