### PR TITLE
Harry/rly tx transfer

### DIFF
--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -86,6 +86,7 @@ func (ccp *CosmosChainProcessor) handleChannelMessage(eventType string, ci provi
 			ccp.channelStateCache[channelKey] = false
 		case chantypes.EventTypeChannelOpenAck, chantypes.EventTypeChannelOpenConfirm:
 			ccp.channelStateCache[channelKey] = true
+			ccp.logChannelOpenMessage(eventType, ci)
 		case chantypes.EventTypeChannelCloseConfirm:
 			for k := range ccp.channelStateCache {
 				if k.PortID == ci.PortID && k.ChannelID == ci.ChannelID {
@@ -180,6 +181,14 @@ func (ccp *CosmosChainProcessor) logChannelMessage(message string, ci provider.C
 		zap.String("counterparty_port_id", ci.CounterpartyPortID),
 		zap.String("connection_id", ci.ConnID),
 	)
+}
+
+func (ccp *CosmosChainProcessor) logChannelOpenMessage(message string, ci provider.ChannelInfo, fields ...zap.Field) {
+	ccp.log.With(
+		zap.String("port_id", ci.PortID),
+		zap.String("connection_id", ci.ConnID),
+		zap.String("channel_id", ci.ChannelID),
+	).Info("Successfully created new channel", fields...)
 }
 
 func (ccp *CosmosChainProcessor) logConnectionMessage(message string, ci provider.ConnectionInfo) {

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -187,9 +187,8 @@ func (ccp *CosmosChainProcessor) logChannelOpenMessage(message string, ci provid
 	fields := []zap.Field{
 
 		zap.String("channel_id", ci.ChannelID),
+		zap.String("connection_id", ci.ConnID),
 		zap.String("port_id", ci.PortID),
-		zap.String("counterparty_channel_id", ci.CounterpartyChannelID),
-		zap.String("counterparty_port_id", ci.CounterpartyPortID),
 	}
 	ccp.log.Info("Successfully created new channel", fields...)
 }

--- a/relayer/chains/cosmos/message_handlers.go
+++ b/relayer/chains/cosmos/message_handlers.go
@@ -183,12 +183,15 @@ func (ccp *CosmosChainProcessor) logChannelMessage(message string, ci provider.C
 	)
 }
 
-func (ccp *CosmosChainProcessor) logChannelOpenMessage(message string, ci provider.ChannelInfo, fields ...zap.Field) {
-	ccp.log.With(
-		zap.String("port_id", ci.PortID),
-		zap.String("connection_id", ci.ConnID),
+func (ccp *CosmosChainProcessor) logChannelOpenMessage(message string, ci provider.ChannelInfo) {
+	fields := []zap.Field{
+
 		zap.String("channel_id", ci.ChannelID),
-	).Info("Successfully created new channel", fields...)
+		zap.String("port_id", ci.PortID),
+		zap.String("counterparty_channel_id", ci.CounterpartyChannelID),
+		zap.String("counterparty_port_id", ci.CounterpartyPortID),
+	}
+	ccp.log.Info("Successfully created new channel", fields...)
 }
 
 func (ccp *CosmosChainProcessor) logConnectionMessage(message string, ci provider.ConnectionInfo) {

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -113,7 +113,15 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 			)
 		}
 		return err
+	} else {
+		if result.SuccessfullySent() {
+			c.log.Info(
+				"Successfully sent a transfer",
+				zap.String("src_chain_id", c.ChainID()),
+				zap.String("dst_chain_id", dst.ChainID()),
+				zap.Object("send_result", result),
+			)
+		}
 	}
-
 	return nil
 }

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -108,6 +108,11 @@ type SendMsgsResult struct {
 	SrcSendError, DstSendError error
 }
 
+// SuccessfullySent reports the presence successfully sent batches
+func (r SendMsgsResult) SuccessfullySent() bool {
+	return (r.SuccessfulSrcBatches > 0 || r.SuccessfulDstBatches > 0)
+}
+
 // PartiallySent reports the presence of both some successfully sent batches
 // and some errors.
 func (r SendMsgsResult) PartiallySent() bool {


### PR DESCRIPTION
- recreated the issue
- partially successful batches had logs enabled but no log for successful batches
- created `SuccessfullySent` method and added logs.
- closes #1151