### PR TITLE
Lock config file for all write operations

### DIFF
--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -45,14 +45,14 @@ func (a *appState) initConfig(ctx context.Context) error {
 	// read the config file bytes
 	file, err := os.ReadFile(a.Viper.ConfigFileUsed())
 	if err != nil {
-		return fmt.Errorf("error reading file:", err)
+		return fmt.Errorf("error reading file: %w", err)
 	}
 
 	// unmarshall them into the wrapper struct
 	cfgWrapper := &ConfigInputWrapper{}
 	err = yaml.Unmarshal(file, cfgWrapper)
 	if err != nil {
-		return fmt.Errorf("error unmarshalling config:", err)
+		return fmt.Errorf("error unmarshalling config: %w", err)
 	}
 
 	// verify that the channel filter rule is valid for every path in the config

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -54,7 +54,7 @@ func chainsAddrCmd(a *appState) *cobra.Command {
 $ %s chains address ibc-0
 $ %s ch addr ibc-0`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -83,7 +83,7 @@ $ %s chains show ibc-0 --yaml
 $ %s ch s ibc-0 --json
 $ %s ch s ibc-0 --yaml`, appName, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, ok := a.Config.Chains[args[0]]
+			c, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -117,7 +117,7 @@ $ %s ch s ibc-0 --yaml`, appName, appName, appName, appName)),
 			}
 		},
 	}
-	return jsonFlag(a.Viper, cmd)
+	return jsonFlag(a.viper, cmd)
 }
 
 func chainsDeleteCmd(a *appState) *cobra.Command {
@@ -130,12 +130,13 @@ func chainsDeleteCmd(a *appState) *cobra.Command {
 $ %s chains delete ibc-0
 $ %s ch d ibc-0`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
-				_, ok := a.Config.Chains[args[0]]
+			chain := args[0]
+			return a.performConfigLockingOperation(cmd.Context(), func() error {
+				_, ok := a.config.Chains[chain]
 				if !ok {
-					return errChainNotFound(args[0])
+					return errChainNotFound(chain)
 				}
-				a.Config.DeleteChain(args[0])
+				a.config.DeleteChain(chain)
 				return nil
 			})
 		},
@@ -160,7 +161,7 @@ func chainsRegistryList(a *appState) *cobra.Command {
 				return err
 			}
 
-			chains, err := cregistry.DefaultChainRegistry(a.Log).ListChains(cmd.Context())
+			chains, err := cregistry.DefaultChainRegistry(a.log).ListChains(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -190,7 +191,7 @@ func chainsRegistryList(a *appState) *cobra.Command {
 			return nil
 		},
 	}
-	return yamlFlag(a.Viper, jsonFlag(a.Viper, cmd))
+	return yamlFlag(a.viper, jsonFlag(a.viper, cmd))
 }
 
 func chainsListCmd(a *appState) *cobra.Command {
@@ -213,7 +214,7 @@ $ %s ch l`, appName, appName)),
 				return err
 			}
 
-			configs := a.Config.Wrapped().ProviderConfigs
+			configs := a.config.Wrapped().ProviderConfigs
 			if len(configs) == 0 {
 				fmt.Fprintln(cmd.ErrOrStderr(), "warning: no chains found (do you need to run 'rly chains add'?)")
 			}
@@ -237,7 +238,7 @@ $ %s ch l`, appName, appName)),
 				return nil
 			default:
 				i := 0
-				for _, c := range a.Config.Chains {
+				for _, c := range a.config.Chains {
 					var (
 						key = xIcon
 						p   = xIcon
@@ -253,7 +254,7 @@ $ %s ch l`, appName, appName)),
 						bal = check
 					}
 
-					for _, pth := range a.Config.Paths {
+					for _, pth := range a.config.Paths {
 						if pth.Src.ChainID == c.ChainProvider.ChainId() || pth.Dst.ChainID == c.ChainID() {
 							p = check
 						}
@@ -265,7 +266,7 @@ $ %s ch l`, appName, appName)),
 			}
 		},
 	}
