### PR TITLE
fix: pipe memo from cli to broadcast tx logic for `MsgTransfer` and `MsgRegisterCounterpartyPayee` 

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/cosmos/relayer/v2/relayer/processor"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -22,7 +21,6 @@ const (
 	flagForceAdd                = "force-add"
 	flagPath                    = "path"
 	flagTestnet                 = "testnet"
-	flagMaxTxSize               = "max-tx-size"
 	flagMaxMsgLength            = "max-msgs"
 	flagIBCDenoms               = "ibc-denoms"
 	flagTimeoutHeightOffset     = "timeout-height-offset"
@@ -64,13 +62,7 @@ const (
 	flagStuckPacketHeightEnd    = "stuck-packet-height-end"
 )
 
-const (
-	// 7597 is "RLYR" on a telephone keypad.
-	// It also happens to be unassigned in the IANA port list.
-	defaultDebugAddr = "localhost:7597"
-
-	blankValue = "blank"
-)
+const blankValue = "blank"
 
 func ibcDenomFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagIBCDenoms, "i", false, "Display IBC denominations for sending tokens back to other chains")
@@ -89,7 +81,14 @@ func heightFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func paginationFlags(v *viper.Viper, cmd *cobra.Command, query string) *cobra.Command {
-	cmd.Flags().Uint64(flagPage, 1, fmt.Sprintf("pagination page of %s to query for. This sets offset to a multiple of limit", query))
+	cmd.Flags().Uint64(
+		flagPage,
+		1,
+		fmt.Sprintf("pagination page of %s to query for. This sets offset to a multiple of limit",
+			query,
+		),
+	)
+
 	cmd.Flags().String(flagPageKey, "", fmt.Sprintf("pagination page-key of %s to query for", query))
 	cmd.Flags().Uint64(flagLimit, 100, fmt.Sprintf("pagination limit of %s to query for", query))
 	cmd.Flags().Bool(flagCountTotal, false, fmt.Sprintf("count total number of records in %s to query for", query))
@@ -304,10 +303,15 @@ func retryFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func updateTimeFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().Duration(flagThresholdTime, relayer.DefaultClientUpdateThreshold, "time after previous client update before automatic client update")
+	cmd.Flags().Duration(
+		flagThresholdTime,
+		relayer.DefaultClientUpdateThreshold,
+		"time after previous client update before automatic client update",
+	)
 	if err := v.BindPFlag(flagThresholdTime, cmd.Flags().Lookup(flagThresholdTime)); err != nil {
 		panic(err)
 	}
+
 	return cmd
 }
 
@@ -316,13 +320,20 @@ func clientParameterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 		"allow governance to update the client if expiry occurs")
 	cmd.Flags().BoolP(flagUpdateAfterMisbehaviour, "m", true,
 		"allow governance to update the client if misbehaviour freezing occurs")
-	cmd.Flags().Duration(flagClientTrustingPeriod, 0, "custom light client trusting period ex. 24h (default: 85% of chains reported unbonding time)")
+	cmd.Flags().Duration(
+		flagClientTrustingPeriod,
+		0,
+		"custom light client trusting period ex. 24h (default: 85% of chains reported unbonding time)",
+	)
+
 	if err := v.BindPFlag(flagUpdateAfterExpiry, cmd.Flags().Lookup(flagUpdateAfterExpiry)); err != nil {
 		panic(err)
 	}
+
 	if err := v.BindPFlag(flagUpdateAfterMisbehaviour, cmd.Flags().Lookup(flagUpdateAfterMisbehaviour)); err != nil {
 		panic(err)
 	}
+
 	if err := v.BindPFlag(flagClientTrustingPeriod, cmd.Flags().Lookup(flagClientTrustingPeriod)); err != nil {
 		panic(err)
 	}
@@ -334,10 +345,17 @@ func channelParameterFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func clientUnbondingPeriodFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().Duration(flagClientUnbondingPeriod, 0, "custom unbonding period for client state. This is useful when you need to create a new client matching an older client state")
+	cmd.Flags().Duration(
+		flagClientUnbondingPeriod,
+		0,
+		"custom unbonding period for client state. This is useful when you need to create a new client matching "+
+			"an older client state",
+	)
+
 	if err := v.BindPFlag(flagClientUnbondingPeriod, cmd.Flags().Lookup(flagClientUnbondingPeriod)); err != nil {
 		panic(err)
 	}
