### PR TITLE
fix(build): strips debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: lint install
 
 ldflags = -X github.com/cosmos/relayer/v2/cmd.Version=$(VERSION) \
 					-X github.com/cosmos/relayer/v2/cmd.Commit=$(COMMIT) \
-					-X github.com/cosmos/relayer/v2/cmd.Dirty=$(DIRTY)
+					-X github.com/cosmos/relayer/v2/cmd.Dirty=$(DIRTY) -s -w
 
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))


### PR DESCRIPTION
After upgrading to Xcode 16.0 on Mac OS 14.5 (MacBook Pro M1) it seems that the `rly` binary is failing with the following error:

```
$ rly                                                                                                                                                    ~/workspace/strange.love/relayer
[1]    23969 killed     rly
```

The solution is to strip debug info from the binary.