### PR TITLE
Don't auto-update-client before successful trusting period query

### DIFF
--- a/relayer/chains/cosmos/event_parser.go
+++ b/relayer/chains/cosmos/event_parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
@@ -169,10 +170,11 @@ type clientInfo struct {
 	header          []byte
 }
 
-func (c clientInfo) ClientState() provider.ClientState {
+func (c clientInfo) ClientState(trustingPeriod time.Duration) provider.ClientState {
 	return provider.ClientState{
 		ClientID:        c.clientID,
 		ConsensusHeight: c.consensusHeight,
+		TrustingPeriod:  trustingPeriod,
 	}
 }
 

--- a/relayer/processor/message_processor.go
+++ b/relayer/processor/message_processor.go
@@ -122,7 +122,8 @@ func (mp *messageProcessor) shouldUpdateClientNow(ctx context.Context, src, dst 
 	twoThirdsTrustingPeriodMs := float64(dst.clientState.TrustingPeriod.Milliseconds()) * 2 / 3
 	timeSinceLastClientUpdateMs := float64(time.Since(consensusHeightTime).Milliseconds())
 
-	pastTwoThirdsTrustingPeriod := timeSinceLastClientUpdateMs > twoThirdsTrustingPeriodMs
+	pastTwoThirdsTrustingPeriod := dst.clientState.TrustingPeriod > 0 &&
+		timeSinceLastClientUpdateMs > twoThirdsTrustingPeriodMs
 
 	pastConfiguredClientUpdateThreshold := clientUpdateThresholdMs > 0 &&
 		time.Since(consensusHeightTime).Milliseconds() > clientUpdateThresholdMs


### PR DESCRIPTION
In case the trusting period query fails, log an error and do not attempt to update clients due to 2/3 trusting period threshold reached.

Related: #1111 