### PR TITLE
fix default coin type

### DIFF
--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -81,8 +81,8 @@ $ %s k a cosmoshub testkey`, appName, appName, appName)),
 			}
 
 			if coinType < 0 {
-				if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok {
-					coinType = int32(ccp.PCfg.Slip44)
+				if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok && ccp.PCfg.Slip44 != nil {
+					coinType = int32(*ccp.PCfg.Slip44)
 				} else {
 					coinType = int32(defaultCoinType)
 				}
@@ -135,8 +135,8 @@ $ %s k r cosmoshub faucet-key "[mnemonic-words]"`, appName, appName)),
 			}
 
 			if coinType < 0 {
-				if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok {
-					coinType = int32(ccp.PCfg.Slip44)
+				if ccp, ok := chain.ChainProvider.(*cosmos.CosmosProvider); ok && ccp.PCfg.Slip44 != nil {
+					coinType = int32(*ccp.PCfg.Slip44)
 				} else {
 					coinType = int32(defaultCoinType)
 				}

--- a/cregistry/chain_info.go
+++ b/cregistry/chain_info.go
@@ -55,7 +55,7 @@ type ChainInfo struct {
 	Genesis      struct {
 		GenesisURL string `json:"genesis_url"`
 	} `json:"genesis"`
-	Slip44   int `json:"slip44"`
+	Slip44   *int `json:"slip44"`
 	Codebase struct {
 		GitRepo            string   `json:"git_repo"`
 		RecommendedVersion string   `json:"recommended_version"`

--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -52,7 +52,7 @@ type CosmosProviderConfig struct {
 	SignModeStr    string                  `json:"sign-mode" yaml:"sign-mode"`
 	ExtraCodecs    []string                `json:"extra-codecs" yaml:"extra-codecs"`
 	Modules        []module.AppModuleBasic `json:"-" yaml:"-"`
-	Slip44         int                     `json:"coin-type" yaml:"coin-type"`
+	Slip44         *int                    `json:"coin-type" yaml:"coin-type"`
 	Broadcast      provider.BroadcastMode  `json:"broadcast-mode" yaml:"broadcast-mode"`
 }
 


### PR DESCRIPTION
Allow backwards compatibility with previous cosmos provider configs which do not have `coin-type` and chains in the chain-registry which do not have `slip44`. If the config field is not present, the default value of 118 will be used.