### PR TITLE
Update Patch Validation of `VoteExtensionsEnableHeight` can cause chain halt 

### DIFF
--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -8,7 +8,7 @@ require (
 	cosmossdk.io/x/feegrant v0.1.0
 	cosmossdk.io/x/upgrade v0.1.0
 	github.com/avast/retry-go/v4 v4.5.1
-	github.com/cometbft/cometbft v0.38.2
+	github.com/cometbft/cometbft v0.38.5
 	github.com/cosmos/cosmos-sdk v0.50.3
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.4.11


### PR DESCRIPTION

A vulnerability in CometBFT’s validation logic for `VoteExtensionsEnableHeight` can result in a chain halt when triggered through a governance parameter change proposal on an ABCI2 Application Chain. If a parameter change proposal including a `VoteExtensionsEnableHeight` modification is passed, nodes running the affected versions may panic, halting the network.