### PR TITLE
Flush query should include begin and end block events

### DIFF
--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -781,6 +781,9 @@ func queryPacketCommitments(
 		for i, p := range c.Commitments {
 			commitments[k][i] = p.Sequence
 		}
+		sort.SliceStable(commitments[k], func(i, j int) bool {
+			return commitments[k][i] < commitments[k][j]
+		})
 		return nil
 	}
 }


### PR DESCRIPTION
Querying for `send_packet` events after finding ICA packet commitments fails because the `send_packet` events are in the end block events, not the tx events. This adds additional searching through the block events when flushing so that packet transfers generated in-protocol can be flushed.