### PR TITLE
IBC packet forward middleware support from memo field

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -294,7 +294,7 @@ func rlyMemo(memo string) string {
 	if memo == "" {
 		return defaultMemo
 	}
-	return fmt.Sprintf("%s | %s", memo, defaultMemo)
+	return memo
 }
 
 // memo returns a formatted message memo string,

--- a/relayer/chains/cosmos/tx.go
+++ b/relayer/chains/cosmos/tx.go
@@ -796,6 +796,7 @@ func (cc *CosmosProvider) MsgTransfer(
 	dstAddr string,
 	amount sdk.Coin,
 	info provider.PacketInfo,
+	memo string,
 ) (provider.RelayerMessage, error) {
 	acc, err := cc.Address()
 	if err != nil {
@@ -808,6 +809,7 @@ func (cc *CosmosProvider) MsgTransfer(
 		Sender:           acc,
 		Receiver:         dstAddr,
 		TimeoutTimestamp: info.TimeoutTimestamp,
+		Memo:             memo,
 	}
 
 	// If the timeoutHeight is 0 then we don't need to explicitly set it on the MsgTransfer
@@ -1746,7 +1748,7 @@ func (cc *CosmosProvider) SetWithExtensionOptions(txf tx.Factory) (tx.Factory, e
 	for _, opt := range cc.PCfg.ExtensionOptions {
 		max, ok := sdkmath.NewIntFromString(opt.Value)
 		if !ok {
-			return txf,errors.New("invalid opt value")
+			return txf, errors.New("invalid opt value")
 		}
 		extensionOption := ethermint.ExtensionOptionDynamicFeeTx{
 			MaxPriorityPrice: max,

--- a/relayer/chains/penumbra/tx.go
+++ b/relayer/chains/penumbra/tx.go
@@ -999,6 +999,7 @@ func (cc *PenumbraProvider) MsgTransfer(
 	dstAddr string,
 	amount sdk.Coin,
 	info provider.PacketInfo,
+	memo string,
 ) (provider.RelayerMessage, error) {
 	acc, err := cc.Address()
 	if err != nil {
@@ -1011,6 +1012,7 @@ func (cc *PenumbraProvider) MsgTransfer(
 		Sender:           acc,
 		Receiver:         dstAddr,
 		TimeoutTimestamp: info.TimeoutTimestamp,
+		Memo:             memo,
 	}
 
 	// If the timeoutHeight is 0 then we don't need to explicitly set it on the MsgTransfer
@@ -2254,7 +2256,7 @@ func (cc *PenumbraProvider) waitForBlockInclusion(
 				return cc.mkTxResult(res)
 			}
 			if strings.Contains(err.Error(), "transaction indexing is disabled") {
-				return nil,errors.New("cannot determine success/failure of tx because transaction indexing is disabled on rpc url")
+				return nil, errors.New("cannot determine success/failure of tx because transaction indexing is disabled on rpc url")
 			}
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/relayer/packet-tx.go
+++ b/relayer/packet-tx.go
@@ -109,7 +109,7 @@ func (c *Chain) SendTransferMsg(
 		TimeoutTimestamp: timeoutTimestamp,
 	}
 
-	msg, err := c.ChainProvider.MsgTransfer(dstAddr, amount, pi)
+	msg, err := c.ChainProvider.MsgTransfer(dstAddr, amount, pi, memo)
 	if err != nil {
 		return err
 	}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -266,7 +266,7 @@ type ChainProvider interface {
 	NextSeqRecv(ctx context.Context, msgTransfer PacketInfo, height uint64) (PacketProof, error)
 
 	// MsgTransfer constructs a MsgTransfer message ready to write to the chain.
-	MsgTransfer(dstAddr string, amount sdk.Coin, info PacketInfo) (RelayerMessage, error)
+	MsgTransfer(dstAddr string, amount sdk.Coin, info PacketInfo, memo string) (RelayerMessage, error)
 
 	// MsgRecvPacket takes the packet information from a MsgTransfer along with the packet commitment,
 	// and assembles a full MsgRecvPacket ready to write to the chain.


### PR DESCRIPTION
Hi everyone,

I tried recently to use relayer for [IBC packet forwarding](https://github.com/cosmos/ibc-apps/blob/main/middleware/packet-forward-middleware/README.md) and faced an interesting issue. As the doc says, to forward IBC transactions a memo field should be filled with the forwarding data. But it's incompatible with how relayer operates at the moment.
There are 2 key points here:
1) Relayer appends `rly(vx.y.z)` string to every memo which is clearly not a valid json which packet forward middleware app expects.
2) When doing `rly tx transfer`, the memo field of `MsgTransfer` message is not actually set, making packet forward middleware to think there is no forward data.

This PR is mostly a proposal since it changes the way how the relayer deals with memo field. Still, this fix was tested with locally deployed chains and it works.

Please tell me if I was not clear enough or some additional details are needed.

Cheers,
Konstantin.