### PR TITLE
fix: validate path name availability before user input collection

### DIFF
--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -130,7 +130,10 @@ func (a *appState) addPathFromUserInput(
 	stderr io.Writer,
 	src, dst, name string,
 ) error {
-	// TODO: confirm name is available before going through input.
+	// Check if the path name is already taken
+	if _, exists := a.config.Paths[name]; exists {
+		return fmt.Errorf("path with name '%s' already exists", name)
+	}
 
 	var (
 		value string


### PR DESCRIPTION
Implements the TODO comment on line 133 to check if a path name is already used before collecting user input. This prevents wasted time from entering details for a path that can't be added due to name conflict.