### PR TITLE
docs: update CODEOWNERS to reference entire strangelove_relayer_maintain team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @jtieri @boojamya @agouin
+* @jtieri @agouin @cosmos/strangelove

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @jtieri @agouin @cosmos/strangelove_relayer_maintain
+* @cosmos/strangelove_relayer_maintain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @jtieri @agouin @cosmos/strangelove
+* @jtieri @agouin @COSMOS/Strangelove

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @jtieri @agouin @COSMOS/Strangelove
+* @jtieri @agouin @cosmos/strangelove_relayer_maintain


### PR DESCRIPTION
Updates the CODEOWNERS file to reference the entire strangelove_relayer_maintain team, so that everyone on the team can help maintain the repo.