+
 	return cmd
 }
 
@@ -382,10 +400,17 @@ func dstPortFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().String(flagDebugAddr, "", "address to use for debug and metrics server. By default, will be the api-listen-addr parameter in the global config.")
+	cmd.Flags().String(
+		flagDebugAddr,
+		"",
+		"address to use for debug and metrics server. By default, "+
+			"will be the api-listen-addr parameter in the global config.",
+	)
+
 	if err := v.BindPFlag(flagDebugAddr, cmd.Flags().Lookup(flagDebugAddr)); err != nil {
 		panic(err)
 	}
+
 	return cmd
 }
 
@@ -398,18 +423,32 @@ func processorFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 }
 
 func initBlockFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().Uint64P(flagInitialBlockHistory, "b", 20, "initial block history to query when using 'events' as the processor for relaying")
+	cmd.Flags().Uint64P(
+		flagInitialBlockHistory,
+		"b",
+		20,
+		"initial block history to query when using 'events' as the processor for relaying",
+	)
+
 	if err := v.BindPFlag(flagInitialBlockHistory, cmd.Flags().Lookup(flagInitialBlockHistory)); err != nil {
 		panic(err)
 	}
+
 	return cmd
 }
 
 func flushIntervalFlag(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().DurationP(flagFlushInterval, "i", relayer.DefaultFlushInterval, "how frequently should a flush routine be run")
+	cmd.Flags().DurationP(
+		flagFlushInterval,
+		"i",
+		relayer.DefaultFlushInterval,
+		"how frequently should a flush routine be run",
+	)
+
 	if err := v.BindPFlag(flagFlushInterval, cmd.Flags().Lookup(flagFlushInterval)); err != nil {
 		panic(err)
 	}
+
 	return cmd
 }
 
