### PR TITLE
Pre-filter flush channels

### DIFF
--- a/relayer/processor/path_processor_internal.go
+++ b/relayer/processor/path_processor_internal.go
@@ -1045,10 +1045,24 @@ func (pp *PathProcessor) flush(ctx context.Context) {
 		if !open {
 			continue
 		}
+		if !pp.pathEnd1.info.ShouldRelayChannel(ChainChannelKey{
+			ChainID:             pp.pathEnd1.info.ChainID,
+			CounterpartyChainID: pp.pathEnd2.info.ChainID,
+			ChannelKey:          k,
+		}) {
+			continue
+		}
 		eg.Go(queryPacketCommitments(ctx, pp.pathEnd1, k, commitments1, &commitments1Mu))
 	}
 	for k, open := range pp.pathEnd2.channelStateCache {
 		if !open {
+			continue
+		}
+		if !pp.pathEnd2.info.ShouldRelayChannel(ChainChannelKey{
+			ChainID:             pp.pathEnd2.info.ChainID,
+			CounterpartyChainID: pp.pathEnd1.info.ChainID,
+			ChannelKey:          k,
+		}) {
 			continue
 		}
 		eg.Go(queryPacketCommitments(ctx, pp.pathEnd2, k, commitments2, &commitments2Mu))


### PR DESCRIPTION
Flush would list out all of the channels in the channelStateCache even if they were later going to be filtered out by the filter rules. This cleans up the logs to indicate more precisely what the relayer is going to do, and also prevents unnecessary querying/caching on channels that won't be flushed.