### PR TITLE
Allow client IDs, conn IDs, and chain IDs to be updated for paths

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,6 +47,12 @@ const (
 	flagMemo                    = "memo"
 	flagFilterRule              = "filter-rule"
 	flagFilterChannels          = "filter-channels"
+	flagSrcChainID              = "src-chain-id"
+	flagDstChainID              = "dst-chain-id"
+	flagSrcClientID             = "src-client-id"
+	flagDstClientID             = "dst-client-id"
+	flagSrcConnID               = "src-connection-id"
+	flagDstConnID               = "dst-connection-id"
 )
 
 const (
@@ -155,12 +161,37 @@ func fileFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func pathFilterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().String(flagFilterRule, "", `filter rule ("allowlist", "denylist", or "" for no filtering)`)
-	if err := v.BindPFlag(flagFilterRule, cmd.Flags().Lookup(flagFilterRule)); err != nil {
+	flags := cmd.Flags()
+	flags.String(flagFilterRule, "blank", `filter rule ("allowlist", "denylist", or "" for no filtering)`)
+	if err := v.BindPFlag(flagFilterRule, flags.Lookup(flagFilterRule)); err != nil {
 		panic(err)
 	}
-	cmd.Flags().String(flagFilterChannels, "", "channels from source chain perspective to filter")
-	if err := v.BindPFlag(flagFilterRule, cmd.Flags().Lookup(flagFilterRule)); err != nil {
+	flags.String(flagFilterChannels, "blank", "channels from source chain perspective to filter")
+	if err := v.BindPFlag(flagFilterRule, flags.Lookup(flagFilterRule)); err != nil {
+		panic(err)
+	}
+	flags.String(flagSrcChainID, "", "chain ID for source chain")
+	if err := v.BindPFlag(flagSrcChainID, flags.Lookup(flagSrcChainID)); err != nil {
+		panic(err)
+	}
+	flags.String(flagDstChainID, "", "chain ID for destination chain")
+	if err := v.BindPFlag(flagDstChainID, flags.Lookup(flagDstChainID)); err != nil {
+		panic(err)
+	}
+	flags.String(flagSrcClientID, "", "client ID for source chain")
+	if err := v.BindPFlag(flagSrcClientID, flags.Lookup(flagSrcClientID)); err != nil {
+		panic(err)
+	}
+	flags.String(flagDstClientID, "", "client ID for destination chain")
+	if err := v.BindPFlag(flagDstClientID, flags.Lookup(flagDstClientID)); err != nil {
+		panic(err)
+	}
+	flags.String(flagSrcConnID, "", "connection ID for source chain")
+	if err := v.BindPFlag(flagSrcConnID, flags.Lookup(flagSrcConnID)); err != nil {
+		panic(err)
+	}
+	flags.String(flagDstConnID, "", "connection ID for destination chain")
+	if err := v.BindPFlag(flagDstConnID, flags.Lookup(flagDstConnID)); err != nil {
 		panic(err)
 	}
 	return cmd

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -59,6 +59,8 @@ const (
 	// 7597 is "RLYR" on a telephone keypad.
 	// It also happens to be unassigned in the IANA port list.
 	defaultDebugAddr = "localhost:7597"
+
+	blankValue = "blank"
 )
 
 func ibcDenomFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
@@ -162,11 +164,11 @@ func fileFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 
 func pathFilterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	flags := cmd.Flags()
-	flags.String(flagFilterRule, "blank", `filter rule ("allowlist", "denylist", or "" for no filtering)`)
+	flags.String(flagFilterRule, blankValue, `filter rule ("allowlist", "denylist", or "" for no filtering)`)
 	if err := v.BindPFlag(flagFilterRule, flags.Lookup(flagFilterRule)); err != nil {
 		panic(err)
 	}
-	flags.String(flagFilterChannels, "blank", "channels from source chain perspective to filter")
+	flags.String(flagFilterChannels, blankValue, "channels from source chain perspective to filter")
 	if err := v.BindPFlag(flagFilterRule, flags.Lookup(flagFilterRule)); err != nil {
 		panic(err)
 	}

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -274,7 +274,7 @@ $ %s paths update demo-path --filter-rule denylist --filter-channels channel-0,c
 $ %s paths update demo-path --src-chain-id chain-1 --dst-chain-id chain-2
 $ %s paths update demo-path --src-client-id 07-tendermint-02 --dst-client-id 07-tendermint-04
 $ %s paths update demo-path --src-connection-id connection-02 --dst-connection-id connection-04`,
-			appName, appName)),
+			appName, appName, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
@@ -287,7 +287,9 @@ $ %s paths update demo-path --src-connection-id connection-02 --dst-connection-i
 			filterRule, _ := flags.GetString(flagFilterRule)
 			if filterRule != "blank" {
 				if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
-					return fmt.Errorf(`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`, filterRule, processor.RuleAllowList, processor.RuleDenyList)
+					return fmt.Errorf(
+						`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`,
+						filterRule, processor.RuleAllowList, processor.RuleDenyList)
 				}
 				p.Filter.Rule = filterRule
 				actionTaken = true

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -266,7 +266,7 @@ func pathsUpdateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update path_name",
 		Aliases: []string{"n"},
-		Short:   `Update a path such as the filter rule ("allowlist", "denylist", or "" for no filtering), channels, `,
+		Short:   `Update a path such as the filter rule ("allowlist", "denylist", or "" for no filtering), filter channels, and src/dst chain, client, or connection IDs`,
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths update demo-path --filter-rule allowlist --filter-channels channel-0,channel-1
@@ -285,7 +285,7 @@ $ %s paths update demo-path --src-connection-id connection-02 --dst-connection-i
 			actionTaken := false
 
 			filterRule, _ := flags.GetString(flagFilterRule)
-			if filterRule != "blank" {
+			if filterRule != blankValue {
 				if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
 					return fmt.Errorf(
 						`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`,
@@ -296,7 +296,7 @@ $ %s paths update demo-path --src-connection-id connection-02 --dst-connection-i
 			}
 
 			filterChannels, _ := flags.GetString(flagFilterChannels)
-			if filterChannels != "blank" {
+			if filterChannels != blankValue {
 				var channelList []string
 
 				if filterChannels != "" {

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -266,39 +266,83 @@ func pathsUpdateCmd(a *appState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update path_name",
 		Aliases: []string{"n"},
-		Short:   `Update a path such as the filter rule ("allowlist", "denylist", or "" for no filtering) and channels`,
+		Short:   `Update a path such as the filter rule ("allowlist", "denylist", or "" for no filtering), channels, `,
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s paths update demo-path --filter-rule allowlist --filter-channels channel-0,channel-1
-$ %s paths update demo-path --filter-rule denylist --filter-channels channel-0,channel-1`,
+$ %s paths update demo-path --filter-rule denylist --filter-channels channel-0,channel-1
+$ %s paths update demo-path --src-chain-id chain-1 --dst-chain-id chain-2
+$ %s paths update demo-path --src-client-id 07-tendermint-02 --dst-client-id 07-tendermint-04
+$ %s paths update demo-path --src-connection-id connection-02 --dst-connection-id connection-04`,
 			appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			filterRule, err := cmd.Flags().GetString(flagFilterRule)
-			if err != nil {
-				return err
-			}
-			if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
-				return fmt.Errorf(`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`, filterRule, processor.RuleAllowList, processor.RuleDenyList)
-			}
-
-			filterChannels, err := cmd.Flags().GetString(flagFilterChannels)
-			if err != nil {
-				return err
-			}
-
-			var channelList []string
-
-			if filterChannels != "" {
-				channelList = strings.Split(filterChannels, ",")
-			}
+			flags := cmd.Flags()
 
 			p := a.Config.Paths.MustGet(name)
 
-			p.Filter = relayer.ChannelFilter{
-				Rule:        filterRule,
-				ChannelList: channelList,
+			actionTaken := false
+
+			filterRule, _ := flags.GetString(flagFilterRule)
+			if filterRule != "blank" {
+				if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
+					return fmt.Errorf(`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`, filterRule, processor.RuleAllowList, processor.RuleDenyList)
+				}
+				p.Filter.Rule = filterRule
+				actionTaken = true
+			}
+
+			filterChannels, _ := flags.GetString(flagFilterChannels)
+			if filterChannels != "blank" {
+				var channelList []string
+
+				if filterChannels != "" {
+					channelList = strings.Split(filterChannels, ",")
+				}
+
+				p.Filter.ChannelList = channelList
+				actionTaken = true
+			}
+
+			srcChainID, _ := flags.GetString(flagSrcChainID)
+			if srcChainID != "" {
+				p.Src.ChainID = srcChainID
+				actionTaken = true
+			}
+
+			dstChainID, _ := flags.GetString(flagDstChainID)
+			if dstChainID != "" {
+				p.Dst.ChainID = dstChainID
+				actionTaken = true
+			}
+
+			srcClientID, _ := flags.GetString(flagSrcClientID)
+			if srcClientID != "" {
+				p.Src.ClientID = srcClientID
+				actionTaken = true
+			}
+
+			dstClientID, _ := flags.GetString(flagDstClientID)
+			if dstClientID != "" {
+				p.Dst.ClientID = dstClientID
+				actionTaken = true
+			}
+
+			srcConnID, _ := flags.GetString(flagSrcConnID)
+			if srcConnID != "" {
+				p.Src.ConnectionID = srcConnID
+				actionTaken = true
+			}
+
+			dstConnID, _ := flags.GetString(flagDstConnID)
+			if dstConnID != "" {
+				p.Dst.ConnectionID = dstConnID
+				actionTaken = true
+			}
+
+			if !actionTaken {
+				return fmt.Errorf("at least one flag must be provided")
 			}
 
 			return a.OverwriteConfig(a.Config)

--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -218,8 +218,13 @@ func (cc *CosmosProvider) TrustingPeriod(ctx context.Context) (time.Duration, er
 	// and then re-growing by 85x.
 	tp := unbondingTime / 100 * 85
 
-	// And we only want the trusting period to be whole hours.
-	return tp.Truncate(time.Hour), nil
+	// We only want the trusting period to be whole hours unless it's less than an hour (for testing).
+	truncated := tp.Truncate(time.Hour)
+	if truncated.Hours() == 0 {
+		return tp, nil
+	}
+
+	return truncated, nil
 }
 
 // Sprint returns the json representation of the specified proto message.

--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -196,8 +196,18 @@ func (cc *CosmosProvider) Address() (string, error) {
 
 func (cc *CosmosProvider) TrustingPeriod(ctx context.Context) (time.Duration, error) {
 	res, err := cc.QueryStakingParams(ctx)
+
+	var unbondingTime time.Duration
 	if err != nil {
-		return 0, err
+		// Attempt ICS query
+		consumerUnbondingPeriod, consumerErr := cc.queryConsumerUnbondingPeriod(ctx)
+		if consumerErr != nil {
+			return 0,
+				fmt.Errorf("failed to query unbonding period as both standard and consumer chain: %s: %w", err.Error(), consumerErr)
+		}
+		unbondingTime = consumerUnbondingPeriod
+	} else {
+		unbondingTime = res.UnbondingTime
 	}
 
 	// We want the trusting period to be 85% of the unbonding time.
@@ -206,7 +216,7 @@ func (cc *CosmosProvider) TrustingPeriod(ctx context.Context) (time.Duration, er
 	// by converting int64 to float64.
 	// Use integer math the whole time, first reducing by a factor of 100
 	// and then re-growing by 85x.
-	tp := res.UnbondingTime / 100 * 85
+	tp := unbondingTime / 100 * 85
 
 	// And we only want the trusting period to be whole hours.
 	return tp.Truncate(time.Hour), nil


### PR DESCRIPTION
Expand `rly paths update` to enable updating all path params.

This is useful for interchain-security where the consumer client tracking the provider is initialized in genesis, and the provider client tracking the consumer is created when the passed proposal executes after the consumer chain spawn time in the proposal. That way, the client IDs can be updated on the path instead of creating more clients.