### PR TITLE
Typo fix view.pb.go

### DIFF
--- a/relayer/chains/penumbra/view/v1/view.pb.go
+++ b/relayer/chains/penumbra/view/v1/view.pb.go
@@ -206,7 +206,7 @@ type AuctionsResponse struct {
 	// service_. Note that the local view service may lag behind the fullnode. For
 	// example, if the chain hits an auction's `end_height`, but the user hasn't
 	// yet exchanged their sequence-0 (opened) auction NFT for a sequence-1
-	// (closed) auction NFT, the local view service will have a sequnce number of
+	// (closed) auction NFT, the local view service will have a sequence number of
 	// 0.
 	//
 	// Dutch auctions move from:


### PR DESCRIPTION
## Description

This pull request fixes a typo in the `view.pb.go` file:  
- Corrected "sequnce" to "sequence" to ensure accurate spelling and maintain code clarity.

## Changes Made
- **File Modified**: `view.pb.go`
  - Replaced all instances of "sequnce" with "sequence."

## Rationale
Correct spelling in code and documentation is essential for readability and maintaining professional standards in the project.

