### PR TITLE
Split scenarios test

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -146,7 +146,8 @@ jobs:
       run: |
         # Run the command and convert its output to a JSON array
         TESTS=$(cd interchaintest && go test -list ^TestScenario | jq -R -s -c 'split("\n")[:-1]')
-        echo "::set-output name=matrix::${TESTS}"
+        echo "matrix=${TESTS}" >> $GITHUB_OUTPUT
+  
 
   scenarios:
     needs: prepare-scenario-matrix

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -145,7 +145,7 @@ jobs:
       id: set-matrix
       run: |
         # Run the command and convert its output to a JSON array
-        TESTS=$(go test -list ^TestScenario | jq -R -s -c 'split("\n")[:-1]')
+        TESTS=$(cd interchaintest && go test -list ^TestScenario | jq -R -s -c 'split("\n")[:-1]')
         echo "::set-output name=matrix::${TESTS}"
 
   scenarios:

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -145,7 +145,7 @@ jobs:
       id: set-matrix
       run: |
         # Run the command and convert its output to a JSON array
-        TESTS=$(cd interchaintest && go test -list ^TestScenario | jq -R -s -c 'split("\n")[:-1]')
+        TESTS=$(cd interchaintest && go test -list ^TestScenario | grep -v "^ok " | jq -R -s -c 'split("\n")[:-1]')
         echo "matrix=${TESTS}" >> $GITHUB_OUTPUT
   
 

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -133,7 +133,7 @@ jobs:
       - name: interchaintest
         run: make interchaintest-fee-grant
 
-  prepare-matrix:
+  prepare-scenario-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -145,15 +145,15 @@ jobs:
       id: set-matrix
       run: |
         # Run the command and convert its output to a JSON array
-        TESTS=$(go test -list ^TEST | jq -R -s -c 'split("\n")[:-1]')
+        TESTS=$(go test -list ^TestScenario | jq -R -s -c 'split("\n")[:-1]')
         echo "::set-output name=matrix::${TESTS}"
 
-  scenarios-client:
-    needs: prepare-matrix
+  scenarios:
+    needs: prepare-scenario-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
+        test: ${{fromJson(needs.prepare-scenario-matrix.outputs.matrix)}}
 
     steps:
       - name: Set up Go 1.21
@@ -164,8 +164,6 @@ jobs:
       - name: checkout relayer
         uses: actions/checkout@v2
 
-      
-
       - uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
@@ -175,4 +173,5 @@ jobs:
 
       - name: interchaintest
         run: |
+          cd interchaintest
           go test -run ${{ matrix.test }}

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -133,8 +133,28 @@ jobs:
       - name: interchaintest
         run: make interchaintest-fee-grant
 
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Generate matrix
+      id: set-matrix
+      run: |
+        # Run the command and convert its output to a JSON array
+        TESTS=$(go test -list ^TEST | jq -R -s -c 'split("\n")[:-1]')
+        echo "::set-output name=matrix::${TESTS}"
+
   scenarios-client:
+    needs: prepare-matrix
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
+
     steps:
       - name: Set up Go 1.21
         uses: actions/setup-go@v4
@@ -144,26 +164,7 @@ jobs:
       - name: checkout relayer
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: interchaintest
-        run: make interchaintest-scenario-client
       
-  scenarios-ica:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
 
       - uses: actions/cache@v1
         with:
@@ -173,88 +174,5 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: interchaintest
-        run: make interchaintest-scenario-ica
-      
-  scenarios-interchainaccounts:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: interchaintest
-        run: make interchaintest-scenario-interchainaccounts
-  
-  scenarios-pathfilter:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: interchaintest
-        run: make interchaintest-scenario-pathfilter
-
-  scenarios-tendermint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: interchaintest
-        run: make interchaintest-scenario-tendermint
-
-  scenarios-stride:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: checkout relayer
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: interchaintest
-        run: make interchaintest-scenario-stride
+        run: |
+          go test -run ${{ matrix.test }}

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -133,7 +133,7 @@ jobs:
       - name: interchaintest
         run: make interchaintest-fee-grant
 
