### PR TITLE
Add verbosity and timeout for scenarios tests in workflow

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -176,4 +176,5 @@ jobs:
       - name: interchaintest
         run: |
           cd interchaintest
-          go test -run ${{ matrix.test }}
+          go test -timeout 30m -race -v -run ${{ matrix.test }}
+


### PR DESCRIPTION
This is a follow up to this PR. #1294
The run command now matches what the Makefile contains. 