@@ -483,7 +522,11 @@ func parseStuckPacketFromFlags(cmd *cobra.Command) (*processor.StuckPacket, erro
 	}
 
 	if stuckPacketHeightEnd < stuckPacketHeightStart {
-		return nil, fmt.Errorf("stuck packet end height %d is less than start height %d", stuckPacketHeightEnd, stuckPacketHeightStart)
+		return nil, fmt.Errorf(
+			"stuck packet end height %d is less than start height %d",
+			stuckPacketHeightEnd,
+			stuckPacketHeightStart,
+		)
 	}
 
 	return &processor.StuckPacket{

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -110,7 +110,12 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			} else {
 				ln, err := net.Listen("tcp", debugAddr)
 				if err != nil {
-					a.log.Error("Failed to listen on debug address. If you have another relayer process open, use --" + flagDebugAddr + " to pick a different address.")
+					a.log.Error(
+						"Failed to listen on debug address. If you have another relayer process open, use --" +
+							flagDebugAddr +
+							" to pick a different address.",
+					)
+
 					return fmt.Errorf("failed to listen on debug address %q: %w", debugAddr, err)
 				}
 				log := a.log.With(zap.String("sys", "debughttp"))
@@ -128,6 +133,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 			if err != nil {
 				return err
 			}
+
 			initialBlockHistory, err := cmd.Flags().GetUint64(flagInitialBlockHistory)
 			if err != nil {
 				return err

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -15,10 +15,17 @@ import (
 
 const defaultTimeoutOffset = 1000
 
-// SendTransferMsg initiates an ics20 transfer from src to dst with the specified args
-//
-//nolint:lll
-func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration, srcChannel *chantypes.IdentifiedChannel) error {
+// SendTransferMsg initiates an ics20 transfer from src to dst with the specified args.
+func (c *Chain) SendTransferMsg(
+	ctx context.Context,
+	log *zap.Logger,
+	dst *Chain,
+	amount sdk.Coin,
+	dstAddr, memo string,
+	toHeightOffset uint64,
+	toTimeOffset time.Duration,
+	srcChannel *chantypes.IdentifiedChannel,
+) error {
 	var (
 		timeoutHeight    uint64
 		timeoutTimestamp uint64
@@ -41,21 +48,29 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		if err != nil {
 			return fmt.Errorf("failed to query the client state response: %w", err)
 		}
+
 		clientState, err := clienttypes.UnpackClientState(clientStateRes.ClientState)
 		if err != nil {
 			return fmt.Errorf("failed to unpack client state: %w", err)
 		}
-		consensusStateRes, err := dst.ChainProvider.QueryClientConsensusState(ctx, dsth, dst.ClientID(), clientState.GetLatestHeight())
+
+		consensusStateRes, err := dst.ChainProvider.QueryClientConsensusState(
+			ctx,
+			dsth,
+			dst.ClientID(),
+			clientState.GetLatestHeight(),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to query client consensus state: %w", err)
 		}
+
 		consensusState, err = clienttypes.UnpackConsensusState(consensusStateRes.ConsensusState)
 		if err != nil {
 			return fmt.Errorf("failed to unpack consensus state: %w", err)
 		}
 
 		// use local clock time as reference time if it is later than the
-		// consensus state timestamp of the counter party chain, otherwise
+		// consensus state timestamp of the counterparty chain, otherwise
 		// still use consensus state timestamp as reference.
 		// see https://github.com/cosmos/ibc-go/blob/ccc4cb804843f1a80acfb0d4dbf106d1ff2178bb/modules/apps/transfer/client/cli/tx.go#L94-L110
 		tmpNow := time.Now().UnixNano()
@@ -93,6 +108,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		},
 		TimeoutTimestamp: timeoutTimestamp,
 	}
+
 	msg, err := c.ChainProvider.MsgTransfer(dstAddr, amount, pi)
 	if err != nil {
 		return err
@@ -102,7 +118,7 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 		Src: []provider.RelayerMessage{msg},
 	}
 
-	result := txs.Send(ctx, log, AsRelayMsgSender(c), AsRelayMsgSender(dst), "")
+	result := txs.Send(ctx, log, AsRelayMsgSender(c), AsRelayMsgSender(dst), memo)
 	if err := result.Error(); err != nil {
 		if result.PartiallySent() {
 			c.log.Info(
@@ -113,15 +129,14 @@ func (c *Chain) SendTransferMsg(ctx context.Context, log *zap.Logger, dst *Chain
 			)
 		}
 		return err
-	} else {
-		if result.SuccessfullySent() {
-			c.log.Info(
-				"Successfully sent a transfer",
-				zap.String("src_chain_id", c.ChainID()),
-				zap.String("dst_chain_id", dst.ChainID()),
-				zap.Object("send_result", result),
-			)
-		}
+	} else if result.SuccessfullySent() {
+		c.log.Info(
+			"Successfully sent a transfer",
+			zap.String("src_chain_id", c.ChainID()),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.Object("send_result", result),
+		)
 	}
+
 	return nil
 }

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -17,10 +17,14 @@ import (
 // after a given relay round. MaxTxSize and MaxMsgLength are ignored if they are
 // set to zero.
 type RelayMsgs struct {
-	Src          []provider.RelayerMessage `json:"src"`
-	Dst          []provider.RelayerMessage `json:"dst"`
-	MaxTxSize    uint64                    `json:"max_tx_size"`    // maximum permitted size of the msgs in a bundled relay transaction
-	MaxMsgLength uint64                    `json:"max_msg_length"` // maximum amount of messages in a bundled relay transaction
+	Src []provider.RelayerMessage `json:"src"`
+	Dst []provider.RelayerMessage `json:"dst"`
+
+	// maximum permitted size of the msgs in a bundled relay transaction
+	MaxTxSize uint64 `json:"max_tx_size"`
+
+	// maximum amount of messages in a bundled relay transaction
+	MaxMsgLength uint64 `json:"max_msg_length"`
 }
 
 // batchSendMessageTimeout is the timeout for sending a single batch of IBC messages to an RPC node.
@@ -110,7 +114,7 @@ type SendMsgsResult struct {
 
 // SuccessfullySent reports the presence successfully sent batches
 func (r SendMsgsResult) SuccessfullySent() bool {
-	return (r.SuccessfulSrcBatches > 0 || r.SuccessfulDstBatches > 0)
+	return r.SuccessfulSrcBatches > 0 || r.SuccessfulDstBatches > 0
 }
 
 // PartiallySent reports the presence of both some successfully sent batches
@@ -146,7 +150,12 @@ func (r SendMsgsResult) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 }
 
 // Send concurrently sends out r's messages to the corresponding RelayMsgSenders.
-func (r *RelayMsgs) Send(ctx context.Context, log *zap.Logger, src, dst RelayMsgSender, memo string) SendMsgsResult {
+func (r *RelayMsgs) Send(
+	ctx context.Context,
+	log *zap.Logger,
+	src, dst RelayMsgSender,
+	memo string,
+) SendMsgsResult {
 	var (
 		wg     sync.WaitGroup
 		result SendMsgsResult
@@ -156,6 +165,7 @@ func (r *RelayMsgs) Send(ctx context.Context, log *zap.Logger, src, dst RelayMsg
 		wg.Add(1)
 		go r.send(ctx, log, &wg, src, r.Src, memo, &result.SuccessfulSrcBatches, &result.SrcSendError)
 	}
+
 	if len(r.Dst) > 0 {
 		wg.Add(1)
 		go r.send(ctx, log, &wg, dst, r.Dst, memo, &result.SuccessfulDstBatches, &result.DstSendError)

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -8,9 +8,8 @@ import (
 	"sync"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/avast/retry-go/v4"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/cosmos/relayer/v2/relayer/chains/cosmos"
 	penumbraprocessor "github.com/cosmos/relayer/v2/relayer/chains/penumbra"
@@ -49,7 +48,7 @@ func StartRelayer(
 	metrics *processor.PrometheusMetrics,
 	stuckPacket *processor.StuckPacket,
 ) chan error {
-	//prevent incorrect bech32 address prefixed addresses when calling AccAddress.String()
+	// prevent incorrect bech32 address prefixed addresses when calling AccAddress.String()
 	sdk.SetAddrCacheEnabled(false)
 	errorChan := make(chan error, 1)
 
@@ -70,8 +69,20 @@ func StartRelayer(
 			var filterSrc, filterDst []processor.ChainChannelKey
 
 			for _, ch := range filter.ChannelList {
-				ruleSrc := processor.ChainChannelKey{ChainID: p.Src.ChainID, ChannelKey: processor.ChannelKey{ChannelID: ch}}
-				ruleDst := processor.ChainChannelKey{CounterpartyChainID: p.Src.ChainID, ChannelKey: processor.ChannelKey{CounterpartyChannelID: ch}}
+				ruleSrc := processor.ChainChannelKey{
+					ChainID: p.Src.ChainID,
+					ChannelKey: processor.ChannelKey{
+						ChannelID: ch,
+					},
+				}
+
+				ruleDst := processor.ChainChannelKey{
+					CounterpartyChainID: p.Src.ChainID,
+					ChannelKey: processor.ChannelKey{
+						CounterpartyChannelID: ch,
+					},
+				}
+
 				filterSrc = append(filterSrc, ruleSrc)
 				filterDst = append(filterDst, ruleDst)
 			}
@@ -120,18 +131,18 @@ type path struct {
 }
 
 // chainProcessor returns the corresponding ChainProcessor implementation instance for a pathChain.
-func (chain *Chain) chainProcessor(
+func (c *Chain) chainProcessor(
 	log *zap.Logger,
 	metrics *processor.PrometheusMetrics,
 ) processor.ChainProcessor {
 	// Handle new ChainProcessor implementations as cases here
-	switch p := chain.ChainProvider.(type) {
+	switch p := c.ChainProvider.(type) {
 	case *penumbraprocessor.PenumbraProvider:
 		return penumbraprocessor.NewPenumbraChainProcessor(log, p)
 	case *cosmos.CosmosProvider:
 		return cosmos.NewCosmosChainProcessor(log, p, metrics)
 	default:
-		panic(fmt.Errorf("unsupported chain provider type: %T", chain.ChainProvider))
+		panic(fmt.Errorf("unsupported chain provider type: %T", c.ChainProvider))
 	}
 }
 


### PR DESCRIPTION
Previously we were failing to register the `--memo` flag for the `rly tx transfer` and `rly tx register-counterparty` cmds. 

We were also failing to pipe the `memo` from the CLI through to the broadcast tx logic where the memo is actually set on the tx before attempting to broadcast it to the network.

This PR also fixes a bunch of linter errors that `golangci-lint` was complaining about.

Closes #1351