### PR TITLE
chore: add path name to logs in message processor

### DIFF
--- a/relayer/processor/message_processor.go
+++ b/relayer/processor/message_processor.go
@@ -332,6 +332,7 @@ func (mp *messageProcessor) sendClientUpdate(
 
 	if err := dst.chainProvider.SendMessagesToMempool(broadcastCtx, msgs, mp.memo, ctx, nil); err != nil {
 		mp.log.Error("Error sending client update message",
+			zap.String("path_name", src.info.PathName),
 			zap.String("src_chain_id", src.info.ChainID),
 			zap.String("dst_chain_id", dst.info.ChainID),
 			zap.String("src_client_id", src.info.ClientID),
@@ -388,6 +389,7 @@ func (mp *messageProcessor) sendBatchMessages(
 
 	if err := dst.chainProvider.SendMessagesToMempool(broadcastCtx, msgs, mp.memo, ctx, callback); err != nil {
 		errFields := []zapcore.Field{
+			zap.String("path_name", src.info.PathName),
 			zap.String("src_chain_id", src.info.ChainID),
 			zap.String("dst_chain_id", dst.info.ChainID),
 			zap.String("src_client_id", src.info.ClientID),
@@ -442,6 +444,7 @@ func (mp *messageProcessor) sendSingleMessage(
 	err := dst.chainProvider.SendMessagesToMempool(broadcastCtx, msgs, mp.memo, ctx, callback)
 	if err != nil {
 		errFields := []zapcore.Field{
+			zap.String("path_name", src.info.PathName),
 			zap.String("src_chain_id", src.info.ChainID),
 			zap.String("dst_chain_id", dst.info.ChainID),
 			zap.String("src_client_id", src.info.ClientID),


### PR DESCRIPTION
This PR adds the path name to failed msg logs as discussed last week. There are places where this isn't completely straightforward because we are in a codepath where the path name is not easily accessible or even easy to pipe the data into but in the message processor its easy enough.

Closes #1148 