-  scenarios:
+  scenarios-client:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.21
@@ -152,8 +152,109 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: interchaintest
-        run: make interchaintest-scenario
+        run: make interchaintest-scenario-client
+      
+  scenarios-ica:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
 
-      - name: Prune Docker images
-        if: always() #ensure dangling images are pruned after interchain-test scenario  passes or fails
-        run: docker image prune -f
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: interchaintest
+        run: make interchaintest-scenario-ica
+      
+  scenarios-interchainaccounts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: interchaintest
+        run: make interchaintest-scenario-interchainaccounts
+  
+  scenarios-pathfilter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: interchaintest
+        run: make interchaintest-scenario-pathfilter
+
+  scenarios-tendermint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: interchaintest
+        run: make interchaintest-scenario-tendermint
+
+  scenarios-stride:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: checkout relayer
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: interchaintest
+        run: make interchaintest-scenario-stride

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -148,7 +148,7 @@ jobs:
         TESTS=$(cd interchaintest && go test -list ^TestScenario | grep -v "^ok " | jq -R -s -c 'split("\n")[:-1]')
         echo "matrix=${TESTS}" >> $GITHUB_OUTPUT
   
-
+  # Note : This job will not start until prepare-scenario-matrix completes sucessfully
   scenarios:
     needs: prepare-scenario-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -153,6 +153,7 @@ jobs:
     needs: prepare-scenario-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         test: ${{fromJson(needs.prepare-scenario-matrix.outputs.matrix)}}
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ interchaintest-fee-grant:
 	cd interchaintest && go test -race -v -run TestRelayerFeeGrant .
 
 interchaintest-scenario: ## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioClient ./...
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenario ./...
 
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,7 @@ interchaintest-fee-middleware:
 interchaintest-fee-grant:
 	cd interchaintest && go test -race -v -run TestRelayerFeeGrant .
 
-## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
-interchaintest-scenario:
+interchaintest-scenario: ## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
 	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioClient ./...
 
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ interchaintest-fee-grant:
 interchaintest-scenario: ## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
 	cd interchaintest && go test -timeout 30m -race -v -run TestScenario ./...
 
-
 coverage:
 	@echo "viewing test coverage..."
 	@go tool cover --html=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -92,23 +92,9 @@ interchaintest-fee-grant:
 	cd interchaintest && go test -race -v -run TestRelayerFeeGrant .
 
 ## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
-interchaintest-scenario-client:
+interchaintest-scenario:
 	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioClient ./...
 
-interchaintest-scenario-ica:
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioICA ./...
-
-interchaintest-scenario-interchainaccounts:
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioInterchainAccounts ./...
-
-interchaintest-scenario-pathfilter:
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioPathFilter ./...
-
-interchaintest-scenario-tendermint:
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioTendermint ./...
-
-interchaintest-scenario-stride:
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioStride ./...
 
 coverage:
 	@echo "viewing test coverage..."

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,24 @@ interchaintest-fee-middleware:
 interchaintest-fee-grant:
 	cd interchaintest && go test -race -v -run TestRelayerFeeGrant .
 
-interchaintest-scenario: ## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
-	cd interchaintest && go test -timeout 30m -race -v -run TestScenario ./...
+## Scenario tests are suitable for simple networks of 1 validator and no full nodes. They test specific functionality.
+interchaintest-scenario-client:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioClient ./...
+
+interchaintest-scenario-ica:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioICA ./...
+
+interchaintest-scenario-interchainaccounts:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioInterchainAccounts ./...
+
+interchaintest-scenario-pathfilter:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioPathFilter ./...
+
+interchaintest-scenario-tendermint:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioTendermint ./...
+
+interchaintest-scenario-stride:
+	cd interchaintest && go test -timeout 30m -race -v -run TestScenarioStride ./...
 
 coverage:
 	@echo "viewing test coverage..."


### PR DESCRIPTION
Goal is to fix the flakiness of the interchain test. 

Using matrix to split the tests into parallel runners as documented here :
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_calloutputs


