### PR TITLE
fix: Use the provider IR instead of creating a new one

### DIFF
--- a/relayer/chains/cosmos/log.go
+++ b/relayer/chains/cosmos/log.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	feetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
@@ -102,11 +101,10 @@ func (cc *CosmosProvider) LogSuccessTx(res *sdk.TxResponse, msgs []provider.Rela
 	fields = append(fields, zap.Int64("gas_used", res.GasUsed))
 
 	// Extract fees and fee_payer if present
-	ir := types.NewInterfaceRegistry()
-	cdc := codec.NewProtoCodec(ir)
+	cdc := codec.NewProtoCodec(cc.Cdc.InterfaceRegistry)
 
 	var m sdk.Msg
-	if err := ir.UnpackAny(res.Tx, &m); err == nil {
+	if err := cc.Cdc.InterfaceRegistry.UnpackAny(res.Tx, &m); err == nil {
 		if tx, ok := m.(*typestx.Tx); ok {
 			fields = append(fields, zap.Stringer("fees", tx.GetFee()))
 			if feePayer := getFeePayer(cc.log, cdc, tx); feePayer != "" {


### PR DESCRIPTION
When using the relayer with custom modules, I get the following errors
```
2023-11-23T16:50:05.318884Z     info    Could not get signers for msg when attempting to get the fee payer      {"error": "InterfaceRegistry requires a proper address codec implementation to do address conversion"}
```

This seems to happen due to the creation of the default `InterfaceRegistry` (which has failing address codecs) instead of the usage of the one under the provider codec. 