### PR TITLE
feat: disables debug server by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Additional information on how IBC works can be found [here](https://ibc.cosmos.n
     [[TROUBLESHOOTING](docs/troubleshooting.md)]
 ---
 
+## Production deployment recomendations
+
+- Make sure the debug server is disabled in production.
+
 ## Security Notice
 
 If you would like to report a security bug related to the relayer repo,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -38,6 +38,7 @@ const (
 	flagDstPort                        = "dst-port"
 	flagOrder                          = "order"
 	flagVersion                        = "version"
+	flagEnableDebugServer              = "enable-debug-server"
 	flagDebugAddr                      = "debug-addr"
 	flagOverwriteConfig                = "overwrite"
 	flagLimit                          = "limit"
@@ -426,6 +427,16 @@ func debugServerFlags(v *viper.Viper, cmd *cobra.Command) *cobra.Command {
 	)
 
 	if err := v.BindPFlag(flagDebugAddr, cmd.Flags().Lookup(flagDebugAddr)); err != nil {
+		panic(err)
+	}
+
+	cmd.Flags().Bool(
+		flagEnableDebugServer,
+		false,
+		"enables debug server. By default, the debug server is disabled due to security concerns.",
+	)
+
+	if err := v.BindPFlag(flagEnableDebugServer, cmd.Flags().Lookup(flagEnableDebugServer)); err != nil {
 		panic(err)
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -105,9 +105,15 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 				debugAddr = debugAddrFlag
 			}
 
-			if debugAddr == "" {
+			flagEnableDebugServer, err := cmd.Flags().GetBool(flagEnableDebugServer)
+			if err != nil {
+				return err
+			}
+
+			if flagEnableDebugServer == false || debugAddr == "" {
 				a.log.Info("Skipping debug server due to empty debug address flag")
 			} else {
+				a.log.Warn("SECURITY WARNING! Debug server is enabled. It should only be used for non-production deployments.")
 				ln, err := net.Listen("tcp", debugAddr)
 				if err != nil {
 					a.log.Error(


### PR DESCRIPTION
1) Adds --enable-debug-server flag that defaults to false
2) Displays warning message in logs if the debug server is enabled 

![image](https://github.com/user-attachments/assets/0d3c240d-f645-4af1-861b-388d12b7400c)
