### PR TITLE
Use unique names for relayer images & cleanup when purpose served

### DIFF
--- a/interchaintest/client_threshold_test.go
+++ b/interchaintest/client_threshold_test.go
@@ -42,7 +42,8 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	g0, g1 := chains[0], chains[1]
 
 	client, network := interchaintest.DockerSetup(t)
-	relayerinterchaintest.BuildRelayerImage(t)
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 
 	// Relayer is set with "--time-threshold 5m"
 	// The client being created below also has a trusting period of 5m.
@@ -50,7 +51,7 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 		interchaintestrelayer.StartupFlags("--time-threshold", "20s"),
 	).Build(t, client, network)
@@ -102,6 +103,7 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	require.NoError(t, r.StartRelayer(ctx, eRep, ibcPath))
 	t.Cleanup(func() {
 		_ = r.StopRelayer(ctx, eRep)
+		relayerinterchaintest.DestroyRelayerImage(t, uuid)
 	})
 
 	const heightOffset = 10
@@ -164,15 +166,16 @@ func TestScenarioClientTrustingPeriodUpdate(t *testing.T) {
 	g0, g1 := chains[0], chains[1]
 
 	client, network := interchaintest.DockerSetup(t)
-	relayerinterchaintest.BuildRelayerImage(t)
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 	logger := zaptest.NewLogger(t)
 
 	// Relayer is set with "--time-threshold 0"
 	// The Relayer should NOT continuously update clients
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
-		logger,
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		zaptest.NewLogger(t),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 

--- a/interchaintest/client_threshold_test.go
+++ b/interchaintest/client_threshold_test.go
@@ -42,8 +42,7 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	g0, g1 := chains[0], chains[1]
 
 	client, network := interchaintest.DockerSetup(t)
-	uuid := relayerinterchaintest.UniqueRelayerImageName()
-	relayerinterchaintest.BuildRelayerImage(t, uuid)
+	image := relayerinterchaintest.BuildRelayerImage(t)
 
 	// Relayer is set with "--time-threshold 5m"
 	// The client being created below also has a trusting period of 5m.
@@ -51,7 +50,7 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(image, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 		interchaintestrelayer.StartupFlags("--time-threshold", "20s"),
 	).Build(t, client, network)
@@ -103,7 +102,6 @@ func TestScenarioClientThresholdUpdate(t *testing.T) {
 	require.NoError(t, r.StartRelayer(ctx, eRep, ibcPath))
 	t.Cleanup(func() {
 		_ = r.StopRelayer(ctx, eRep)
-		relayerinterchaintest.DestroyRelayerImage(t, uuid)
 	})
 
 	const heightOffset = 10
@@ -166,16 +164,15 @@ func TestScenarioClientTrustingPeriodUpdate(t *testing.T) {
 	g0, g1 := chains[0], chains[1]
 
 	client, network := interchaintest.DockerSetup(t)
-	uuid := relayerinterchaintest.UniqueRelayerImageName()
-	relayerinterchaintest.BuildRelayerImage(t, uuid)
+	image := relayerinterchaintest.BuildRelayerImage(t)
 	logger := zaptest.NewLogger(t)
 
 	// Relayer is set with "--time-threshold 0"
 	// The Relayer should NOT continuously update clients
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
-		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
+		logger,
+		interchaintestrelayer.CustomDockerImage(image, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 

--- a/interchaintest/docker.go
+++ b/interchaintest/docker.go
@@ -33,8 +33,7 @@ type dockerErrorDetail struct {
 func uniqueRelayerImageName() (string, error) {
 	uuid, err := uuid.NewRandom()
 	if err != nil {
-		fmt.Printf("Failed to generate UUID: %v\n", err)
-		return "", err
+		return "", fmt.Errorf("failed to generate uuid %v", err)
 	}
 	return RelayerImagePrefix + uuid.String()[:6], nil
 }

--- a/interchaintest/docker.go
+++ b/interchaintest/docker.go
@@ -12,11 +12,12 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/google/uuid"
 	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 )
 
-const RelayerImageName = "interchaintestrelayer"
+const RelayerImagePrefix = "interchaintestrelayer"
 
 type dockerLogLine struct {
 	Stream      string            `json:"stream"`
@@ -29,7 +30,15 @@ type dockerErrorDetail struct {
 	Message string `json:"message"`
 }
 
-func BuildRelayerImage(t *testing.T) {
+func UniqueRelayerImageName() string {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		fmt.Printf("Failed to generate UUID: %v\n", err)
+	}
+	return RelayerImagePrefix + uuid.String()[:6]
+}
+
+func BuildRelayerImage(t *testing.T, uniquestr string) {
 	_, b, _, _ := runtime.Caller(0)
 	basepath := filepath.Join(filepath.Dir(b), "..")
 
@@ -41,12 +50,25 @@ func BuildRelayerImage(t *testing.T) {
 
 	res, err := cli.ImageBuild(context.Background(), tar, dockertypes.ImageBuildOptions{
 		Dockerfile: "local.Dockerfile",
-		Tags:       []string{RelayerImageName},
+		Tags:       []string{uniquestr},
 	})
 	require.NoError(t, err, "error building docker image")
 
 	defer res.Body.Close()
 	handleDockerBuildOutput(t, res.Body)
+}
+
+func DestroyRelayerImage(t *testing.T, uniquestr string) {
+	// Create a Docker client
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err, "error building docker client")
+
+	// Remove the Docker image using the provided tag (uniquestr)
+	_, err = cli.ImageRemove(context.Background(), uniquestr, dockertypes.ImageRemoveOptions{
+		Force:         true, // Force remove the image
+		PruneChildren: true, // Remove all child images
+	})
+	require.NoError(t, err, "error removing docker image")
 }
 
 func handleDockerBuildOutput(t *testing.T, body io.Reader) {

--- a/interchaintest/ibc_test.go
+++ b/interchaintest/ibc_test.go
@@ -21,7 +21,7 @@ import (
 // so it uses only one pair of chains.
 //
 // The canonical set of test chains are defined in the interchaintest repository.
-func interchaintestConformance(t *testing.T, rf interchaintest.RelayerFactory) {
+func interchaintestConformance(t *testing.T, rf interchaintest.RelayerFactory, uuid string) {
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		{Name: "gaia", Version: "v7.0.1", ChainConfig: ibc.ChainConfig{ChainID: "cosmoshub-1004"}},
 		{Name: "osmosis", Version: "v7.2.0", ChainConfig: ibc.ChainConfig{ChainID: "osmosis-1001"}},
@@ -33,13 +33,16 @@ func interchaintestConformance(t *testing.T, rf interchaintest.RelayerFactory) {
 		[]interchaintest.RelayerFactory{rf},
 		testreporter.NewNopReporter(),
 	)
+	if uuid != "" {
+		relayerinterchaintest.DestroyRelayerImage(t, uuid)
+	}
 }
 
 // TestRelayerInProcess runs the interchaintest conformance tests against
 // the current state of this relayer implementation running in process.
 func TestRelayerInProcess(t *testing.T) {
 	t.Parallel()
-	interchaintestConformance(t, relayerinterchaintest.RelayerFactory{})
+	interchaintestConformance(t, relayerinterchaintest.RelayerFactory{}, "")
 }
 
 // TestRelayerDockerEventProcessor runs the interchaintest conformance tests against
@@ -48,15 +51,17 @@ func TestRelayerInProcess(t *testing.T) {
 func TestRelayerDockerEventProcessor(t *testing.T) {
 	t.Parallel()
 
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 	rf := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 		interchaintestrelayer.StartupFlags("--processor", "events", "--block-history", "100"),
 	)
 
-	interchaintestConformance(t, rf)
+	interchaintestConformance(t, rf, uuid)
 }
 
 // TestRelayerDockerLegacyProcessor runs the interchaintest conformance tests against
@@ -64,17 +69,18 @@ func TestRelayerDockerEventProcessor(t *testing.T) {
 // Relayer runs using the legacy processor.
 func TestRelayerDockerLegacyProcessor(t *testing.T) {
 	t.Parallel()
-	relayerinterchaintest.BuildRelayerImage(t)
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 
 	rf := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 		interchaintestrelayer.StartupFlags("--processor", "legacy"),
 	)
 
-	interchaintestConformance(t, rf)
+	interchaintestConformance(t, rf, uuid)
 }
 
 // TestRelayerEventProcessor runs the interchaintest conformance tests against
@@ -86,7 +92,7 @@ func TestRelayerEventProcessor(t *testing.T) {
 	interchaintestConformance(t, relayerinterchaintest.NewRelayerFactory(relayerinterchaintest.RelayerConfig{
 		Processor:           relayer.ProcessorEvents,
 		InitialBlockHistory: 0,
-	}))
+	}), "")
 }
 
 // TestRelayerLegacyProcessor runs the interchaintest conformance tests against
@@ -97,5 +103,5 @@ func TestRelayerLegacyProcessor(t *testing.T) {
 
 	interchaintestConformance(t, relayerinterchaintest.NewRelayerFactory(relayerinterchaintest.RelayerConfig{
 		Processor: relayer.ProcessorLegacy,
-	}))
+	}), "")
 }

--- a/interchaintest/multi_channel_test.go
+++ b/interchaintest/multi_channel_test.go
@@ -18,13 +18,14 @@ import (
 )
 
 func TestMultipleChannelsOneConnection(t *testing.T) {
-	relayerinterchaintest.BuildRelayerImage(t)
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 
 	client, network := interchaintest.DockerSetup(t)
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 
@@ -109,6 +110,7 @@ func TestMultipleChannelsOneConnection(t *testing.T) {
 			if err != nil {
 				t.Logf("an error occured while stopping the relayer: %s", err)
 			}
+			relayerinterchaintest.DestroyRelayerImage(t, uuid)
 		},
 	)
 

--- a/interchaintest/multi_channel_test.go
+++ b/interchaintest/multi_channel_test.go
@@ -18,14 +18,13 @@ import (
 )
 
 func TestMultipleChannelsOneConnection(t *testing.T) {
-	uuid := relayerinterchaintest.UniqueRelayerImageName()
-	relayerinterchaintest.BuildRelayerImage(t, uuid)
+	image := relayerinterchaintest.BuildRelayerImage(t)
 
 	client, network := interchaintest.DockerSetup(t)
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(image, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 
@@ -110,7 +109,6 @@ func TestMultipleChannelsOneConnection(t *testing.T) {
 			if err != nil {
 				t.Logf("an error occured while stopping the relayer: %s", err)
 			}
-			relayerinterchaintest.DestroyRelayerImage(t, uuid)
 		},
 	)
 

--- a/interchaintest/relayer_override_test.go
+++ b/interchaintest/relayer_override_test.go
@@ -23,14 +23,13 @@ import (
 // is a client-id present in the relative path config. If the override flag is present, the relayer should always
 // attempt to create a new light client and then overwrite the config file if successful.
 func TestClientOverrideFlag(t *testing.T) {
-	uuid := relayerinterchaintest.UniqueRelayerImageName()
-	relayerinterchaintest.BuildRelayerImage(t, uuid)
+	image := relayerinterchaintest.BuildRelayerImage(t)
 
 	client, network := interchaintest.DockerSetup(t)
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(image, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 
@@ -96,7 +95,6 @@ func TestClientOverrideFlag(t *testing.T) {
 			if err != nil {
 				t.Logf("an error occured while stopping the relayer: %s", err)
 			}
-			relayerinterchaintest.DestroyRelayerImage(t, uuid)
 		},
 	)
 

--- a/interchaintest/relayer_override_test.go
+++ b/interchaintest/relayer_override_test.go
@@ -23,13 +23,14 @@ import (
 // is a client-id present in the relative path config. If the override flag is present, the relayer should always
 // attempt to create a new light client and then overwrite the config file if successful.
 func TestClientOverrideFlag(t *testing.T) {
-	relayerinterchaintest.BuildRelayerImage(t)
+	uuid := relayerinterchaintest.UniqueRelayerImageName()
+	relayerinterchaintest.BuildRelayerImage(t, uuid)
 
 	client, network := interchaintest.DockerSetup(t)
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		interchaintestrelayer.CustomDockerImage(relayerinterchaintest.RelayerImageName, "latest", "100:1000"),
+		interchaintestrelayer.CustomDockerImage(uuid, "latest", "100:1000"),
 		interchaintestrelayer.ImagePull(false),
 	).Build(t, client, network)
 
@@ -95,6 +96,7 @@ func TestClientOverrideFlag(t *testing.T) {
 			if err != nil {
 				t.Logf("an error occured while stopping the relayer: %s", err)
 			}
+			relayerinterchaintest.DestroyRelayerImage(t, uuid)
 		},
 	)
 


### PR DESCRIPTION
Resolves [#1033](https://github.com/cosmos/relayer/issues/1033)
 1. Use unique tags to create relayer images with a prefix "interchaintestrelayer" and a 6 character unique tag using the uuid package from google. 
 2. After the image that is created using BuildRelayerImage is used and its purpose is served , it can be cleaned up by calling DestroyRelayerImage in the t.Cleanup call . 
