### PR TITLE
fix: fix slice init length

### DIFF
--- a/relayer/chains/penumbra/tx.go
+++ b/relayer/chains/penumbra/tx.go
@@ -283,7 +283,7 @@ func (cc *PenumbraProvider) getAnchor(ctx context.Context) (*penumbracrypto.Merk
 }
 
 func parseEventsFromABCIResponse(resp abci.ExecTxResult) []provider.RelayerEvent {
-	events := make([]provider.RelayerEvent, len(resp.Events))
+	events := make([]provider.RelayerEvent, 0, len(resp.Events))
 
 	for _, event := range resp.Events {
 		attributes := make(map[string]string)


### PR DESCRIPTION
The purpose here should be to initialize a slice with a capacity of len(call.Arguments) and a length of 0, and then append it later. Instead of initializing the length to len(call.Arguments) from the beginning, the resulting slice will not meet expectations.

The online demo: https://go.dev/play/p/q1BcVCmvidW