### PR TITLE
Skip to current height after hitting stuck packet end height

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -488,6 +488,11 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 			newLatestQueriedBlock == int64(stuckPacket.EndHeight) {
 			i = persistence.latestHeight
 			ccp.log.Debug("Parsed stuck packet height, skipping to current")
+			newLatestQueriedBlock, err = ccp.latestHeightWithRetry(ctx)
+			if err != nil {
+				ccp.log.Error("Failed to query node height after max attempts. Consider checking endpoint and retyring for stuck packets")
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, when when using the `--stuck-packet-*` flags, the relayer does not pick back up at the latest height after reaching the `--stuck-packet-height-end` flag. This means that you have to wait for the relayer to catch all the way back up to chain tip before it can use the current client state to relay the packets. 
Depending on how far back the stuck packets are, this can take a very long time.

This should fix this issue.

Notice `height` in logs below 

Before:
![before](https://github.com/cosmos/relayer/assets/56059752/614ad9e8-9539-4272-8cb0-9b0d88e3cf90)


After: 
![after](https://github.com/cosmos/relayer/assets/56059752/22b7f73e-eafa-47c1-8b47-7c3a75bf1ad3)

