### PR TITLE
Fix timeouts

### DIFF
--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -331,10 +331,17 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 		return false
 	}
 
-	if message.info.Height >= counterparty.latestBlock.Height {
+	pathEndForHeight := counterparty
+	if eventType == chantypes.EventTypeTimeoutPacket || eventType == chantypes.EventTypeTimeoutPacketOnClose {
+		pathEndForHeight = pathEnd
+	}
+
+	if message.info.Height >= pathEndForHeight.latestBlock.Height {
 		pathEnd.log.Debug("Waiting to relay packet message until counterparty height has incremented",
 			zap.String("event_type", eventType),
 			zap.Uint64("sequence", sequence),
+			zap.Uint64("message_height", message.info.Height),
+			zap.Uint64("counterparty_height", counterparty.latestBlock.Height),
 			zap.Inline(k),
 		)
 		return false


### PR DESCRIPTION
For packet timeout messages, the same chain as the packet commitment needs to be checked for the height increment. This was leading to a failure to relay timeouts when the counterparty height is lower than the chain where the packet commitment occurred.