### PR TITLE
Better Error Messaging when failing to query the Block Height

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,6 +53,17 @@ it will be helpful to provide the output from `http://localhost:7597/debug/pprof
 
 ---
 
+**Error querying blockdata**
+
+The relayer looks back in time at historical transactions and needs to have an index of them.
+
+Specifically check `~/.<node_data_dir>/config/config.toml` has the following fields set:
+```toml
+indexer = "kv"
+index_all_tags = true
+```
+---
+
 **Error building or broadcasting transaction**
 
 When preparing a transaction for relaying, the amount of gas that the transaction will consume is unknown.  To compute how much gas the transaction will need, the transaction is prepared with 0 gas and delivered as a `/cosmos.tx.v1beta1.Service/Simulate` query to the RPC endpoint.  Recently chains have been creating AnteHandlers in which 0 gas triggers an error case:

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -381,7 +381,12 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		})
 
 		if err := eg.Wait(); err != nil {
-			ccp.log.Warn("Error querying block data", zap.Error(err))
+			ccp.log.Warn(
+				"Could not query block data. Consider checking if your RPC node is online, and that transaction indexing is enabled.",
+				zap.String("chainID", chainID),
+				zap.Int64("height", i),
+			)
+			ccp.log.Debug("Error querying block data", zap.Error(err))
 
 			persistence.retriesAtLatestQueriedBlock++
 			if persistence.retriesAtLatestQueriedBlock >= blockMaxRetries {

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -383,7 +383,6 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		if err := eg.Wait(); err != nil {
 			ccp.log.Warn(
 				"Could not query block data. Consider checking if your RPC node is online, and that transaction indexing is enabled.",
-				zap.String("chainID", chainID),
 				zap.Int64("height", i),
 			)
 			ccp.log.Debug("Error querying block data", zap.Error(err))


### PR DESCRIPTION
Specifically: 
- Make the `warn` log user friendly and suggest solutions while providing relevant data
- Log the old, potentially too verbose / confusing message under a `debug` level
- Update the troubleshooting guide to help users understand this scenario 

Testing:
- I'm relying on CI to tell me that I haven't done anything too silly 
- Here's an example log when I run against a node that has transaction indexing turned off:
```shell
May 12 12:10:13 test_relayer rly[128858]: ts=2023-05-12T19:10:13.806367Z lvl=warn msg="Could not query block data. Consider checking if your RPC node is online, and that transaction indexing is enabled." chain_name=cosmoshub chain_id=cosmoshub-4 height=15270883

```