### PR TITLE
fix: wallet balance metric occasionally reporting false 0 amounts

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -538,7 +538,12 @@ func (ccp *CosmosChainProcessor) CollectMetrics(ctx context.Context, persistence
 
 	// Wait a while before updating the balance
 	if time.Since(persistence.lastBalanceUpdate) > persistence.balanceUpdateWaitDuration {
-		ccp.CurrentRelayerBalance(ctx)
+		err := ccp.CurrentRelayerBalance(ctx)
+		if err != nil {
+			ccp.log.Error(fmt.Sprintf("Failed to update wallet balance metric. Will retry in %v.", persistence.balanceUpdateWaitDuration),
+				zap.Error(err))
+			return
+		}
 		persistence.lastBalanceUpdate = time.Now()
 	}
 }
@@ -547,7 +552,7 @@ func (ccp *CosmosChainProcessor) CurrentBlockHeight(ctx context.Context, persist
 	ccp.metrics.SetLatestHeight(ccp.chainProvider.ChainId(), persistence.latestHeight)
 }
 
-func (ccp *CosmosChainProcessor) CurrentRelayerBalance(ctx context.Context) {
+func (ccp *CosmosChainProcessor) CurrentRelayerBalance(ctx context.Context) error {
 	// memoize the current gas prices to only show metrics for "interesting" denoms
 	gasPrice := ccp.chainProvider.PCfg.GasPrices
 
@@ -559,10 +564,7 @@ func (ccp *CosmosChainProcessor) CurrentRelayerBalance(ctx context.Context) {
 
 		gp, err := sdk.ParseDecCoins(gasPrice)
 		if err != nil {
-			ccp.log.Error(
-				"Failed to parse gas prices",
-				zap.Error(err),
-			)
+			return fmt.Errorf("failed to parse gas prices: %w", err)
 		}
 		ccp.parsedGasPrices = &gp
 	}
@@ -570,17 +572,12 @@ func (ccp *CosmosChainProcessor) CurrentRelayerBalance(ctx context.Context) {
 	// Get the balance for the chain provider's key
 	relayerWalletBalances, err := ccp.chainProvider.QueryBalance(ctx, ccp.chainProvider.Key())
 	if err != nil {
-		ccp.log.Error(
-			"Failed to query relayer balance",
-			zap.Error(err),
-		)
+		return fmt.Errorf("failed to query relayer balance: %w", err)
 	}
 	address, err := ccp.chainProvider.Address()
 	if err != nil {
-		ccp.log.Error(
-			"Failed to get relayer bech32 wallet addresss",
-			zap.Error(err),
-		)
+		return fmt.Errorf("failed to get relayer bech32 address: %w", err)
+
 	}
 
 	// Print the relevant gas prices
@@ -591,4 +588,5 @@ func (ccp *CosmosChainProcessor) CurrentRelayerBalance(ctx context.Context) {
 		f, _ := big.NewFloat(0.0).SetInt(bal.BigInt()).Float64()
 		ccp.metrics.SetWalletBalance(ccp.chainProvider.ChainId(), gasPrice, ccp.chainProvider.Key(), address, gasDenom.Denom, f)
 	}
+	return nil
 }


### PR DESCRIPTION
Our infra team has reported that occasionally the `cosmos_relayer_wallet_balance` metric falsely reports a balance of `0`. 

I believe the main culprit here is the `ccp.chainProvider.QueryBalance` method. 

Prior to this PR, we would continue to update the metric even though querying the balance failed.