### PR TITLE
fix: avoid counterparty recv packet message get removed before open channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [\#1326](https://github.com/cosmos/relayer/pull/1326) Avoid sending channel close confirm message after channel get closed successfully.
 * [\#1364](https://github.com/cosmos/relayer/pull/1364) Include feegrant message when calculate gas.
 * [\#1390](https://github.com/cosmos/relayer/pull/1390) Avoid no concrete type registered for type URL error of EthAccount.
+* [\#1455](https://github.com/cosmos/relayer/pull/1455) Avoid counterparty recv packet message get removed before open channel.
 
 ## v0.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [\#1326](https://github.com/cosmos/relayer/pull/1326) Avoid sending channel close confirm message after channel get closed successfully.
 * [\#1364](https://github.com/cosmos/relayer/pull/1364) Include feegrant message when calculate gas.
 * [\#1390](https://github.com/cosmos/relayer/pull/1390) Avoid no concrete type registered for type URL error of EthAccount.
-* [\#1455](https://github.com/cosmos/relayer/pull/1455) Avoid counterparty recv packet message get removed before open channel.
+* [\#1455](https://github.com/cosmos/relayer/pull/1455) Allow retry for pathEnd to avoid packet message get removed before open channel.
 
 ## v0.9.3
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -637,7 +637,7 @@ func (pathEnd *pathEndRuntime) removePacketRetention(
 
 	// delete all packet flow retention history for this sequence
 	pathEnd.messageCache.PacketFlow[k].DeleteMessages(toDelete)
-	counterparty.messageCache.PacketFlow[k.Counterparty()].DeleteMessages(toDeleteCounterparty)
+	counterparty.messageCache.PacketFlow[k].DeleteMessages(toDeleteCounterparty)
 }
 
 // shouldSendConnectionMessage determines if the connection handshake message should be sent now.

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -561,12 +561,12 @@ func (pathEnd *pathEndRuntime) shouldSendPacketMessage(message packetIBCMessage,
 			zap.Uint64("sequence", sequence),
 			zap.Inline(k),
 		)
-		pathEnd.retryCount++
-		if pathEnd.retryCount >= maxMessageSendRetries {
+		if pathEnd.retryCount >= maxMessageSendRetriesIfChannelNotOpen {
 			pathEnd.removePacketRetention(counterparty, eventType, k, sequence)
 			pathEnd.retryCount = 0
 			return false
 		}
+		pathEnd.retryCount++
 	}
 	msgProcessCache, ok := pathEnd.packetProcessing[k]
 	if !ok {

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -39,6 +39,9 @@ const (
 	// How many times to retry sending a message before giving up on it.
 	maxMessageSendRetries = 5
 
+	// How many times to retry sending a message if channel is not opened.
+	maxMessageSendRetriesIfChannelNotOpen = 1
+
 	// How many blocks of history to retain ibc headers in the cache for.
 	ibcHeadersToCache = 10
 


### PR DESCRIPTION
relay packet message happens right before new channel get created, for more info:
<Details>

2024-05-01T01:36:49.868214Z	info	Successfully created new channel	{"chain_name": "cronos_777-1", "chain_id": "cronos_777-1", "channel_id": "channel-2", "connection_id": "connection-0", "port_id": "icacontroller-crc1q04jewhxw4xxu3vlg3rc85240h9q7ns6hglz0g"}

2024-05-01T01:36:52.722142Z	info	Successful transaction	{"provider_type": "cosmos", "chain_id": "chainmain-1", "gas_used": 161557, "fees": "196281000000basecro", "fee_payer": "cro1u08u5dvtnpmlpdq333uj9tcj75yceggszxpnsy", "height": 57, "msg_types": ["/ibc.core.client.v1.MsgUpdateClient", "/ibc.core.channel.v1.MsgChannelOpenConfirm"], "tx_hash": "46663D951CA2738EC796451679400C351D93AD3B73F22778654CA5301EA39F09"}

2024-05-01T01:36:52.869073Z	warn	Refusing to relay packet message because channel is not open	{"path_name": "chainmain-cronos", "chain_id": "chainmain-1", "client_id": "07-tendermint-0", "event_type": "recv_packet", "sequence": 1, "channel_id": "channel-2", "port_id": "icahost", "counterparty_channel_id": "channel-2", "counterparty_port_id": "icacontroller-crc1q04jewhxw4xxu3vlg3rc85240h9q7ns6hglz0g"}

2024-05-01T01:36:52.869222Z	info	Successfully created new channel	{"chain_name": "chainmain-1", "chain_id": "chainmain-1", "channel_id": "channel-2", "connection_id": "connection-0", "port_id": "icahost"}
</Details>