### PR TITLE
test: Implement address verification in TestKeysExport

### DIFF
--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -114,7 +114,12 @@ func TestKeysExport(t *testing.T) {
 	kr := keyring.NewInMemory(cdc)
 	require.NoError(t, kr.ImportPrivKey("temp", armorOut, keys.DefaultKeyPass))
 
-	// TODO: confirm the imported address matches?
+	// Retrieve the imported key's address and confirm it matches the expected address
+	info, err := kr.Key("temp")
+	require.NoError(t, err, "failed to retrieve imported key")
+	addr, err := info.GetAddress()
+	require.NoError(t, err, "failed to get address from imported key")
+	require.Equal(t, relayertest.ZeroCosmosAddr, addr.String(), "imported address does not match expected address")
 }
 
 func TestKeysDefaultCoinType(t *testing.T) {
@@ -248,7 +253,7 @@ func TestKeysRestoreAll_Delete(t *testing.T) {
 	res = sys.MustRun(t, "keys", "delete", "testChain2", "default", "-y")
 	require.Empty(t, res.Stdout.String())
 	require.Equal(t, res.Stderr.String(), "key default deleted\n")
-	
+
 	res = sys.MustRun(t, "keys", "delete", "testChain3", "default", "-y")
 	require.Empty(t, res.Stdout.String())
 	require.Equal(t, res.Stderr.String(), "key default deleted\n")


### PR DESCRIPTION
This commit implements the TODO in the TestKeysExport function to verify that
the address of the imported key matches the expected address. This ensures
that the key export and import process correctly preserves the key's address.

The implementation:
1. Retrieves the imported key from the keyring
2. Gets the address from the key
3. Compares it with the expected address (relayertest.ZeroCosmosAddr)

This verification adds an additional layer of testing to ensure the key
export/import functionality works correctly.