### PR TITLE
fix: use filepath instead of path for Windows compatibility

### DIFF
--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/gofrs/flock"
@@ -48,7 +48,7 @@ func (a *appState) initLogger(configLogLevel string) error {
 }
 
 func (a *appState) configPath() string {
-	return path.Join(a.homePath, "config", "config.yaml")
+	return filepath.Join(a.homePath, "config", "config.yaml")
 }
 
 // loadConfigFile reads config file into a.Config if file is present.
@@ -197,7 +197,7 @@ func (a *appState) addPathFromUserInput(
 }
 
 func (a *appState) performConfigLockingOperation(ctx context.Context, operation func() error) error {
-	lockFilePath := path.Join(a.homePath, "config", "config.lock")
+	lockFilePath := filepath.Join(a.homePath, "config", "config.lock")
 	fileLock := flock.New(lockFilePath)
 	_, err := fileLock.TryLock()
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -69,7 +68,7 @@ $ %s cfg list`, appName, defaultHome, appName)),
 				return err
 			}
 
-			cfgPath := path.Join(home, "config", "config.yaml")
+			cfgPath := filepath.Join(home, "config", "config.yaml")
 			if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 				if _, err := os.Stat(home); os.IsNotExist(err) {
 					return fmt.Errorf("home path does not exist: %s", home)
@@ -125,8 +124,8 @@ $ %s cfg i`, appName, defaultHome, appName)),
 				return err
 			}
 
-			cfgDir := path.Join(home, "config")
-			cfgPath := path.Join(cfgDir, "config.yaml")
+			cfgDir := filepath.Join(home, "config")
+			cfgPath := filepath.Join(cfgDir, "config.yaml")
 
 			// If the config doesn't exist...
 			if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
@@ -178,7 +177,7 @@ $ %s cfg i`, appName, defaultHome, appName)),
 // the error is logged.
 // An error is only returned if the directory cannot be read at all.
 func addChainsFromDirectory(ctx context.Context, stderr io.Writer, a *appState, dir string) error {
-	dir = path.Clean(dir)
+	dir = filepath.Clean(dir)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return err
@@ -230,7 +229,7 @@ func addChainsFromDirectory(ctx context.Context, stderr io.Writer, a *appState, 
 // addPathsFromDirectory returns the first error encountered,
 // which means a's paths may include a subset of the path files in dir.
 func addPathsFromDirectory(ctx context.Context, stderr io.Writer, a *appState, dir string) error {
-	dir = path.Clean(dir)
+	dir = filepath.Clean(dir)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #1471

- Replace path.Join() with filepath.Join() in cmd/appstate.go and cmd/config.go
- Use filepath.Clean() instead of path.Clean()
- Remove unused path import

This change ensures correct path handling on Windows systems while maintaining compatibility with other platforms.