-	return yamlFlag(a.Viper, jsonFlag(a.Viper, cmd))
+	return yamlFlag(a.viper, jsonFlag(a.viper, cmd))
 }
 
 func chainsAddCmd(a *appState) *cobra.Command {
@@ -285,11 +286,11 @@ func chainsAddCmd(a *appState) *cobra.Command {
 				return err
 			}
 
-			if ok := a.Config; ok == nil {
+			if ok := a.config; ok == nil {
 				return fmt.Errorf("config not initialized, consider running `rly config init`")
 			}
 
-			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+			return a.performConfigLockingOperation(cmd.Context(), func() error {
 				// default behavior fetch from chain registry
 				// still allow for adding config from url or file
 				switch {
@@ -323,7 +324,7 @@ func chainsAddCmd(a *appState) *cobra.Command {
 		},
 	}
 
-	return chainsAddFlags(a.Viper, cmd)
+	return chainsAddFlags(a.viper, cmd)
 }
 
 func chainsAddDirCmd(a *appState) *cobra.Command {
@@ -365,15 +366,15 @@ func addChainFromFile(a *appState, chainName string, file string) error {
 	}
 
 	prov, err := pcw.Value.NewProvider(
-		a.Log.With(zap.String("provider_type", pcw.Type)),
-		a.HomePath, a.Debug, chainName,
+		a.log.With(zap.String("provider_type", pcw.Type)),
+		a.homePath, a.debug, chainName,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build ChainProvider for %s: %w", file, err)
 	}
 
-	c := relayer.NewChain(a.Log, prov, a.Debug)
-	if err = a.Config.AddChain(c); err != nil {
+	c := relayer.NewChain(a.log, prov, a.debug)
+	if err = a.config.AddChain(c); err != nil {
 		return err
 	}
 
@@ -405,28 +406,28 @@ func addChainFromURL(a *appState, chainName string, rawurl string) error {
 
 	// build the ChainProvider before initializing the chain
 	prov, err := pcw.Value.NewProvider(
-		a.Log.With(zap.String("provider_type", pcw.Type)),
-		a.HomePath, a.Debug, chainName,
+		a.log.With(zap.String("provider_type", pcw.Type)),
+		a.homePath, a.debug, chainName,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build ChainProvider for %s: %w", rawurl, err)
 	}
 
-	c := relayer.NewChain(a.Log, prov, a.Debug)
-	if err := a.Config.AddChain(c); err != nil {
+	c := relayer.NewChain(a.log, prov, a.debug)
+	if err := a.config.AddChain(c); err != nil {
 		return err
 	}
 	return nil
 }
 
 func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) error {
-	chainRegistry := cregistry.DefaultChainRegistry(a.Log)
+	chainRegistry := cregistry.DefaultChainRegistry(a.log)
 
 	var existed, failed, added []string
 
 	for _, chain := range chains {
-		if _, ok := a.Config.Chains[chain]; ok {
-			a.Log.Warn(
+		if _, ok := a.config.Chains[chain]; ok {
+			a.log.Warn(
 				"Chain already exists",
 				zap.String("chain", chain),
 				zap.String("source_link", chainRegistry.SourceLink()),
@@ -437,7 +438,7 @@ func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) er
 
 		chainInfo, err := chainRegistry.GetChain(ctx, chain)
 		if err != nil {
-			a.Log.Warn(
+			a.log.Warn(
 				"Error retrieving chain",
 				zap.String("chain", chain),
 				zap.Error(err),
@@ -448,7 +449,7 @@ func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) er
 
 		chainConfig, err := chainInfo.GetChainConfig(ctx)
 		if err != nil {
-			a.Log.Warn(
+			a.log.Warn(
 				"Error generating chain config",
 				zap.String("chain", chain),
 				zap.Error(err),
@@ -461,11 +462,11 @@ func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) er
 
 		// build the ChainProvider
 		prov, err := chainConfig.NewProvider(
-			a.Log.With(zap.String("provider_type", "cosmos")),
-			a.HomePath, a.Debug, chainInfo.ChainName,
+			a.log.With(zap.String("provider_type", "cosmos")),
+			a.homePath, a.debug, chainInfo.ChainName,
 		)
 		if err != nil {
-			a.Log.Warn(
+			a.log.Warn(
 				"Failed to build ChainProvider",
 				zap.String("chain_id", chainConfig.ChainID),
 				zap.Error(err),
@@ -475,9 +476,9 @@ func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) er
 		}
 
 		// add to config
-		c := relayer.NewChain(a.Log, prov, a.Debug)
-		if err = a.Config.AddChain(c); err != nil {
-			a.Log.Warn(
+		c := relayer.NewChain(a.log, prov, a.debug)
+		if err = a.config.AddChain(c); err != nil {
+			a.log.Warn(
 				"Failed to add chain to config",
 				zap.String("chain", chain),
 				zap.Error(err),
@@ -490,7 +491,7 @@ func addChainsFromRegistry(ctx context.Context, a *appState, chains []string) er
 		// found the correct chain so move on to next chain in chains
 
 	}
-	a.Log.Info("Config update status",
+	a.log.Info("Config update status",
 		zap.Any("added", added),
 		zap.Any("failed", failed),
 		zap.Any("already existed", existed),

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -65,7 +65,7 @@ $ %s keys add ibc-0
 $ %s keys add ibc-1 key2
 $ %s k a cosmoshub testkey`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -120,7 +120,7 @@ $ %s k r cosmoshub faucet-key "[mnemonic-words]"`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyName := args[1]
 
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -168,7 +168,7 @@ $ %s keys delete ibc-0 -y
 $ %s keys delete ibc-1 key2 -y
 $ %s k d cosmoshub default`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -195,7 +195,7 @@ $ %s k d cosmoshub default`, appName, appName, appName)),
 		},
 	}
 
-	return skipConfirm(a.Viper, cmd)
+	return skipConfirm(a.viper, cmd)
 }
 
 func askForConfirmation(a *appState, stdin io.Reader, stderr io.Writer) bool {
@@ -203,7 +203,7 @@ func askForConfirmation(a *appState, stdin io.Reader, stderr io.Writer) bool {
 
 	_, err := fmt.Fscanln(stdin, &response)
 	if err != nil {
-		a.Log.Fatal("Failed to read input", zap.Error(err))
+		a.log.Fatal("Failed to read input", zap.Error(err))
 	}
 
 	switch strings.ToLower(response) {
@@ -230,7 +230,7 @@ $ %s k l ibc-1`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 
-			chain, ok := a.Config.Chains[chainName]
+			chain, ok := a.config.Chains[chainName]
 			if !ok {
 				return errChainNotFound(chainName)
 			}
@@ -267,7 +267,7 @@ $ %s keys show ibc-0
 $ %s keys show ibc-1 key2
 $ %s k s ibc-2 testkey`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -308,7 +308,7 @@ $ %s keys export ibc-0 testkey
 $ %s k e cosmoshub testkey`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyName := args[1]
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -49,11 +49,13 @@ func pathsDeleteCmd(a *appState) *cobra.Command {
 $ %s paths delete demo-path
 $ %s pth d path-name`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := a.Config.Paths.Get(args[0]); err != nil {
-				return err
-			}
-			delete(a.Config.Paths, args[0])
-			return a.OverwriteConfig(a.Config)
+			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+				if _, err := a.Config.Paths.Get(args[0]); err != nil {
+					return err
+				}
+				delete(a.Config.Paths, args[0])
+				return nil
+			})
 		},
 	}
 	return cmd
@@ -183,27 +185,29 @@ $ %s paths add ibc-0 ibc-1 demo-path --file paths/demo.json
 $ %s pth a ibc-0 ibc-1 demo-path`, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			_, err := a.Config.Chains.Gets(src, dst)
-			if err != nil {
-				return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
-			}
 
-			file, err := cmd.Flags().GetString(flagFile)
-			if err != nil {
-				return err
-			}
+			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+				_, err := a.Config.Chains.Gets(src, dst)
+				if err != nil {
+					return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
+				}
 
-			if file != "" {
-				if err := a.AddPathFromFile(cmd.Context(), cmd.ErrOrStderr(), file, args[2]); err != nil {
+				file, err := cmd.Flags().GetString(flagFile)
+				if err != nil {
 					return err
 				}
-			} else {
-				if err := a.AddPathFromUserInput(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
-					return err
-				}
-			}
 
-			return a.OverwriteConfig(a.Config)
+				if file != "" {
+					if err := a.AddPathFromFile(cmd.Context(), cmd.ErrOrStderr(), file, args[2]); err != nil {
+						return err
+					}
+				} else {
+					if err := a.AddPathFromUserInput(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr(), src, dst, args[2]); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
 		},
 	}
 	return fileFlag(a.Viper, cmd)
@@ -220,10 +224,7 @@ func pathsAddDirCmd(a *appState) *cobra.Command {
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config add-paths examples/demo/configs/paths`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if err := addPathsFromDirectory(cmd.Context(), cmd.ErrOrStderr(), a, args[0]); err != nil {
-				return err
-			}
-			return a.OverwriteConfig(a.Config)
+			return addPathsFromDirectory(cmd.Context(), cmd.ErrOrStderr(), a, args[0])
 		},
 	}
 
@@ -241,22 +242,24 @@ $ %s paths new ibc-0 ibc-1 demo-path
 $ %s pth n ibc-0 ibc-1 demo-path`, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			_, err := a.Config.Chains.Gets(src, dst)
-			if err != nil {
-				return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
-			}
 
-			p := &relayer.Path{
-				Src: &relayer.PathEnd{ChainID: src},
-				Dst: &relayer.PathEnd{ChainID: dst},
-			}
+			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+				_, err := a.Config.Chains.Gets(src, dst)
+				if err != nil {
+					return fmt.Errorf("chains need to be configured before paths to them can be added: %w", err)
+				}
 
-			name := args[2]
-			if err = a.Config.Paths.Add(name, p); err != nil {
-				return err
-			}
+				p := &relayer.Path{
+					Src: &relayer.PathEnd{ChainID: src},
+					Dst: &relayer.PathEnd{ChainID: dst},
+				}
 
-			return a.OverwriteConfig(a.Config)
+				name := args[2]
+				if err = a.Config.Paths.Add(name, p); err != nil {
+					return err
+				}
+				return nil
+			})
 		},
 	}
 	return channelParameterFlags(a.Viper, cmd)
@@ -280,74 +283,76 @@ $ %s paths update demo-path --src-connection-id connection-02 --dst-connection-i
 
 			flags := cmd.Flags()
 
-			p := a.Config.Paths.MustGet(name)
+			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+				p := a.Config.Paths.MustGet(name)
 
-			actionTaken := false
+				actionTaken := false
 
-			filterRule, _ := flags.GetString(flagFilterRule)
-			if filterRule != blankValue {
-				if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
-					return fmt.Errorf(
-						`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`,
-						filterRule, processor.RuleAllowList, processor.RuleDenyList)
-				}
-				p.Filter.Rule = filterRule
-				actionTaken = true
-			}
-
-			filterChannels, _ := flags.GetString(flagFilterChannels)
-			if filterChannels != blankValue {
-				var channelList []string
-
-				if filterChannels != "" {
-					channelList = strings.Split(filterChannels, ",")
+				filterRule, _ := flags.GetString(flagFilterRule)
+				if filterRule != blankValue {
+					if filterRule != "" && filterRule != processor.RuleAllowList && filterRule != processor.RuleDenyList {
+						return fmt.Errorf(
+							`invalid filter rule : "%s". valid rules: ("", "%s", "%s")`,
+							filterRule, processor.RuleAllowList, processor.RuleDenyList)
+					}
+					p.Filter.Rule = filterRule
+					actionTaken = true
 				}
 
-				p.Filter.ChannelList = channelList
-				actionTaken = true
-			}
+				filterChannels, _ := flags.GetString(flagFilterChannels)
+				if filterChannels != blankValue {
+					var channelList []string
 
-			srcChainID, _ := flags.GetString(flagSrcChainID)
-			if srcChainID != "" {
-				p.Src.ChainID = srcChainID
-				actionTaken = true
-			}
+					if filterChannels != "" {
+						channelList = strings.Split(filterChannels, ",")
+					}
 
-			dstChainID, _ := flags.GetString(flagDstChainID)
-			if dstChainID != "" {
-				p.Dst.ChainID = dstChainID
-				actionTaken = true
-			}
+					p.Filter.ChannelList = channelList
+					actionTaken = true
+				}
 
-			srcClientID, _ := flags.GetString(flagSrcClientID)
-			if srcClientID != "" {
-				p.Src.ClientID = srcClientID
-				actionTaken = true
-			}
+				srcChainID, _ := flags.GetString(flagSrcChainID)
+				if srcChainID != "" {
+					p.Src.ChainID = srcChainID
+					actionTaken = true
+				}
 
-			dstClientID, _ := flags.GetString(flagDstClientID)
-			if dstClientID != "" {
-				p.Dst.ClientID = dstClientID
-				actionTaken = true
-			}
+				dstChainID, _ := flags.GetString(flagDstChainID)
+				if dstChainID != "" {
+					p.Dst.ChainID = dstChainID
+					actionTaken = true
+				}
 
-			srcConnID, _ := flags.GetString(flagSrcConnID)
-			if srcConnID != "" {
-				p.Src.ConnectionID = srcConnID
-				actionTaken = true
-			}
+				srcClientID, _ := flags.GetString(flagSrcClientID)
+				if srcClientID != "" {
+					p.Src.ClientID = srcClientID
+					actionTaken = true
+				}
 
-			dstConnID, _ := flags.GetString(flagDstConnID)
-			if dstConnID != "" {
-				p.Dst.ConnectionID = dstConnID
-				actionTaken = true
-			}
+				dstClientID, _ := flags.GetString(flagDstClientID)
+				if dstClientID != "" {
+					p.Dst.ClientID = dstClientID
+					actionTaken = true
+				}
 
-			if !actionTaken {
-				return fmt.Errorf("at least one flag must be provided")
-			}
+				srcConnID, _ := flags.GetString(flagSrcConnID)
+				if srcConnID != "" {
+					p.Src.ConnectionID = srcConnID
+					actionTaken = true
+				}
 
-			return a.OverwriteConfig(a.Config)
+				dstConnID, _ := flags.GetString(flagDstConnID)
+				if dstConnID != "" {
+					p.Dst.ConnectionID = dstConnID
+					actionTaken = true
+				}
+
+				if !actionTaken {
+					return fmt.Errorf("at least one flag must be provided")
+				}
+
+				return nil
+			})
 		},
 	}
 	cmd = pathFilterFlags(a.Viper, cmd)
@@ -367,90 +372,87 @@ $ %s pth fch`, appName, defaultHome, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			overwrite, _ := cmd.Flags().GetBool(flagOverwriteConfig)
 
-			chains := []string{}
-			for chainName := range a.Config.Chains {
-				chains = append(chains, chainName)
-			}
+			return a.PerformConfigLockingOperation(cmd.Context(), func() error {
+				chains := []string{}
+				for chainName := range a.Config.Chains {
+					chains = append(chains, chainName)
+				}
 
-			// find all combinations of paths for configured chains
-			chainCombinations := make(map[string]bool)
-			for _, chainA := range chains {
-				for _, chainB := range chains {
-					if chainA == chainB {
+				// find all combinations of paths for configured chains
+				chainCombinations := make(map[string]bool)
+				for _, chainA := range chains {
+					for _, chainB := range chains {
+						if chainA == chainB {
+							continue
+						}
+
+						pair := chainA + "-" + chainB
+						if chainB < chainA {
+							pair = chainB + "-" + chainA
+						}
+						chainCombinations[pair] = true
+					}
+				}
+
+				client := github.NewClient(nil)
+				for pthName := range chainCombinations {
+					_, exist := a.Config.Paths[pthName]
+					if exist && !overwrite {
+						fmt.Fprintf(cmd.ErrOrStderr(), "skipping:  %s already exists in config, use -o to overwrite (clears filters)\n", pthName)
 						continue
 					}
 
-					pair := chainA + "-" + chainB
-					if chainB < chainA {
-						pair = chainB + "-" + chainA
+					// TODO: Don't use github api. Potentially use: https://github.com/eco-stake/cosmos-directory once they integrate IBC data into restAPI. This will avoid rate limits.
+					fileName := pthName + ".json"
+					regPath := path.Join("_IBC", fileName)
+					client, _, err := client.Repositories.DownloadContents(cmd.Context(), "cosmos", "chain-registry", regPath, nil)
+					if err != nil {
+						if errors.As(err, new(*github.RateLimitError)) {
+							fmt.Println("some paths failed: ", err)
+							break
+						}
+						fmt.Fprintf(cmd.ErrOrStderr(), "failure retrieving: %s: consider adding to cosmos/chain-registry: ERR: %v\n", pthName, err)
+						continue
 					}
-					chainCombinations[pair] = true
-				}
-			}
+					defer client.Close()
 
-			client := github.NewClient(nil)
-			for pthName := range chainCombinations {
-				_, exist := a.Config.Paths[pthName]
-				if exist && !overwrite {
-					fmt.Fprintf(cmd.ErrOrStderr(), "skipping:  %s already exists in config, use -o to overwrite (clears filters)\n", pthName)
-					continue
-				}
-
-				// TODO: Don't use github api. Potentially use: https://github.com/eco-stake/cosmos-directory once they integrate IBC data into restAPI. This will avoid rate limits.
-				fileName := pthName + ".json"
-				regPath := path.Join("_IBC", fileName)
-				client, _, err := client.Repositories.DownloadContents(cmd.Context(), "cosmos", "chain-registry", regPath, nil)
-				if err != nil {
-					if errors.As(err, new(*github.RateLimitError)) {
-						fmt.Println("some paths failed: ", err)
-						break
+					b, err := io.ReadAll(client)
+					if err != nil {
+						return fmt.Errorf("error reading response body: %w", err)
 					}
-					fmt.Fprintf(cmd.ErrOrStderr(), "failure retrieving: %s: consider adding to cosmos/chain-registry: ERR: %v\n", pthName, err)
-					continue
+
+					ibc := &relayer.IBCdata{}
+					if err = json.Unmarshal(b, &ibc); err != nil {
+						return fmt.Errorf("failed to unmarshal: %w ", err)
+					}
+
+					srcChainName := ibc.Chain1.ChainName
+					dstChainName := ibc.Chain2.ChainName
+
+					srcPathEnd := &relayer.PathEnd{
+						ChainID:      a.Config.Chains[srcChainName].ChainID(),
+						ClientID:     ibc.Chain1.ClientID,
+						ConnectionID: ibc.Chain1.ConnectionID,
+					}
+					dstPathEnd := &relayer.PathEnd{
+						ChainID:      a.Config.Chains[dstChainName].ChainID(),
+						ClientID:     ibc.Chain2.ClientID,
+						ConnectionID: ibc.Chain2.ConnectionID,
+					}
+					newPath := &relayer.Path{
+						Src: srcPathEnd,
+						Dst: dstPathEnd,
+					}
+					client.Close()
+
+					if err = a.Config.AddPath(pthName, newPath); err != nil {
+						return fmt.Errorf("failed to add path %s: %w", pthName, err)
+					}
+					fmt.Fprintf(cmd.ErrOrStderr(), "added:  %s\n", pthName)
+
 				}
-				defer client.Close()
-
-				b, err := io.ReadAll(client)
-				if err != nil {
-					return fmt.Errorf("error reading response body: %w", err)
-				}
-
-				ibc := &relayer.IBCdata{}
-				if err = json.Unmarshal(b, &ibc); err != nil {
-					return fmt.Errorf("failed to unmarshal: %w ", err)
-				}
-
-				srcChainName := ibc.Chain1.ChainName
-				dstChainName := ibc.Chain2.ChainName
-
-				srcPathEnd := &relayer.PathEnd{
-					ChainID:      a.Config.Chains[srcChainName].ChainID(),
-					ClientID:     ibc.Chain1.ClientID,
-					ConnectionID: ibc.Chain1.ConnectionID,
-				}
-				dstPathEnd := &relayer.PathEnd{
-					ChainID:      a.Config.Chains[dstChainName].ChainID(),
-					ClientID:     ibc.Chain2.ClientID,
-					ConnectionID: ibc.Chain2.ConnectionID,
-				}
-				newPath := &relayer.Path{
-					Src: srcPathEnd,
-					Dst: dstPathEnd,
-				}
-				client.Close()
-
-				if err = a.Config.AddPath(pthName, newPath); err != nil {
-					return fmt.Errorf("failed to add path %s: %w", pthName, err)
-				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "added:  %s\n", pthName)
-
-			}
-
-			if err := a.OverwriteConfig(a.Config); err != nil {
-				return err
-			}
-			return nil
-
+				return nil
+			})
 		},
 	}
 	return OverwriteConfigFlag(a.Viper, cmd)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -63,7 +63,7 @@ $ %s q ibc-denoms ibc-0`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -99,7 +99,7 @@ $ %s q denom-trace osmosis 9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D9
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, ok := a.Config.Chains[args[0]]
+			c, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -127,7 +127,7 @@ $ %s q tx ibc-0 A5DF8D272F1C451CFF92BA6C41942C4D29B5CF180279439ED6AB038282F956BE
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -168,7 +168,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -198,7 +198,7 @@ $ %s q txs ibc-0 "message.action=transfer"`,
 		},
 	}
 
-	return paginationFlags(a.Viper, cmd, "txs")
+	return paginationFlags(a.viper, cmd, "txs")
 }
 
 func queryBalanceCmd(a *appState) *cobra.Command {
@@ -213,7 +213,7 @@ $ %s query balance ibc-0 testkey`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -247,7 +247,7 @@ $ %s query balance ibc-0 testkey`,
 		},
 	}
 
-	return ibcDenomFlags(a.Viper, cmd)
+	return ibcDenomFlags(a.viper, cmd)
 }
 
 func queryHeaderCmd(a *appState) *cobra.Command {
@@ -261,7 +261,7 @@ $ %s query header ibc-0 1400`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -315,7 +315,7 @@ $ %s q node-state ibc-1`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -355,7 +355,7 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -392,7 +392,7 @@ $ %s query client ibc-0 ibczeroclient --height 1205`,
 		},
 	}
 
-	return heightFlag(a.Viper, cmd)
+	return heightFlag(a.viper, cmd)
 }
 
 func queryClientsCmd(a *appState) *cobra.Command {
@@ -407,7 +407,7 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -437,7 +437,7 @@ $ %s query clients ibc-2 --offset 2 --limit 30`,
 		},
 	}
 
-	return paginationFlags(a.Viper, cmd, "client states")
+	return paginationFlags(a.viper, cmd, "client states")
 }
 
 func queryConnections(a *appState) *cobra.Command {
@@ -453,7 +453,7 @@ $ %s q conns ibc-1`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -483,7 +483,7 @@ $ %s q conns ibc-1`,
 		},
 	}
 
-	return paginationFlags(a.Viper, cmd, "connections on a network")
+	return paginationFlags(a.viper, cmd, "connections on a network")
 }
 
 func queryConnectionsUsingClient(a *appState) *cobra.Command {
@@ -499,7 +499,7 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//TODO - Add pagination
 
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -536,7 +536,7 @@ $ %s query client-connections ibc-0 ibczeroclient --height 1205`,
 		},
 	}
 
-	return heightFlag(a.Viper, cmd)
+	return heightFlag(a.viper, cmd)
 }
 
 func queryConnection(a *appState) *cobra.Command {
@@ -551,7 +551,7 @@ $ %s q conn ibc-1 ibconeconn`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -595,7 +595,7 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -629,7 +629,7 @@ $ %s query connection-channels ibc-2 ibcconnection2 --offset 2 --limit 30`,
 		},
 	}
 
-	return paginationFlags(a.Viper, cmd, "channels associated with a connection")
+	return paginationFlags(a.viper, cmd, "channels associated with a connection")
 }
 
 func queryChannel(a *appState) *cobra.Command {
@@ -643,7 +643,7 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -682,7 +682,7 @@ $ %s query channel ibc-2 ibctwochannel transfer --height 1205`,
 		},
 	}
 
-	return heightFlag(a.Viper, cmd)
+	return heightFlag(a.viper, cmd)
 }
 
 // chanExtendedInfo is an intermediate type for holding additional useful
@@ -880,13 +880,13 @@ $ %s query channels ibc-0 ibc-2`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
 
 			if len(args) > 1 {
-				dstChain, ok := a.Config.Chains[args[1]]
+				dstChain, ok := a.config.Chains[args[1]]
 				if !ok {
 					return errChainNotFound(args[1])
 				}
@@ -902,7 +902,7 @@ $ %s query channels ibc-0 ibc-2`,
 		},
 	}
 
-	return paginationFlags(a.Viper, cmd, "channels on a network")
+	return paginationFlags(a.viper, cmd, "channels on a network")
 }
 
 func queryPacketCommitment(a *appState) *cobra.Command {
@@ -916,7 +916,7 @@ $ %s q packet-commit ibc-1 ibconechannel transfer 31`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			chain, ok := a.Config.Chains[args[0]]
+			chain, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
@@ -961,14 +961,14 @@ $ %s query unrelayed-pkts demo-path channel-0`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := a.Config.Paths.Get(args[0])
+			path, err := a.config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 
 			src, dst := path.Src.ChainID, path.Dst.ChainID
 
-			c, err := a.Config.Chains.Gets(src, dst)
+			c, err := a.config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
@@ -1014,13 +1014,13 @@ $ %s query unrelayed-acks demo-path channel-0`,
 			appName, appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := a.Config.Paths.Get(args[0])
+			path, err := a.config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 			src, dst := path.Src.ChainID, path.Dst.ChainID
 
-			c, err := a.Config.Chains.Gets(src, dst)
+			c, err := a.config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
@@ -1063,12 +1063,12 @@ $ %s query clients-expiration demo-path`,
 			appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path, err := a.Config.Paths.Get(args[0])
+			path, err := a.config.Paths.Get(args[0])
 			if err != nil {
 				return err
 			}
 			src, dst := path.Src.ChainID, path.Dst.ChainID
-			c, err := a.Config.Chains.Gets(src, dst)
+			c, err := a.config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func NewRootCmd(log *zap.Logger) *cobra.Command {
 		}
 
 		// reads `homeDir/config/config.yaml` into `a.Config`
-		return initConfig(rootCmd, a)
+		return a.initConfig(rootCmd.Context())
 	}
 
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, _ []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func NewRootCmd(log *zap.Logger) *cobra.Command {
 		}
 
 		// reads `homeDir/config/config.yaml` into `a.Config`
