### PR TITLE
Fix: Incorrect Flag in cmd Command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -13,8 +13,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/
-package cmd
+*/package cmd
 
 import (
 	"context"
@@ -172,7 +171,12 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 	return cmd
 }
 
-func setupMetricsServer(cmd *cobra.Command, a *appState, err error, chains map[string]*relayer.Chain) (*processor.PrometheusMetrics, error) {
+func setupMetricsServer(
+	cmd *cobra.Command,
+	a *appState,
+	err error,
+	chains map[string]*relayer.Chain,
+) (*processor.PrometheusMetrics, error) {
 	var prometheusMetrics *processor.PrometheusMetrics
 
 	metricsListenAddr := a.config.Global.MetricsListenPort
@@ -199,7 +203,7 @@ func setupMetricsServer(cmd *cobra.Command, a *appState, err error, chains map[s
 		a.log.Info("Metrics server is enabled")
 		ln, err := net.Listen("tcp", metricsListenAddr)
 		if err != nil {
-			a.log.Error(fmt.Sprintf("Failed to start metrics server you can change the address and port using metrics-listen-addr config settingh or --metrics-listen-flag"))
+			a.log.Error(fmt.Sprintf("Failed to start metrics server you can change the address and port using metrics-listen-addr config settingh or --metrics-listen-addr flag"))
 
 			return nil, fmt.Errorf("failed to listen on metrics address %q: %w", metricsListenAddr, err)
 		}
@@ -238,7 +242,9 @@ func setupDebugServer(cmd *cobra.Command, a *appState, err error) error {
 
 	if debugAddrFlag != "" {
 		debugListenAddr = debugAddrFlag
-		a.log.Warn("DEPRECATED: --debug-addr flag is deprecated use --enable-debug-server and --debug-listen-addr instead")
+		a.log.Warn(
+			"DEPRECATED: --debug-addr flag is deprecated use --enable-debug-server and --debug-listen-addr instead",
+		)
 	}
 
 	if debugListenAddrFlag != "" {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -13,7 +13,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/package cmd
+*/
+package cmd
 
 import (
 	"context"
@@ -171,12 +172,7 @@ $ %s start demo-path2 --max-tx-size 10`, appName, appName, appName, appName)),
 	return cmd
 }
 
-func setupMetricsServer(
-	cmd *cobra.Command,
-	a *appState,
-	err error,
-	chains map[string]*relayer.Chain,
-) (*processor.PrometheusMetrics, error) {
+func setupMetricsServer(cmd *cobra.Command, a *appState, err error, chains map[string]*relayer.Chain) (*processor.PrometheusMetrics, error) {
 	var prometheusMetrics *processor.PrometheusMetrics
 
 	metricsListenAddr := a.config.Global.MetricsListenPort
@@ -242,9 +238,7 @@ func setupDebugServer(cmd *cobra.Command, a *appState, err error) error {
 
 	if debugAddrFlag != "" {
 		debugListenAddr = debugAddrFlag
-		a.log.Warn(
-			"DEPRECATED: --debug-addr flag is deprecated use --enable-debug-server and --debug-listen-addr instead",
-		)
+		a.log.Warn("DEPRECATED: --debug-addr flag is deprecated use --enable-debug-server and --debug-listen-addr instead")
 	}
 
 	if debugListenAddrFlag != "" {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -267,7 +267,7 @@ func setupDebugServer(cmd *cobra.Command, a *appState, err error) error {
 		a.log.Warn("SECURITY WARNING! Debug server should only be run with caution and proper security in place")
 		ln, err := net.Listen("tcp", debugListenAddr)
 		if err != nil {
-			a.log.Error(fmt.Sprintf("Failed to start debug server you can change the address and port using debug-listen-addr config settingh or --debug-listen-flag"))
+			a.log.Error(fmt.Sprintf("Failed to start debug server you can change the address and port using debug-listen-addr config settingh or --debug-listen-addr flag"))
 
 			return fmt.Errorf("failed to listen on debug address %q: %w", debugListenAddr, err)
 		}


### PR DESCRIPTION
This PR fixes an issue where an incorrect flag was used in the cmd command. The incorrect flag caused unexpected behavior, leading to potential misconfigurations or failures when executing the command.

### Changes
- Replaced the incorrect flag with the correct one.
