### PR TITLE
chore: register solomachine codec types

### DIFF
--- a/relayer/chains/cosmos/module/app_module.go
+++ b/relayer/chains/cosmos/module/app_module.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	solomachine "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,8 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(*codec.LegacyAmino) {}
 // RegisterInterfaces registers module concrete types into protobuf Any.
 func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	tmlightclient.RegisterInterfaces(registry)
+	solomachine.RegisterInterfaces(registry)
+	// TODO: add the localhost light client when ibc-go v7.1.0 is available
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the ibc module.


### PR DESCRIPTION
This PR registers the codec types for the solo machine client. Without this the relayer would be unable to unmarshal the results from `QueryClients` when it encounters a solo machine client state.

We will need to do this again for the localhost client when ibc-go v7.1.0 is released. Additionally we should skip/ignore types that the relayer fails to unmarshal as recommended in #1102 