### PR TITLE
Problem: packet get relayed even estimated gas is higher than max gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [\#1221](https://github.com/cosmos/relayer/pull/1221) Update cometbft to v0.37.2 and ibc-go to v7.2.0.
 * [\#1226](https://github.com/cosmos/relayer/pull/1226) Avoid invalid Bech32 prefix error in parallel tests when sdk Config get overwritten by each other in single process.
 * [\#1231](https://github.com/cosmos/relayer/pull/1231) Reduce get bech32 prefix when get signer.
+* [\#](https://github.com/cosmos/relayer/pull/) Avoid packet get relayed when estimated gas is higher than max gas.
 
 ## v0.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [\#1221](https://github.com/cosmos/relayer/pull/1221) Update cometbft to v0.37.2 and ibc-go to v7.2.0.
 * [\#1226](https://github.com/cosmos/relayer/pull/1226) Avoid invalid Bech32 prefix error in parallel tests when sdk Config get overwritten by each other in single process.
 * [\#1231](https://github.com/cosmos/relayer/pull/1231) Reduce get bech32 prefix when get signer.
-* [\#](https://github.com/cosmos/relayer/pull/) Avoid packet get relayed when estimated gas is higher than max gas.
+* [\#1302](https://github.com/cosmos/relayer/pull/1302) Avoid packet get relayed when estimated gas is higher than max gas.
 
 ## v0.9.3
 

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -1673,9 +1673,8 @@ func (cc *CosmosProvider) PrepareFactory(txf tx.Factory, signingKey string) (tx.
 }
 
 // AdjustEstimatedGas adjusts the estimated gas usage by multiplying it by the gas adjustment factor
-// and bounding the result by the maximum gas amount option. If the gas usage is zero, the adjusted gas
-// is also zero. If the gas adjustment factor produces an infinite result, an error is returned.
-// max-gas-amount is enforced.
+// and return estimated gas is higher than max gas error. If the gas usage is zero, the adjusted gas
+// is also zero.
 func (cc *CosmosProvider) AdjustEstimatedGas(gasUsed uint64) (uint64, error) {
 	if gasUsed == 0 {
 		return gasUsed, nil

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"math/rand"
 	"regexp"
@@ -1683,6 +1684,9 @@ func (cc *CosmosProvider) AdjustEstimatedGas(gasUsed uint64) (uint64, error) {
 		return 0, fmt.Errorf("estimated gas %d is higher than max gas %d", gasUsed, cc.PCfg.MaxGasAmount)
 	}
 	gas := cc.PCfg.GasAdjustment * float64(gasUsed)
+	if math.IsInf(gas, 1) {
+		return 0, fmt.Errorf("infinite gas used")
+	}
 	return uint64(gas), nil
 }
 

--- a/relayer/chains/cosmos/tx_test.go
+++ b/relayer/chains/cosmos/tx_test.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -50,6 +51,14 @@ func TestCosmosProvider_AdjustEstimatedGas(t *testing.T) {
 			maxGasAmount:  100000,
 			expectedGas:   75000,
 			expectedErr:   nil,
+		},
+		{
+			name:          "gas used is infinite",
+			gasUsed:       10000,
+			gasAdjustment: math.Inf(1),
+			maxGasAmount:  0,
+			expectedGas:   0,
+			expectedErr:   fmt.Errorf("infinite gas used"),
 		},
 		{
 			name:          "gas used is non-zero with zero max gas amount as default",

--- a/relayer/chains/cosmos/tx_test.go
+++ b/relayer/chains/cosmos/tx_test.go
@@ -2,7 +2,6 @@ package cosmos
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -53,20 +52,20 @@ func TestCosmosProvider_AdjustEstimatedGas(t *testing.T) {
 			expectedErr:   nil,
 		},
 		{
-			name:          "gas used is infinite",
-			gasUsed:       10000,
-			gasAdjustment: math.Inf(1),
-			maxGasAmount:  0,
-			expectedGas:   0,
-			expectedErr:   fmt.Errorf("infinite gas used"),
-		},
-		{
 			name:          "gas used is non-zero with zero max gas amount as default",
 			gasUsed:       50000,
 			gasAdjustment: 1.5,
 			maxGasAmount:  0,
 			expectedGas:   75000,
 			expectedErr:   nil,
+		},
+		{
+			name:          "estimated gas is higher than max gas",
+			gasUsed:       50000,
+			gasAdjustment: 1.5,
+			maxGasAmount:  70000,
+			expectedGas:   75000,
+			expectedErr:   fmt.Errorf("estimated gas 75000 is higher than max gas 70000"),
 		},
 	}
 


### PR DESCRIPTION
to align estimate fee behaviour with [hermes](https://github.com/informalsystems/hermes/blob/77423055c25b968fb3b0f704a76a955458262ee9/crates/relayer/src/chain/cosmos/estimate.rs#L76) 