### PR TITLE
Make min query loop duration configurable

### DIFF
--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -35,25 +35,26 @@ var (
 const cometEncodingThreshold = "v0.37.0-alpha"
 
 type CosmosProviderConfig struct {
-	KeyDirectory   string                  `json:"key-directory" yaml:"key-directory"`
-	Key            string                  `json:"key" yaml:"key"`
-	ChainName      string                  `json:"-" yaml:"-"`
-	ChainID        string                  `json:"chain-id" yaml:"chain-id"`
-	RPCAddr        string                  `json:"rpc-addr" yaml:"rpc-addr"`
-	AccountPrefix  string                  `json:"account-prefix" yaml:"account-prefix"`
-	KeyringBackend string                  `json:"keyring-backend" yaml:"keyring-backend"`
-	GasAdjustment  float64                 `json:"gas-adjustment" yaml:"gas-adjustment"`
-	GasPrices      string                  `json:"gas-prices" yaml:"gas-prices"`
-	MinGasAmount   uint64                  `json:"min-gas-amount" yaml:"min-gas-amount"`
-	Debug          bool                    `json:"debug" yaml:"debug"`
-	Timeout        string                  `json:"timeout" yaml:"timeout"`
-	BlockTimeout   string                  `json:"block-timeout" yaml:"block-timeout"`
-	OutputFormat   string                  `json:"output-format" yaml:"output-format"`
-	SignModeStr    string                  `json:"sign-mode" yaml:"sign-mode"`
-	ExtraCodecs    []string                `json:"extra-codecs" yaml:"extra-codecs"`
-	Modules        []module.AppModuleBasic `json:"-" yaml:"-"`
-	Slip44         *int                    `json:"coin-type" yaml:"coin-type"`
-	Broadcast      provider.BroadcastMode  `json:"broadcast-mode" yaml:"broadcast-mode"`
+	KeyDirectory    string                  `json:"key-directory" yaml:"key-directory"`
+	Key             string                  `json:"key" yaml:"key"`
+	ChainName       string                  `json:"-" yaml:"-"`
+	ChainID         string                  `json:"chain-id" yaml:"chain-id"`
+	RPCAddr         string                  `json:"rpc-addr" yaml:"rpc-addr"`
+	AccountPrefix   string                  `json:"account-prefix" yaml:"account-prefix"`
+	KeyringBackend  string                  `json:"keyring-backend" yaml:"keyring-backend"`
+	GasAdjustment   float64                 `json:"gas-adjustment" yaml:"gas-adjustment"`
+	GasPrices       string                  `json:"gas-prices" yaml:"gas-prices"`
+	MinGasAmount    uint64                  `json:"min-gas-amount" yaml:"min-gas-amount"`
+	Debug           bool                    `json:"debug" yaml:"debug"`
+	Timeout         string                  `json:"timeout" yaml:"timeout"`
+	BlockTimeout    string                  `json:"block-timeout" yaml:"block-timeout"`
+	OutputFormat    string                  `json:"output-format" yaml:"output-format"`
+	SignModeStr     string                  `json:"sign-mode" yaml:"sign-mode"`
+	ExtraCodecs     []string                `json:"extra-codecs" yaml:"extra-codecs"`
+	Modules         []module.AppModuleBasic `json:"-" yaml:"-"`
+	Slip44          *int                    `json:"coin-type" yaml:"coin-type"`
+	Broadcast       provider.BroadcastMode  `json:"broadcast-mode" yaml:"broadcast-mode"`
+	MinLoopDuration time.Duration           `json:"min-loop-duration" yaml:"min-loop-duration"`
 }
 
 func (pc CosmosProviderConfig) Validate() error {

--- a/relayer/chains/penumbra/penumbra_chain_processor.go
+++ b/relayer/chains/penumbra/penumbra_chain_processor.go
@@ -154,9 +154,14 @@ type queryCyclePersistence struct {
 // The initialBlockHistory parameter determines how many historical blocks should be fetched and processed before continuing with current blocks.
 // ChainProcessors should obey the context and return upon context cancellation.
 func (pcp *PenumbraChainProcessor) Run(ctx context.Context, initialBlockHistory uint64) error {
+	minQueryLoopDuration := pcp.chainProvider.PCfg.MinLoopDuration
+	if minQueryLoopDuration == 0 {
+		minQueryLoopDuration = defaultMinQueryLoopDuration
+	}
+
 	// this will be used for persistence across query cycle loop executions
 	persistence := queryCyclePersistence{
-		minQueryLoopDuration: defaultMinQueryLoopDuration,
+		minQueryLoopDuration: minQueryLoopDuration,
 	}
 
 	// Infinite retry to get initial latest height

--- a/relayer/chains/penumbra/provider.go
+++ b/relayer/chains/penumbra/provider.go
@@ -37,25 +37,26 @@ var (
 const cometEncodingThreshold = "v0.37.0-alpha"
 
 type PenumbraProviderConfig struct {
-	KeyDirectory   string                  `json:"key-directory" yaml:"key-directory"`
-	Key            string                  `json:"key" yaml:"key"`
-	ChainName      string                  `json:"-" yaml:"-"`
-	ChainID        string                  `json:"chain-id" yaml:"chain-id"`
-	RPCAddr        string                  `json:"rpc-addr" yaml:"rpc-addr"`
-	AccountPrefix  string                  `json:"account-prefix" yaml:"account-prefix"`
-	KeyringBackend string                  `json:"keyring-backend" yaml:"keyring-backend"`
-	GasAdjustment  float64                 `json:"gas-adjustment" yaml:"gas-adjustment"`
-	GasPrices      string                  `json:"gas-prices" yaml:"gas-prices"`
-	MinGasAmount   uint64                  `json:"min-gas-amount" yaml:"min-gas-amount"`
-	Debug          bool                    `json:"debug" yaml:"debug"`
-	Timeout        string                  `json:"timeout" yaml:"timeout"`
-	BlockTimeout   string                  `json:"block-timeout" yaml:"block-timeout"`
-	OutputFormat   string                  `json:"output-format" yaml:"output-format"`
-	SignModeStr    string                  `json:"sign-mode" yaml:"sign-mode"`
-	ExtraCodecs    []string                `json:"extra-codecs" yaml:"extra-codecs"`
-	Modules        []module.AppModuleBasic `json:"-" yaml:"-"`
-	Slip44         int                     `json:"coin-type" yaml:"coin-type"`
-	Broadcast      provider.BroadcastMode  `json:"broadcast-mode" yaml:"broadcast-mode"`
+	KeyDirectory    string                  `json:"key-directory" yaml:"key-directory"`
+	Key             string                  `json:"key" yaml:"key"`
+	ChainName       string                  `json:"-" yaml:"-"`
+	ChainID         string                  `json:"chain-id" yaml:"chain-id"`
+	RPCAddr         string                  `json:"rpc-addr" yaml:"rpc-addr"`
+	AccountPrefix   string                  `json:"account-prefix" yaml:"account-prefix"`
+	KeyringBackend  string                  `json:"keyring-backend" yaml:"keyring-backend"`
+	GasAdjustment   float64                 `json:"gas-adjustment" yaml:"gas-adjustment"`
+	GasPrices       string                  `json:"gas-prices" yaml:"gas-prices"`
+	MinGasAmount    uint64                  `json:"min-gas-amount" yaml:"min-gas-amount"`
+	Debug           bool                    `json:"debug" yaml:"debug"`
+	Timeout         string                  `json:"timeout" yaml:"timeout"`
+	BlockTimeout    string                  `json:"block-timeout" yaml:"block-timeout"`
+	OutputFormat    string                  `json:"output-format" yaml:"output-format"`
+	SignModeStr     string                  `json:"sign-mode" yaml:"sign-mode"`
+	ExtraCodecs     []string                `json:"extra-codecs" yaml:"extra-codecs"`
+	Modules         []module.AppModuleBasic `json:"-" yaml:"-"`
+	Slip44          int                     `json:"coin-type" yaml:"coin-type"`
+	Broadcast       provider.BroadcastMode  `json:"broadcast-mode" yaml:"broadcast-mode"`
+	MinLoopDuration time.Duration           `json:"min-loop-duration" yaml:"min-loop-duration"`
 }
 
 func (pc PenumbraProviderConfig) Validate() error {

--- a/relayer/channel.go
+++ b/relayer/channel.go
@@ -74,7 +74,7 @@ func (c *Chain) CreateOpenChannels(
 			dst.chainProcessor(c.log, nil),
 		).
 		WithPathProcessors(pp).
-		WithInitialBlockHistory(100).
+		WithInitialBlockHistory(0).
 		WithMessageLifecycle(&processor.ChannelMessageLifecycle{
 			Initial: &processor.ChannelMessage{
 				ChainID:   c.PathEnd.ChainID,


### PR DESCRIPTION
The default min query loop duration of 1 second is too slow for chains such as Sei. This makes it configurable with a default of 1 second.