### PR TITLE
feat: add the ability to query the hash associated with an IBC denom trace

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -53,6 +53,7 @@ func queryCmd(a *appState) *cobra.Command {
 		queryIBCDenoms(a),
 		queryBaseDenomFromIBCDenom(a),
 		feegrantQueryCmd(a),
+		queryIBCDenomHash(a),
 	)
 
 	return cmd
@@ -123,7 +124,37 @@ $ %s q denom-trace osmosis 9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D9
 			if !ok {
 				return errChainNotFound(args[0])
 			}
+
 			res, err := c.ChainProvider.QueryDenomTrace(cmd.Context(), args[1])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), res)
+			return nil
+		},
+	}
+	cmd = addOutputFlag(a.viper, cmd)
+	return cmd
+}
+
+func queryIBCDenomHash(a *appState) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "denom-hash chain_id trace",
+		Short: "query the denom hash info from a given denom trace",
+		Args:  withUsage(cobra.ExactArgs(2)),
+		Example: strings.TrimSpace(fmt.Sprintf(`
+$ %s query denom-hash osmosis transfer/channel-0/uatom
+$ %s q denom-hash osmosis transfer/channel-0/uatom`,
+			appName, appName,
+		)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, ok := a.config.Chains[args[0]]
+			if !ok {
+				return errChainNotFound(args[0])
+			}
+
+			res, err := c.ChainProvider.QueryDenomHash(cmd.Context(), args[1])
 			if err != nil {
 				return err
 			}

--- a/relayer/chains/cosmos/query.go
+++ b/relayer/chains/cosmos/query.go
@@ -1215,6 +1215,7 @@ func (cc *CosmosProvider) QueryDenomTrace(ctx context.Context, denom string) (*t
 	if err != nil {
 		return nil, err
 	}
+
 	return transfers.DenomTrace, nil
 }
 
@@ -1243,6 +1244,21 @@ func (cc *CosmosProvider) QueryDenomTraces(ctx context.Context, offset, limit ui
 		p.Key = next
 	}
 	return transfers, nil
+}
+
+func (cc *CosmosProvider) QueryDenomHash(ctx context.Context, trace string) (string, error) {
+	qc := transfertypes.NewQueryClient(cc)
+
+	req := &transfertypes.QueryDenomHashRequest{
+		Trace: trace,
+	}
+
+	resp, err := qc.DenomHash(ctx, req, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Hash, nil
 }
 
 func (cc *CosmosProvider) QueryStakingParams(ctx context.Context) (*stakingtypes.Params, error) {

--- a/relayer/chains/penumbra/query.go
+++ b/relayer/chains/penumbra/query.go
@@ -854,6 +854,10 @@ func (cc *PenumbraProvider) QueryDenomTraces(ctx context.Context, offset, limit 
 	return transfers.DenomTraces, nil
 }
 
+func (cc *PenumbraProvider) QueryDenomHash(ctx context.Context, trace string) (string, error) {
+	panic("not implemented")
+}
+
 func (cc *PenumbraProvider) QueryStakingParams(ctx context.Context) (*stakingtypes.Params, error) {
 	res, err := stakingtypes.NewQueryClient(cc).Params(ctx, &stakingtypes.QueryParamsRequest{})
 	if err != nil {

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -468,6 +468,7 @@ type QueryProvider interface {
 	// ics 20 - transfer
 	QueryDenomTrace(ctx context.Context, denom string) (*transfertypes.DenomTrace, error)
 	QueryDenomTraces(ctx context.Context, offset, limit uint64, height int64) ([]transfertypes.DenomTrace, error)
+	QueryDenomHash(ctx context.Context, trace string) (string, error)
 }
 
 type RelayPacket interface {


### PR DESCRIPTION
We currently have commands to query all IBC denom traces or a specific IBC denom trace based off a given hash, but we are lacking the ability to query a hash based off a specific IBC denom trace. This adds a new query to the `Provider` interface that allows users to query this IBC denom trace information for a given chain and hash.

Closes #1416 