### PR TITLE
fix(injective): replace x/auth/types with /types

### DIFF
--- a/relayer/codecs/injective/codec.go
+++ b/relayer/codecs/injective/codec.go
@@ -3,6 +3,7 @@ package injective
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -20,10 +21,10 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*cryptotypes.PubKey)(nil), &PubKey{})
 	registry.RegisterImplementations((*cryptotypes.PrivKey)(nil), &PrivKey{})
 
-	registry.RegisterInterface("injective.types.v1beta1.EthAccount", (*authtypes.AccountI)(nil))
+	registry.RegisterInterface("injective.types.v1beta1.EthAccount", (*types.AccountI)(nil))
 
 	registry.RegisterImplementations(
-		(*authtypes.AccountI)(nil),
+		(*types.AccountI)(nil),
 		&EthAccount{},
 	)
 


### PR DESCRIPTION
`rly tx update-clients -d mainnet-sei-kava ` throws the following error 

```
2024-02-06T20:00:49.668047Z     info    Error building or broadcasting transaction      {"provider_type": "cosmos", "chain_id": "injective-1", "attempt": 1, "max_attempts": 5, "error": "no concrete type registered for type URL /injective.types.v1beta1.EthAccount against interface *types.AccountI"}
```