### PR TITLE
refactor: avoid killing entire rly process

### DIFF
--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -399,7 +399,11 @@ func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 			return
 		}
 
-		for len(pp.pathEnd1.incomingCacheData) > 0 || len(pp.pathEnd2.incomingCacheData) > 0 || len(pp.retryProcess) > 0 || len(pp.pathEnd1.finishedProcessing) > 0 || len(pp.pathEnd2.finishedProcessing) > 0 {
+		for len(pp.pathEnd1.incomingCacheData) > 0 ||
+			len(pp.pathEnd2.incomingCacheData) > 0 ||
+			len(pp.retryProcess) > 0 ||
+			len(pp.pathEnd1.finishedProcessing) > 0 ||
+			len(pp.pathEnd2.finishedProcessing) > 0 {
 			// signals are available, so this will not need to block.
 			if pp.processAvailableSignals(ctx, cancel) {
 				return


### PR DESCRIPTION
Currently, the relayer will terminate the entire process if any of the ChainProcessors encounter critical errors due to underlying node issues. Instead, we should keep the rly process running and let individual ChainProcessors and PathProcessors be terminated.