### PR TITLE
Improve PrivKey String() method: output hex instead of raw bytes

### DIFF
--- a/relayer/chains/cosmos/keys/sr25519/privkey.go
+++ b/relayer/chains/cosmos/keys/sr25519/privkey.go
@@ -1,6 +1,8 @@
 package sr25519
 
 import (
+	"encoding/hex"
+
 	tmsr25519 "github.com/cometbft/cometbft/crypto/sr25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
@@ -39,7 +41,7 @@ func (m *PrivKey) Reset() {
 }
 
 func (m *PrivKey) String() string {
-	return string(m.Bytes())
+	return hex.EncodeToString(m.Bytes())
 }
 
 func GenPrivKey() *PrivKey {


### PR DESCRIPTION
The String() method of the sr25519 PrivKey type now returns the private key as a hex-encoded string instead of raw bytes. This change improves readability and safety when logging or displaying private keys, preventing issues with unprintable or unsafe characters. No functional logic is changed—only the string representation is affected.