### PR TITLE
fix: add handling for MsgTimeout in Penumbra ChainProvider

### DIFF
--- a/relayer/chains/penumbra/tx.go
+++ b/relayer/chains/penumbra/tx.go
@@ -190,7 +190,12 @@ func msgToPenumbraAction(msg sdk.Msg) (*penumbratypes.Action, error) {
 				RawAction: anyMsg,
 			}},
 		}, nil
-
+	case *chantypes.MsgTimeout:
+		return &penumbratypes.Action{
+			Action: &penumbratypes.Action_IbcRelayAction{IbcRelayAction: &penumbraibctypes.IbcRelay{
+				RawAction: anyMsg,
+			}},
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown message type: %T", msg)
 	}


### PR DESCRIPTION
This update introduces a new case statement for *chantypes.MsgTimeout within the Penumbra chain logic. This will correctly construct and return an Action_IbcRelayAction when a MsgTimeout is encountered.