-		return a.initConfig(rootCmd.Context())
+		return a.loadConfigFile(rootCmd.Context())
 	}
 
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, _ []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,9 +57,9 @@ func NewRootCmd(log *zap.Logger) *cobra.Command {
 	// Use a local app state instance scoped to the new root command,
 	// so that tests don't concurrently access the state.
 	a := &appState{
-		Viper: viper.New(),
+		viper: viper.New(),
 
-		Log: log,
+		log: log,
 	}
 
 	// RootCmd represents the base command when called without any subcommands
@@ -78,12 +78,12 @@ func NewRootCmd(log *zap.Logger) *cobra.Command {
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		// Inside persistent pre-run because this takes effect after flags are parsed.
 		if log == nil {
-			log, err := newRootLogger(a.Viper.GetString("log-format"), a.Viper.GetBool("debug"))
+			log, err := newRootLogger(a.viper.GetString("log-format"), a.viper.GetBool("debug"))
 			if err != nil {
 				return err
 			}
 
-			a.Log = log
+			a.log = log
 		}
 
 		// reads `homeDir/config/config.yaml` into `a.Config`
@@ -92,23 +92,23 @@ func NewRootCmd(log *zap.Logger) *cobra.Command {
 
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, _ []string) {
 		// Force syncing the logs before exit, if anything is buffered.
-		a.Log.Sync()
+		_ = a.log.Sync()
 	}
 
 	// Register --home flag
-	rootCmd.PersistentFlags().StringVar(&a.HomePath, flagHome, defaultHome, "set home directory")
-	if err := a.Viper.BindPFlag(flagHome, rootCmd.PersistentFlags().Lookup(flagHome)); err != nil {
+	rootCmd.PersistentFlags().StringVar(&a.homePath, flagHome, defaultHome, "set home directory")
+	if err := a.viper.BindPFlag(flagHome, rootCmd.PersistentFlags().Lookup(flagHome)); err != nil {
 		panic(err)
 	}
 
 	// Register --debug flag
-	rootCmd.PersistentFlags().BoolVarP(&a.Debug, "debug", "d", false, "debug output")
-	if err := a.Viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+	rootCmd.PersistentFlags().BoolVarP(&a.debug, "debug", "d", false, "debug output")
+	if err := a.viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		panic(err)
 	}
 
 	rootCmd.PersistentFlags().String("log-format", "auto", "log output format (auto, logfmt, json, or console)")
-	if err := a.Viper.BindPFlag("log-format", rootCmd.PersistentFlags().Lookup("log-format")); err != nil {
+	if err := a.viper.BindPFlag("log-format", rootCmd.PersistentFlags().Lookup("log-format")); err != nil {
 		panic(err)
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -50,7 +50,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 
 			if len(args) > 0 {
 				for i, pathName := range args {
-					path := a.Config.Paths.MustGet(pathName)
+					path := a.config.Paths.MustGet(pathName)
 					paths[i] = relayer.NamedPath{
 						Name: pathName,
 						Path: path,
@@ -61,7 +61,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 					chains[path.Dst.ChainID] = nil
 				}
 			} else {
-				for n, path := range a.Config.Paths {
+				for n, path := range a.config.Paths {
 					paths = append(paths, relayer.NamedPath{
 						Name: n,
 						Path: path,
@@ -79,7 +79,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			}
 
 			// get chain configurations
-			chains, err := a.Config.Chains.Gets(chainIDs...)
+			chains, err := a.config.Chains.Gets(chainIDs...)
 			if err != nil {
 				return err
 			}
@@ -95,7 +95,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 
 			var prometheusMetrics *processor.PrometheusMetrics
 
-			debugAddr := a.Config.Global.APIListenPort
+			debugAddr := a.config.Global.APIListenPort
 
 			debugAddrFlag, err := cmd.Flags().GetString(flagDebugAddr)
 			if err != nil {
@@ -107,14 +107,14 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			}
 
 			if debugAddr == "" {
-				a.Log.Info("Skipping debug server due to empty debug address flag")
+				a.log.Info("Skipping debug server due to empty debug address flag")
 			} else {
 				ln, err := net.Listen("tcp", debugAddr)
 				if err != nil {
-					a.Log.Error("Failed to listen on debug address. If you have another relayer process open, use --" + flagDebugAddr + " to pick a different address.")
+					a.log.Error("Failed to listen on debug address. If you have another relayer process open, use --" + flagDebugAddr + " to pick a different address.")
 					return fmt.Errorf("failed to listen on debug address %q: %w", debugAddr, err)
 				}
-				log := a.Log.With(zap.String("sys", "debughttp"))
+				log := a.log.With(zap.String("sys", "debughttp"))
 				log.Info("Debug server listening", zap.String("addr", debugAddr))
 				prometheusMetrics = processor.NewPrometheusMetrics()
 				relaydebug.StartDebugServer(cmd.Context(), log, ln, prometheusMetrics.Registry)
@@ -146,11 +146,11 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 
 			rlyErrCh := relayer.StartRelayer(
 				cmd.Context(),
-				a.Log,
+				a.log,
 				chains,
 				paths,
 				maxTxSize, maxMsgLength,
-				a.Config.memo(cmd),
+				a.config.memo(cmd),
 				clientUpdateThresholdTime,
 				flushInterval,
 				nil,
@@ -164,7 +164,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			// so we don't want to separately monitor the ctx.Done channel,
 			// because we would risk returning before the relayer cleans up.
 			if err := <-rlyErrCh; err != nil && !errors.Is(err, context.Canceled) {
-				a.Log.Warn(
+				a.log.Warn(
 					"Relayer start error",
 					zap.Error(err),
 				)
@@ -173,13 +173,13 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			return nil
 		},
 	}
-	cmd = updateTimeFlags(a.Viper, cmd)
-	cmd = strategyFlag(a.Viper, cmd)
-	cmd = debugServerFlags(a.Viper, cmd)
-	cmd = processorFlag(a.Viper, cmd)
-	cmd = initBlockFlag(a.Viper, cmd)
-	cmd = flushIntervalFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = updateTimeFlags(a.viper, cmd)
+	cmd = strategyFlag(a.viper, cmd)
+	cmd = debugServerFlags(a.viper, cmd)
+	cmd = processorFlag(a.viper, cmd)
+	cmd = initBlockFlag(a.viper, cmd)
+	cmd = flushIntervalFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -85,7 +85,7 @@ func createClientsCmd(a *appState) *cobra.Command {
 
 			path := args[0]
 
-			c, src, dst, err := a.Config.ChainsFromPath(path)
+			c, src, dst, err := a.config.ChainsFromPath(path)
 			if err != nil {
 				return err
 			}
@@ -98,12 +98,12 @@ func createClientsCmd(a *appState) *cobra.Command {
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			clientSrc, clientDst, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, customClientTrustingPeriod, a.Config.memo(cmd))
+			clientSrc, clientDst, err := c[src].CreateClients(cmd.Context(), c[dst], allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, customClientTrustingPeriod, a.config.memo(cmd))
 			if err != nil {
 				return err
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd.Context(), path, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.updatePathConfig(cmd.Context(), path, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -112,9 +112,9 @@ func createClientsCmd(a *appState) *cobra.Command {
 		},
 	}
 
-	cmd = clientParameterFlags(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = clientParameterFlags(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -147,17 +147,17 @@ func createClientCmd(a *appState) *cobra.Command {
 				return err
 			}
 
-			src, ok := a.Config.Chains[args[0]]
+			src, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
-			dst, ok := a.Config.Chains[args[1]]
+			dst, ok := a.config.Chains[args[1]]
 			if !ok {
 				return errChainNotFound(args[1])
 			}
 
 			pathName := args[2]
-			path, err := a.Config.Paths.Get(pathName)
+			path, err := a.config.Paths.Get(pathName)
 			if err != nil {
 				return err
 			}
@@ -194,7 +194,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				}
 				return nil
 			}, retry.Context(cmd.Context()), relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
-				a.Log.Info(
+				a.log.Info(
 					"Failed to get light signed header",
 					zap.String("src_chain_id", src.ChainID()),
 					zap.Int64("src_height", srch),
@@ -209,7 +209,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				return err
 			}
 
-			clientID, err := relayer.CreateClient(cmd.Context(), src, dst, srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, customClientTrustingPeriod, a.Config.memo(cmd))
+			clientID, err := relayer.CreateClient(cmd.Context(), src, dst, srcUpdateHeader, dstUpdateHeader, allowUpdateAfterExpiry, allowUpdateAfterMisbehaviour, override, customClientTrustingPeriod, a.config.memo(cmd))
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				clientDst = clientID
 			}
 			if clientID != "" {
-				if err = a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err = a.updatePathConfig(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -229,9 +229,9 @@ func createClientCmd(a *appState) *cobra.Command {
 		},
 	}
 
-	cmd = clientParameterFlags(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = clientParameterFlags(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -245,7 +245,7 @@ corresponding update-client messages.`,
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`$ %s transact update-clients demo-path`, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := a.Config.ChainsFromPath(args[0])
+			c, src, dst, err := a.config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -258,11 +258,11 @@ corresponding update-client messages.`,
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			return relayer.UpdateClients(cmd.Context(), c[src], c[dst], a.Config.memo(cmd))
+			return relayer.UpdateClients(cmd.Context(), c[src], c[dst], a.config.memo(cmd))
 		},
 	}
 
-	return memoFlag(a.Viper, cmd)
+	return memoFlag(a.viper, cmd)
 }
 
 func upgradeClientsCmd(a *appState) *cobra.Command {
@@ -271,7 +271,7 @@ func upgradeClientsCmd(a *appState) *cobra.Command {
 		Short: "upgrades IBC clients between two configured chains with a configured path and chain-id",
 		Args:  withUsage(cobra.ExactArgs(2)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, src, dst, err := a.Config.ChainsFromPath(args[0])
+			c, src, dst, err := a.config.ChainsFromPath(args[0])
 			if err != nil {
 				return err
 			}
@@ -291,7 +291,7 @@ func upgradeClientsCmd(a *appState) *cobra.Command {
 
 			targetChainID := args[1]
 
-			memo := a.Config.memo(cmd)
+			memo := a.config.memo(cmd)
 
 			// send the upgrade message on the targetChainID
 			if src == targetChainID {
@@ -302,8 +302,8 @@ func upgradeClientsCmd(a *appState) *cobra.Command {
 		},
 	}
 
-	cmd = heightFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = heightFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -339,7 +339,7 @@ $ %s tx conn demo-path --timeout 5s`,
 
 			pathName := args[0]
 
-			c, src, dst, err := a.Config.ChainsFromPath(pathName)
+			c, src, dst, err := a.config.ChainsFromPath(pathName)
 			if err != nil {
 				return err
 			}
@@ -367,7 +367,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			memo := a.Config.memo(cmd)
+			memo := a.config.memo(cmd)
 
 			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
 			if err != nil {
@@ -380,7 +380,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.updatePathConfig(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -390,7 +390,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 			if connectionSrc != "" || connectionDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
+				if err := a.updatePathConfig(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
 					return err
 				}
 			}
@@ -399,12 +399,12 @@ $ %s tx conn demo-path --timeout 5s`,
 		},
 	}
 
-	cmd = timeoutFlag(a.Viper, cmd)
-	cmd = retryFlag(a.Viper, cmd)
-	cmd = clientParameterFlags(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
-	cmd = initBlockFlag(a.Viper, cmd)
+	cmd = timeoutFlag(a.viper, cmd)
+	cmd = retryFlag(a.viper, cmd)
+	cmd = clientParameterFlags(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
+	cmd = initBlockFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -426,7 +426,7 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 
 			pathName := args[0]
 
-			c, src, dst, err := a.Config.ChainsFromPath(pathName)
+			c, src, dst, err := a.config.ChainsFromPath(pathName)
 			if err != nil {
 				return err
 			}
@@ -475,15 +475,15 @@ $ %s tx chan demo-path --timeout 5s --max-retries 10`,
 			}
 
 			// create channel if it isn't already created
-			return c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override, a.Config.memo(cmd), pathName)
+			return c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override, a.config.memo(cmd), pathName)
 		},
 	}
 
-	cmd = timeoutFlag(a.Viper, cmd)
-	cmd = retryFlag(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = channelParameterFlags(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = timeoutFlag(a.viper, cmd)
+	cmd = retryFlag(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = channelParameterFlags(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -502,7 +502,7 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pathName := args[0]
 
-			c, src, dst, err := a.Config.ChainsFromPath(pathName)
+			c, src, dst, err := a.config.ChainsFromPath(pathName)
 			if err != nil {
 				return err
 			}
@@ -538,13 +538,13 @@ $ %s tx channel-close demo-path channel-0 transfer -o 3s`,
 				return err
 			}
 
-			return c[src].CloseChannel(cmd.Context(), c[dst], retries, to, channelID, portID, a.Config.memo(cmd), pathName)
+			return c[src].CloseChannel(cmd.Context(), c[dst], retries, to, channelID, portID, a.config.memo(cmd), pathName)
 		},
 	}
 
-	cmd = timeoutFlag(a.Viper, cmd)
-	cmd = retryFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = timeoutFlag(a.viper, cmd)
+	cmd = retryFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -581,13 +581,13 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 
 			pathName := args[0]
 
-			pth, err := a.Config.Paths.Get(pathName)
+			pth, err := a.config.Paths.Get(pathName)
 			if err != nil {
 				return err
 			}
 
 			src, dst := pth.Src.ChainID, pth.Dst.ChainID
-			c, err := a.Config.Chains.Gets(src, dst)
+			c, err := a.config.Chains.Gets(src, dst)
 			if err != nil {
 				return err
 			}
@@ -638,7 +638,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return fmt.Errorf("key %s not found on dst chain %s", c[dst].ChainProvider.Key(), c[dst].ChainID())
 			}
 
-			memo := a.Config.memo(cmd)
+			memo := a.config.memo(cmd)
 
 			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
 			if err != nil {
@@ -651,7 +651,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return fmt.Errorf("error creating clients: %w", err)
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.updatePathConfig(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -662,7 +662,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return fmt.Errorf("error creating connections: %w", err)
 			}
 			if connectionSrc != "" || connectionDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
+				if err := a.updatePathConfig(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
 					return err
 				}
 			}
@@ -671,13 +671,13 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 			return c[src].CreateOpenChannels(cmd.Context(), c[dst], retries, to, srcPort, dstPort, order, version, override, memo, pathName)
 		},
 	}
-	cmd = timeoutFlag(a.Viper, cmd)
-	cmd = retryFlag(a.Viper, cmd)
-	cmd = clientParameterFlags(a.Viper, cmd)
-	cmd = channelParameterFlags(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
-	cmd = initBlockFlag(a.Viper, cmd)
+	cmd = timeoutFlag(a.viper, cmd)
+	cmd = retryFlag(a.viper, cmd)
+	cmd = clientParameterFlags(a.viper, cmd)
+	cmd = channelParameterFlags(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
+	cmd = initBlockFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -697,7 +697,7 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 			lCmd := linkCmd(a)
 
 			for err := lCmd.RunE(cmd, args); err != nil; err = lCmd.RunE(cmd, args) {
-				a.Log.Info("Error running link; retrying", zap.Error(err))
+				a.log.Info("Error running link; retrying", zap.Error(err))
 				select {
 				case <-time.After(time.Second):
 					// Keep going.
@@ -711,17 +711,17 @@ $ %s tx link-then-start demo-path --timeout 5s`, appName, appName)),
 		},
 	}
 
-	cmd = timeoutFlag(a.Viper, cmd)
-	cmd = retryFlag(a.Viper, cmd)
-	cmd = strategyFlag(a.Viper, cmd)
-	cmd = clientParameterFlags(a.Viper, cmd)
-	cmd = channelParameterFlags(a.Viper, cmd)
-	cmd = overrideFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
-	cmd = debugServerFlags(a.Viper, cmd)
-	cmd = initBlockFlag(a.Viper, cmd)
-	cmd = processorFlag(a.Viper, cmd)
-	cmd = updateTimeFlags(a.Viper, cmd)
+	cmd = timeoutFlag(a.viper, cmd)
+	cmd = retryFlag(a.viper, cmd)
+	cmd = strategyFlag(a.viper, cmd)
+	cmd = clientParameterFlags(a.viper, cmd)
+	cmd = channelParameterFlags(a.viper, cmd)
+	cmd = overrideFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
+	cmd = debugServerFlags(a.viper, cmd)
+	cmd = initBlockFlag(a.viper, cmd)
+	cmd = processorFlag(a.viper, cmd)
+	cmd = updateTimeFlags(a.viper, cmd)
 	return cmd
 }
 
@@ -743,7 +743,7 @@ $ %s tx flush demo-path channel-0`,
 
 			if len(args) > 0 {
 				pathName := args[0]
-				path := a.Config.Paths.MustGet(pathName)
+				path := a.config.Paths.MustGet(pathName)
 				paths = append(paths, relayer.NamedPath{
 					Name: pathName,
 					Path: path,
@@ -753,7 +753,7 @@ $ %s tx flush demo-path channel-0`,
 				chains[path.Src.ChainID] = nil
 				chains[path.Dst.ChainID] = nil
 			} else {
-				for n, path := range a.Config.Paths {
+				for n, path := range a.config.Paths {
 					paths = append(paths, relayer.NamedPath{
 						Name: n,
 						Path: path,
@@ -771,7 +771,7 @@ $ %s tx flush demo-path channel-0`,
 			}
 
 			// get chain configurations
-			chains, err := a.Config.Chains.Gets(chainIDs...)
+			chains, err := a.config.Chains.Gets(chainIDs...)
 			if err != nil {
 				return err
 			}
@@ -798,11 +798,11 @@ $ %s tx flush demo-path channel-0`,
 
 			rlyErrCh := relayer.StartRelayer(
 				ctx,
-				a.Log,
+				a.log,
 				chains,
 				paths,
 				maxTxSize, maxMsgLength,
-				a.Config.memo(cmd),
+				a.config.memo(cmd),
 				0,
 				0,
 				&processor.FlushLifecycle{},
@@ -816,7 +816,7 @@ $ %s tx flush demo-path channel-0`,
 			// so we don't want to separately monitor the ctx.Done channel,
 			// because we would risk returning before the relayer cleans up.
 			if err := <-rlyErrCh; err != nil && !errors.Is(err, context.Canceled) {
-				a.Log.Warn(
+				a.log.Warn(
 					"Relayer start error",
 					zap.Error(err),
 				)
@@ -826,8 +826,8 @@ $ %s tx flush demo-path channel-0`,
 		},
 	}
 
-	cmd = strategyFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = strategyFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -843,13 +843,13 @@ $ %s tx relay-pkts demo-path channel-0`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a.Log.Warn("This command is deprecated. Please use 'tx flush' command instead")
+			a.log.Warn("This command is deprecated. Please use 'tx flush' command instead")
 			return flushCmd(a).RunE(cmd, args)
 		},
 	}
 
-	cmd = strategyFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = strategyFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -865,13 +865,13 @@ $ %s tx relay-acks demo-path channel-0 -l 3 -s 6`,
 			appName, appName,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a.Log.Warn("This command is deprecated. Please use 'tx flush' command instead")
+			a.log.Warn("This command is deprecated. Please use 'tx flush' command instead")
 			return flushCmd(a).RunE(cmd, args)
 		},
 	}
 
-	cmd = strategyFlag(a.Viper, cmd)
-	cmd = memoFlag(a.Viper, cmd)
+	cmd = strategyFlag(a.viper, cmd)
+	cmd = memoFlag(a.viper, cmd)
 	return cmd
 }
 
@@ -889,11 +889,11 @@ $ %s tx transfer ibc-0 ibc-1 100000stake raw:non-bech32-address channel-0 --path
 $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk channel-0 --path demo -c 5
 `, appName, appName, appName, appName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			src, ok := a.Config.Chains[args[0]]
+			src, ok := a.config.Chains[args[0]]
 			if !ok {
 				return errChainNotFound(args[0])
 			}
-			dst, ok := a.Config.Chains[args[1]]
+			dst, ok := a.config.Chains[args[1]]
 			if !ok {
 				return errChainNotFound(args[1])
 			}
@@ -979,16 +979,16 @@ $ %s tx raw send ibc-0 ibc-1 100000stake cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9
 				dstAddr = rawDstAddr
 			}
 
-			return src.SendTransferMsg(cmd.Context(), a.Log, dst, amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
+			return src.SendTransferMsg(cmd.Context(), a.log, dst, amount, dstAddr, toHeightOffset, toTimeOffset, srcChannel)
 		},
 	}
 
-	return timeoutFlags(a.Viper, pathFlag(a.Viper, cmd))
+	return timeoutFlags(a.viper, pathFlag(a.viper, cmd))
 }
 
 func setPathsFromArgs(a *appState, src, dst *relayer.Chain, name string) (*relayer.Path, error) {
 	// find any configured paths between the chains
-	paths, err := a.Config.Paths.PathsFromChains(src.ChainID(), dst.ChainID())
+	paths, err := a.config.Paths.PathsFromChains(src.ChainID(), dst.ChainID())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -103,7 +103,7 @@ func createClientsCmd(a *appState) *cobra.Command {
 				return err
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd, path, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.OverwriteConfigOnTheFly(cmd.Context(), path, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -220,7 +220,7 @@ func createClientCmd(a *appState) *cobra.Command {
 				clientDst = clientID
 			}
 			if clientID != "" {
-				if err = a.OverwriteConfigOnTheFly(cmd, pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err = a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -380,7 +380,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd, pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -390,7 +390,7 @@ $ %s tx conn demo-path --timeout 5s`,
 				return err
 			}
 			if connectionSrc != "" || connectionDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd, pathName, "", "", connectionSrc, connectionDst); err != nil {
+				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
 					return err
 				}
 			}
@@ -651,7 +651,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return fmt.Errorf("error creating clients: %w", err)
 			}
 			if clientSrc != "" || clientDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd, pathName, clientSrc, clientDst, "", ""); err != nil {
+				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, clientSrc, clientDst, "", ""); err != nil {
 					return err
 				}
 			}
@@ -662,7 +662,7 @@ $ %s tx connect demo-path --src-port transfer --dst-port transfer --order unorde
 				return fmt.Errorf("error creating connections: %w", err)
 			}
 			if connectionSrc != "" || connectionDst != "" {
-				if err := a.OverwriteConfigOnTheFly(cmd, pathName, "", "", connectionSrc, connectionDst); err != nil {
+				if err := a.OverwriteConfigOnTheFly(cmd.Context(), pathName, "", "", connectionSrc, connectionDst); err != nil {
 					return err
 				}
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -76,5 +76,5 @@ $ %s v`,
 		},
 	}
 
-	return jsonFlag(a.Viper, versionCmd)
+	return jsonFlag(a.viper, versionCmd)
 }


### PR DESCRIPTION
Packet forward middleware test concurrent add path calls were overwriting previously written config data, causing things like client and connection IDs to be lost.