### PR TITLE
chore: simplified directory creation step

### DIFF
--- a/examples/demo/scripts/two-chainz
+++ b/examples/demo/scripts/two-chainz
@@ -46,7 +46,7 @@ chainid0=ibc-0
 chainid1=ibc-1
 
 echo "Generating gaia configurations..."
-mkdir -p $GAIA_DATA && cd $GAIA_DATA && cd ../
+mkdir -p "$GAIA_DATA"
 ./scripts/one-chain gaiad $chainid0 ./data 26657 26656 6060 9090 stake samoleans
 ./scripts/one-chain gaiad $chainid1 ./data 26557 26556 6061 9091 rice beans
 


### PR DESCRIPTION
I noticed that there were redundant `cd` commands in the script after creating the directory for `GAIA_DATA`. It’s enough to just use `mkdir -p "$GAIA_DATA"` to ensure the directory is created without needing to change the current working directory back and forth. I’ve updated the script accordingly to improve clarity and efficiency.