### PR TITLE
feat: implement support for Osmosis EIP-1559

### DIFF
--- a/relayer/chains/cosmos/fee_market.go
+++ b/relayer/chains/cosmos/fee_market.go
@@ -1,0 +1,79 @@
+package cosmos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	sdkmath "cosmossdk.io/math"
+	"go.uber.org/zap"
+)
+
+const queryPath = "/osmosis.txfees.v1beta1.Query/GetEipBaseFee"
+
+// DynamicFee queries the dynamic gas price base fee and returns a string with the base fee and token denom concatenated.
+// If the chain does not have dynamic fees enabled in the config, nothing happens and an empty string is always returned.
+func (cc *CosmosProvider) DynamicFee(ctx context.Context) string {
+	if !cc.PCfg.DynamicGasPrice {
+		return ""
+	}
+
+	dynamicFee, err := cc.QueryBaseFee(ctx)
+	if err != nil {
+		// If there was an error querying the dynamic base fee, do nothing and fall back to configured gas price.
+		cc.log.Warn("Failed to query the dynamic gas price base fee", zap.Error(err))
+		return ""
+	}
+
+	return dynamicFee
+}
+
+// QueryBaseFee attempts to make an ABCI query to retrieve the base fee on chains using the Osmosis EIP-1559 implementation.
+// This is currently hardcoded to only work on Osmosis.
+func (cc *CosmosProvider) QueryBaseFee(ctx context.Context) (string, error) {
+	resp, err := cc.RPCClient.ABCIQuery(ctx, queryPath, nil)
+	if err != nil || resp.Response.Code != 0 {
+		return "", err
+	}
+
+	// The response value contains the data link escape control character which must be removed before parsing.
+	cleanedString := strings.ReplaceAll(strings.TrimSpace(string(resp.Response.Value)), "\u0010", "")
+
+	decFee, err := sdkmath.LegacyNewDecFromStr(cleanedString)
+	if err != nil {
+		return "", err
+	}
+
+	baseFee, err := decFee.Float64()
+	if err != nil {
+		return "", err
+	}
+
+	// The current EIP-1559 implementation returns an integer and does not return any value that tells us how many
+	// decimal places we need to account for.
+	//
+	// This may be problematic because we are assuming that we always need to move the decimal 18 places.
+	fee := baseFee / 1e18
+
+	denom, err := parseTokenDenom(cc.PCfg.GasPrices)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%f%s", fee, denom), nil
+}
+
+// parseTokenDenom takes a string in the format numericGasPrice + tokenDenom (e.g. 0.0025uosmo),
+// and parses the tokenDenom portion (e.g. uosmo) before returning just the token denom.
+func parseTokenDenom(gasPrice string) (string, error) {
+	regex := regexp.MustCompile(`^0\.\d+([a-zA-Z]+)$`)
+
+	matches := regex.FindStringSubmatch(gasPrice)
+
+	if len(matches) != 2 {
+		return "", fmt.Errorf("failed to parse token denom from string %s", gasPrice)
+	}
+
+	return matches[1], nil
+}

--- a/relayer/chains/cosmos/fee_market_test.go
+++ b/relayer/chains/cosmos/fee_market_test.go
@@ -1,0 +1,61 @@
+package cosmos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	coinType = 118
+
+	testCfg = CosmosProviderConfig{
+		KeyDirectory:     "",
+		Key:              "default",
+		ChainName:        "osmosis",
+		ChainID:          "osmosis-1",
+		RPCAddr:          "https://rpc.osmosis.strange.love:443",
+		AccountPrefix:    "osmo",
+		KeyringBackend:   "test",
+		DynamicGasPrice:  true,
+		GasAdjustment:    1.2,
+		GasPrices:        "0.0025uosmo",
+		MinGasAmount:     1,
+		MaxGasAmount:     0,
+		Debug:            false,
+		Timeout:          "30s",
+		BlockTimeout:     "30s",
+		OutputFormat:     "json",
+		SignModeStr:      "direct",
+		ExtraCodecs:      nil,
+		Modules:          nil,
+		Slip44:           &coinType,
+		SigningAlgorithm: "",
+		Broadcast:        "batch",
+		MinLoopDuration:  0,
+		ExtensionOptions: nil,
+		FeeGrants:        nil,
+	}
+)
+
+func TestQueryBaseFee(t *testing.T) {
+	p, err := testCfg.NewProvider(nil, t.TempDir(), true, testCfg.ChainName)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = p.Init(ctx)
+	require.NoError(t, err)
+
+	cp := p.(*CosmosProvider)
+
+	baseFee, err := cp.QueryBaseFee(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, "", baseFee)
+}
+
+func TestParseDenom(t *testing.T) {
+	denom, err := parseTokenDenom(testCfg.GasPrices)
+	require.NoError(t, err)
+	require.Equal(t, "uosmo", denom)
+}

--- a/relayer/chains/cosmos/grpc_query.go
+++ b/relayer/chains/cosmos/grpc_query.go
@@ -178,7 +178,20 @@ func (cc *CosmosProvider) TxServiceBroadcast(ctx context.Context, req *tx.Broadc
 
 	wg.Add(1)
 
-	if err := cc.broadcastTx(ctx, req.TxBytes, nil, nil, ctx, blockTimeout, []func(*provider.RelayerTxResponse, error){callback}); err != nil {
+	dynamicFee := cc.DynamicFee(ctx)
+
+	err = cc.broadcastTx(
+		ctx,
+		req.TxBytes,
+		nil,
+		nil,
+		ctx,
+		blockTimeout,
+		[]func(*provider.RelayerTxResponse, error){callback},
+		dynamicFee,
+	)
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/relayer/chains/cosmos/provider.go
+++ b/relayer/chains/cosmos/provider.go
@@ -32,11 +32,6 @@ var (
 	_ provider.ProviderConfig = &CosmosProviderConfig{}
 )
 
-const (
-	cometEncodingThreshold     = "v0.37.0-alpha"
-	cometBlockResultsThreshold = "v0.38.0-alpha"
-)
-
 type CosmosProviderConfig struct {
 	KeyDirectory     string                     `json:"key-directory" yaml:"key-directory"`
 	Key              string                     `json:"key" yaml:"key"`
@@ -45,6 +40,7 @@ type CosmosProviderConfig struct {
 	RPCAddr          string                     `json:"rpc-addr" yaml:"rpc-addr"`
 	AccountPrefix    string                     `json:"account-prefix" yaml:"account-prefix"`
 	KeyringBackend   string                     `json:"keyring-backend" yaml:"keyring-backend"`
+	DynamicGasPrice  bool                       `json:"dynamic-gas-price" yaml:"dynamic-gas-price"`
 	GasAdjustment    float64                    `json:"gas-adjustment" yaml:"gas-adjustment"`
 	GasPrices        string                     `json:"gas-prices" yaml:"gas-prices"`
 	MinGasAmount     uint64                     `json:"min-gas-amount" yaml:"min-gas-amount"`


### PR DESCRIPTION
This PR adds support for querying the dynamic gas price base fee on Osmosis. 

A new config value, `dynamic-gas-price`, is added to the `CosmosProviderConfig`, if this value is true then an ABCI query will be made to fetch the dynamic gas price base fee which is used in place of the configured `gas-prices` value. If the query fails for some reason the relayer will fall back to using the configured `gas-prices` value.

This feature is currently limited to working on Osmosis due to hardcoded values necessary to make it work, but once Skip's Fee Market module is live we can refactor this code to be generic enough to work against any chain for various fee market models.

Closes #1368 